### PR TITLE
fix: export supabaseConfig from supabase.js (build fix)

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -28,4 +28,10 @@ export async function testConnection() {
   }
 }
 
+export const supabaseConfig = {
+  url: supabaseUrl,
+  anonKey: supabaseKey,
+  isConfigured: !!(supabaseUrl && supabaseKey)
+};
+
 export default supabase;


### PR DESCRIPTION
## Summary
- Corrige l'erreur de build : `supabaseConfig` n'était pas exporté depuis `supabase.js`
- Vite résolvait vers `.js` au lieu de `.ts`, causant un échec du build sur `editorial.astro`

https://claude.ai/code/session_01W7ojMsQ5bGPu78izX9zNtn