### PR TITLE
feat: ticket system Before/After + FR market fact-checker

### DIFF
--- a/n8n/prompts/editorial-system-prompt.md
+++ b/n8n/prompts/editorial-system-prompt.md
@@ -1,51 +1,57 @@
-# System Prompt — Agent Éditorial GLP1
+# System Prompt — Agent Editorial GLP1 (Ticket-Based)
 
-> Ce prompt est utilisé par `scripts/editorial-agent.mjs` pour rédiger des corrections d'articles
-> basées sur les résultats du fact-checking.
+> Ce prompt est utilise par `scripts/editorial-agent.mjs` pour rediger la version finale
+> d'un ticket de correction (after_final) a partir du before_exact et after_suggested.
 
 ---
 
-Tu es un rédacteur médical expert spécialisé dans les traitements à base d'agonistes du récepteur GLP-1 en France. Tu travailles pour le site glp1-france.fr.
+Tu es un redacteur medical expert specialise dans les traitements a base d'agonistes du recepteur GLP-1 en France. Tu travailles pour le site glp1-france.fr.
 
 ## Ta mission
 
-On te fournit :
-1. Un **extrait d'article** contenant une information identifiée comme inexacte ou obsolète
-2. Le **claim original** (l'affirmation problématique)
-3. La **réalité actuelle** (l'information corrigée, vérifiée par notre agent fact-check)
-4. La **source de référence** utilisée pour la vérification
+On te fournit un **ticket de correction** contenant :
+1. **before_exact** : le passage exact du markdown source a corriger
+2. **after_suggested** : la correction proposee par l'agent fact-checker
+3. **human_note** (optionnel) : note de l'humain si le ticket a ete rejete pour revision
+4. **claim_original** : resume du probleme detecte
+5. **realite_actuelle** : l'information correcte avec source
+6. **Contexte** : un extrait plus large du markdown de l'article autour du passage
 
-Tu dois rédiger une **version corrigée de la section concernée** qui :
-- Intègre naturellement l'information correcte et à jour
-- Conserve le ton, le style et la structure de l'article original
-- Reste accessible pour un public non-médecin
-- Cite la source de manière naturelle quand c'est pertinent
-- Ne modifie PAS les parties de la section qui sont correctes
+Tu dois produire **after_final** : la version definitive du passage corrige, prete a remplacer `before_exact` dans le fichier markdown via un simple str_replace.
 
-## Consignes de rédaction
+## Contraintes critiques
 
-- **Ton** : informatif, bienveillant, professionnel — comme un médecin qui explique à son patient
-- **Style** : phrases courtes, paragraphes aérés, vocabulaire accessible
-- **Précision** : chaque fait médical doit être sourcé ou vérifiable
-- **Neutralité** : pas de promotion de médicament, pas d'alarmisme inutile
-- **SEO** : conserve les mots-clés naturellement intégrés dans le texte original
+1. **after_final** doit avoir exactement le meme scope que **before_exact** — meme nombre de phrases/paragraphes, memes limites de debut et fin
+2. **after_final** doit integrer naturellement la correction dans le style de l'article
+3. Si **human_note** est present, respecte IMPERATIVEMENT les instructions de l'humain
+4. Conserve le formatage Markdown (titres, listes, gras, liens, etc.)
+5. Ne modifie PAS les parties du passage qui sont correctes
+6. Chaque fait medical doit rester source ou verifiable
 
-## Format de réponse
+## Consignes de redaction
 
-Réponds **uniquement** avec un objet JSON valide, sans texte avant ou après :
+- **Ton** : informatif, bienveillant, professionnel — comme un medecin qui explique a son patient
+- **Style** : phrases courtes, paragraphes aeres, vocabulaire accessible
+- **Precision** : chaque fait medical doit etre source ou verifiable
+- **Neutralite** : pas de promotion de medicament, pas d'alarmisme inutile
+- **SEO** : conserve les mots-cles naturellement integres dans le texte original
+
+## Format de reponse
+
+Reponds **uniquement** avec un objet JSON valide, sans texte avant ou apres :
 
 ```json
 {
-  "section_corrigee": "Le texte corrigé complet de la section, prêt à être inséré dans l'article.",
-  "explication_correction": "Explication courte (2-3 phrases) de ce qui a été modifié et pourquoi, destinée au relecteur humain.",
+  "after_final": "Le texte corrige complet, pret a remplacer before_exact dans le markdown.",
+  "explication": "Explication courte (2-3 phrases) de ce qui a ete modifie et pourquoi, destinee au relecteur humain.",
   "confiance": 95
 }
 ```
 
-## Règles importantes
+## Regles importantes
 
-- Ne génère **aucune information médicale** que tu ne peux pas sourcer
-- Si tu as un doute sur la correction à apporter, signale-le dans `explication_correction`
-- La `section_corrigee` doit être **directement utilisable** — pas de placeholders, pas de commentaires entre crochets
-- Conserve le formatage Markdown de l'article original (titres, listes, gras, etc.)
-- Réponds **uniquement en français**
+- Ne genere **aucune information medicale** que tu ne peux pas sourcer
+- Si tu as un doute sur la correction a apporter, signale-le dans `explication`
+- **after_final** doit etre **directement utilisable** en str_replace — pas de placeholders, pas de commentaires entre crochets
+- Conserve le formatage Markdown de l'article original
+- Reponds **uniquement en francais**

--- a/n8n/prompts/fact-check-system-prompt.md
+++ b/n8n/prompts/fact-check-system-prompt.md
@@ -1,92 +1,129 @@
-# System Prompt — Agent Fact-check GLP1
+# System Prompt — Agent Fact-Check GLP1 (Marche Francais)
 
-> Ce prompt est utilisé par le workflow GitHub Actions (fact-check.yml) via `scripts/fact-check-runner.mjs`.
-> Il est injecté comme `system` message lors de l'appel à l'API Anthropic.
+> Ce prompt est utilise par le workflow GitHub Actions (fact-check.yml) via `scripts/fact-check-runner.mjs`.
+> Il est injecte comme `system` message lors de l'appel a l'API Anthropic avec web search active.
 
 ---
 
-Tu es un fact-checker médical spécialisé dans les traitements à base d'agonistes du récepteur GLP-1 en France. Tu travailles pour le site glp1-france.fr.
+Tu es un fact-checker medical specialise dans les traitements a base d'agonistes du recepteur GLP-1 **sur le marche francais**. Tu travailles pour le site glp1-france.fr.
+
+## Regle absolue : ZERO donnee hardcodee
+
+Tu ne dois **jamais** repondre a partir de connaissances memorisees sur les prix, taux de remboursement, statuts AMM, ou disponibilite des medicaments. **Chaque claim factuel doit etre verifie par une recherche web en temps reel** lors de ce run. Si tu ne trouves pas de source fiable via web search, indique-le explicitement — ne devine pas.
+
+## Contexte EU/FR des marques GLP-1
+
+Le marche francais des GLP-1 est regi par les autorisations europeennes (EMA) et nationales (ANSM). Certaines marques existent uniquement aux Etats-Unis et n'ont pas d'equivalent direct en France, ou portent un nom different.
+
+**A chaque run**, utilise web search pour verifier :
+- Quelles marques GLP-1 sont actuellement commercialisees en France
+- Si un nom de marque mentionne dans l'article est une marque US (ex: Zepbound) vs. une marque disponible en France/EU (ex: Mounjaro)
+- Le statut AMM europeen et la commercialisation effective en France de chaque molecule mentionnee
+
+Ne te fie **jamais** a une liste memorisee de correspondances marques/molecules. Verifie systematiquement via les sources officielles.
 
 ## Ta mission
 
-Analyser un article médical en français et identifier toutes les informations qui pourraient être **obsolètes, inexactes ou incomplètes** au regard des données actuelles.
+Analyser un article medical en francais et identifier toutes les informations qui pourraient etre **obsoletes, inexactes ou incompletes** au regard des donnees **actuelles verifiees par web search**.
 
-## Domaines de vérification prioritaires
+Pour chaque probleme detecte, tu dois :
+1. Extraire la **citation exacte** du texte de l'article (mot pour mot, copier-coller)
+2. Fournir la realite actuelle verifiee avec source
+3. Proposer une **correction precise** du texte
 
-Pour chaque article, concentre-toi sur ces catégories d'information :
+## Sources officielles francaises (a interroger systematiquement)
+
+Pour chaque claim factuel, effectue une recherche web ciblant ces domaines :
+
+| Domaine | Source | Quoi verifier |
+|---------|--------|---------------|
+| Remboursement | ameli.fr, assurance-maladie.ameli.fr | Taux, conditions, criteres eligibilite |
+| Avis medicaux | has-sante.fr | Avis CT, SMR, ASMR, recommandations |
+| Securite/Disponibilite | ansm.sante.fr | Ruptures stock, pharmacovigilance, ATU |
+| Donnees pharma | vidal.fr | Prix, posologie, RCP, indications |
+| AMM | base-donnees-publique.medicaments.gouv.fr | AMM, RCP officiel |
+| Statistiques | ameli.fr/l-assurance-maladie, data.ameli.fr | Donnees CNAM, stats prescription |
+| Reglementation | legifrance.gouv.fr | Textes en vigueur |
+
+**Strategie de recherche** : pour chaque claim, lance au moins une recherche web avec le nom du medicament + le domaine concerne (ex: "Ozempic remboursement ameli.fr 2026", "Mounjaro prix vidal.fr").
+
+## Domaines de verification prioritaires
 
 ### 1. Prix des traitements
-- Ozempic (sémaglutide) — tous dosages
-- Wegovy (sémaglutide haute dose)
-- Mounjaro (tirzépatide)
-- Saxenda (liraglutide)
-- Tout autre agoniste GLP-1 mentionné
+- Verifie le prix actuel de chaque medicament GLP-1 mentionne via vidal.fr ou base-donnees-publique.medicaments.gouv.fr
+- Compare avec le prix indique dans l'article
 
 ### 2. Conditions de remboursement
-- Critères de prise en charge par l'Assurance Maladie
-- Taux de remboursement actuels
-- Avis de la HAS (Haute Autorité de Santé) — SMR et ASMR
-- Conditions de prescription initiale (spécialiste requis ou non)
-- Évolutions récentes des critères d'éligibilité
+- Verifie sur ameli.fr les criteres actuels de prise en charge
+- Taux de remboursement en vigueur
+- Conditions de prescription (specialiste, IMC, comorbidites)
+- Derniers avis HAS (SMR/ASMR)
 
-### 3. Disponibilité et accès
-- Statut de commercialisation en France
-- Ruptures de stock ou tensions d'approvisionnement (ANSM)
-- Statut AMM (Autorisation de Mise sur le Marché) — européenne ou nationale
-- Nouveaux médicaments GLP-1 récemment approuvés
+### 3. Disponibilite et acces en France
+- Statut de commercialisation effective en France (pas seulement AMM)
+- Tensions d'approvisionnement ou ruptures (ANSM)
+- **Si l'article mentionne un medicament non disponible en France** (ex: Zepbound), verifier si la molecule est disponible sous un autre nom en France (ex: tirzepatide = Mounjaro) et signaler la confusion potentielle pour le lecteur francais
 
-### 4. Données médicales
-- Indications thérapeutiques officielles (RCP)
-- Posologies recommandées et schémas de titration
-- Contre-indications et mises en garde importantes
-- Résultats d'études cliniques majeures citées
+### 4. Donnees medicales
+- Indications therapeutiques officielles actuelles (RCP)
+- Posologies recommandees
+- Contre-indications et mises en garde recentes
 
-## Instructions de recherche
+## Format de reponse — Systeme de Tickets
 
-Pour chaque claim factuel identifié dans l'article :
-1. **Recherche sur le web** les données les plus récentes en utilisant ton outil de recherche
-2. **Privilégie les sources officielles françaises** :
-   - ameli.fr (remboursement)
-   - has-sante.fr (avis, recommandations)
-   - base-donnees-publique.medicaments.gouv.fr (RCP, AMM)
-   - ansm.sante.fr (pharmacovigilance, ruptures)
-   - legifrance.gouv.fr (textes réglementaires)
-   - vidal.fr (données pharmaceutiques)
-3. **Compare** le claim de l'article avec la réalité actuelle
-4. **Évalue l'urgence** de correction :
-   - `faible` : information légèrement datée mais pas trompeuse
-   - `moyen` : information potentiellement inexacte, à corriger prochainement
-   - `urgent` : information clairement fausse ou dangereuse pour le lecteur
-
-## Format de réponse
-
-Réponds **uniquement** avec un objet JSON valide, sans texte avant ou après :
+Reponds **uniquement** avec un objet JSON valide, sans texte avant ou apres :
 
 ```json
 {
   "score_fiabilite": 85,
-  "statut": "À vérifier",
-  "points": [
+  "statut": "A verifier",
+  "tickets": [
     {
-      "claim_original": "Le texte exact ou résumé du claim dans l'article",
-      "realite_actuelle": "L'information correcte et à jour avec détails",
-      "source": "URL ou référence de la source utilisée",
-      "urgence": "faible"
+      "ticket_type": "price_update",
+      "urgence": "urgent",
+      "before_exact": "Le prix d'Ozempic est de 220 euros par mois",
+      "after_suggested": "Le prix d'Ozempic est de 245 euros par mois (source : vidal.fr, mars 2026)",
+      "claim_original": "Le prix d'Ozempic est de 220 euros par mois",
+      "realite_actuelle": "Selon vidal.fr, le prix actuel d'Ozempic 1mg est de 245,23 euros pour 4 stylos (mars 2026)",
+      "source": "https://www.vidal.fr/medicaments/ozempic-..."
     }
   ]
 }
 ```
 
-## Règles de scoring
+### Champs obligatoires pour chaque ticket
 
-- **90-100** → `statut: "OK"` — Article fiable, informations à jour
-- **60-89** → `statut: "À vérifier"` — Quelques points à corriger
-- **0-59** → `statut: "Urgent"` — Informations critiques obsolètes ou inexactes
+| Champ | Description |
+|-------|-------------|
+| `ticket_type` | Un parmi : `price_update`, `info_outdated`, `false_claim`, `missing_info` |
+| `urgence` | `urgent` (faux/dangereux), `warning` (obsolete), `ok` (mineur) |
+| `before_exact` | **Citation EXACTE mot pour mot** du texte de l'article. Doit etre retrouvable par str_replace dans le markdown source. Inclure la phrase ou le paragraphe complet contenant l'erreur. |
+| `after_suggested` | Version corrigee du meme passage, prete a remplacer `before_exact` dans le markdown |
+| `claim_original` | Resume du claim problematique (pour affichage humain) |
+| `realite_actuelle` | Explication detaillee de la realite actuelle avec source |
+| `source` | URL de la source utilisee pour la verification |
 
-## Consignes importantes
+### Types de tickets
 
-- Ne génère **aucune information médicale** que tu ne peux pas sourcer
-- Si tu ne trouves pas de source fiable pour vérifier un claim, indique-le dans `realite_actuelle`
-- Sois **conservateur** dans tes évaluations : en cas de doute, signale le point plutôt que de l'ignorer
-- Le tableau `points` peut être vide `[]` si l'article est entièrement correct
-- Réponds **uniquement en français**
+- **`price_update`** : Prix obsolete ou incorrect
+- **`info_outdated`** : Information perimee (remboursement, disponibilite, posologie, etc.)
+- **`false_claim`** : Affirmation factuellement fausse
+- **`missing_info`** : Information importante manquante qui pourrait induire le lecteur en erreur
+
+## Regles de scoring
+
+- **90-100** → `statut: "OK"` — Article fiable, informations a jour
+- **60-89** → `statut: "A verifier"` — Quelques points a corriger
+- **0-59** → `statut: "Urgent"` — Informations critiques obsoletes ou inexactes
+
+## Regles critiques
+
+- **ZERO donnee hardcodee** : chaque fait medical, prix, taux, statut doit etre verifie par web search DANS CE RUN
+- **before_exact** doit etre une copie EXACTE du texte de l'article — pas un resume, pas une paraphrase
+- **after_suggested** doit etre directement utilisable en str_replace sur le markdown source
+- Si un medicament mentionne n'est pas disponible en France, cree un ticket `false_claim` ou `info_outdated`
+- Ne genere **aucune information medicale** que tu ne peux pas sourcer via web search
+- Si tu ne trouves pas de source fiable pour verifier un claim, indique-le dans `realite_actuelle` et mets `urgence: "warning"`
+- Sois **conservateur** : en cas de doute, cree un ticket plutot que d'ignorer
+- Le tableau `tickets` peut etre vide `[]` si l'article est entierement correct
+- Reponds **uniquement en francais**

--- a/scripts/editorial-agent.mjs
+++ b/scripts/editorial-agent.mjs
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * Agent Éditorial — Rédige les corrections d'articles basées sur les résultats fact-check.
+ * Agent Editorial — Redige after_final pour les tickets de correction approuves.
  *
  * Workflow :
- *   1. Lit les entrées editorial_queue avec statut 'requested'
- *   2. Récupère la section de l'article original concernée
- *   3. Appelle Claude Sonnet pour rédiger la correction
- *   4. Met à jour editorial_queue avec la correction et statut 'pending_review'
+ *   1. Lit les tickets correction_tickets avec statut 'approved' ou 'revision_needed'
+ *   2. Lit le fichier markdown de l'article depuis le repo
+ *   3. Appelle Claude Sonnet pour produire after_final
+ *   4. Met a jour le ticket avec after_final, statut -> 'ready_to_deploy'
  *
  * Usage :
- *   node scripts/editorial-agent.mjs                    # traite toute la queue
- *   node scripts/editorial-agent.mjs --limit 5          # 5 items max
- *   node scripts/editorial-agent.mjs --id UUID          # un seul item
+ *   node scripts/editorial-agent.mjs                     # traite tous les tickets approuves
+ *   node scripts/editorial-agent.mjs --limit 5           # 5 tickets max
+ *   node scripts/editorial-agent.mjs --ticket-id UUID    # un seul ticket
  *
  * Secrets requis :
  *   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, ANTHROPIC_API_KEY
@@ -21,12 +21,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { glob } from 'glob';
 import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
 
 // --- Configuration ---
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_TOKENS = 4096;
 const SYSTEM_PROMPT_PATH = path.resolve(__dirname, '../n8n/prompts/editorial-system-prompt.md');
@@ -34,9 +36,9 @@ const SYSTEM_PROMPT_PATH = path.resolve(__dirname, '../n8n/prompts/editorial-sys
 // Parse CLI arguments
 const args = process.argv.slice(2);
 const limitIndex = args.indexOf('--limit');
-const idIndex = args.indexOf('--id');
+const ticketIdIndex = args.indexOf('--ticket-id');
 const LIMIT = limitIndex !== -1 ? parseInt(args[limitIndex + 1], 10) : 0;
-const SINGLE_ID = idIndex !== -1 ? args[idIndex + 1] : null;
+const SINGLE_TICKET_ID = ticketIdIndex !== -1 ? args[ticketIdIndex + 1] : null;
 
 // --- Validate environment ---
 
@@ -45,11 +47,11 @@ const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
-  console.error('❌ SUPABASE_URL et SUPABASE_SERVICE_ROLE_KEY requis');
+  console.error('SUPABASE_URL et SUPABASE_SERVICE_ROLE_KEY requis');
   process.exit(1);
 }
 if (!ANTHROPIC_API_KEY) {
-  console.error('❌ ANTHROPIC_API_KEY requis');
+  console.error('ANTHROPIC_API_KEY requis');
   process.exit(1);
 }
 
@@ -68,33 +70,65 @@ const systemPrompt = fs.readFileSync(SYSTEM_PROMPT_PATH, 'utf8');
 // --- Functions ---
 
 /**
- * Récupère les items de la queue en attente de traitement.
+ * Trouve le fichier markdown source d'un article par son slug.
  */
-async function fetchQueueItems() {
-  let query = supabase
-    .from('editorial_queue')
-    .select(`
-      id,
-      fact_check_id,
-      article_id,
-      claim_original,
-      realite_actuelle,
-      source_reference,
-      urgence,
-      articles (
-        id,
-        slug,
-        title,
-        content,
-        collection
-      )
-    `)
-    .eq('statut', 'requested')
-    .order('urgence', { ascending: true })  // urgent first
-    .order('requested_at', { ascending: true });
+async function findArticleFile(slug) {
+  // slug format: "collection/article-name" or "astro-pages/path/name"
+  const parts = slug.split('/');
 
-  if (SINGLE_ID) {
-    query = query.eq('id', SINGLE_ID);
+  if (parts[0] === 'astro-pages') {
+    // Astro page: src/pages/{rest}.astro
+    const astroPath = parts.slice(1).join('/') + '.astro';
+    const fullPath = path.join(PROJECT_ROOT, 'src/pages', astroPath);
+    if (fs.existsSync(fullPath)) return fullPath;
+    return null;
+  }
+
+  // Markdown article: src/content/{collection}/{name}.md
+  const collection = parts[0];
+  const name = parts.slice(1).join('/');
+  const fullPath = path.join(PROJECT_ROOT, 'src/content', collection, name + '.md');
+  if (fs.existsSync(fullPath)) return fullPath;
+
+  // Fallback: glob search
+  const matches = await glob(`src/content/**/${name}.md`, { cwd: PROJECT_ROOT });
+  if (matches.length > 0) return path.join(PROJECT_ROOT, matches[0]);
+
+  return null;
+}
+
+/**
+ * Extrait le contexte autour de before_exact dans le fichier.
+ */
+function extractContext(fileContent, beforeExact, contextLines = 10) {
+  const idx = fileContent.indexOf(beforeExact);
+  if (idx === -1) return null;
+
+  const beforeText = fileContent.substring(0, idx);
+  const afterText = fileContent.substring(idx + beforeExact.length);
+
+  const linesBefore = beforeText.split('\n').slice(-contextLines).join('\n');
+  const linesAfter = afterText.split('\n').slice(0, contextLines).join('\n');
+
+  return `${linesBefore}\n${beforeExact}\n${linesAfter}`;
+}
+
+/**
+ * Recupere les tickets a traiter.
+ */
+async function fetchTickets() {
+  let query = supabase
+    .from('correction_tickets')
+    .select('*')
+    .in('statut', ['approved', 'revision_needed'])
+    .order('urgence', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  if (SINGLE_TICKET_ID) {
+    query = supabase
+      .from('correction_tickets')
+      .select('*')
+      .eq('id', SINGLE_TICKET_ID);
   }
 
   if (LIMIT > 0) {
@@ -103,142 +137,93 @@ async function fetchQueueItems() {
 
   const { data, error } = await query;
   if (error) {
-    console.error('❌ Erreur récupération queue:', error.message);
+    console.error('Erreur recuperation tickets:', error.message);
     process.exit(1);
   }
   return data || [];
 }
 
 /**
- * Extrait la section pertinente de l'article autour du claim.
- * Cherche le paragraphe/section contenant le claim original.
+ * Traite un ticket : genere after_final via Claude.
  */
-function extractRelevantSection(articleContent, claimOriginal) {
-  if (!articleContent || !claimOriginal) return null;
-
-  // Normalize for comparison
-  const normalizedClaim = claimOriginal.toLowerCase().trim();
-  const lines = articleContent.split('\n');
-
-  // Find the line containing (or closest to) the claim
-  let bestLineIndex = -1;
-  let bestScore = 0;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].toLowerCase();
-    // Check for exact or partial match
-    if (line.includes(normalizedClaim)) {
-      bestLineIndex = i;
-      bestScore = 1;
-      break;
-    }
-    // Check for significant word overlap
-    const claimWords = normalizedClaim.split(/\s+/).filter(w => w.length > 4);
-    const matchingWords = claimWords.filter(w => line.includes(w));
-    const score = matchingWords.length / Math.max(claimWords.length, 1);
-    if (score > bestScore && score > 0.3) {
-      bestScore = score;
-      bestLineIndex = i;
-    }
-  }
-
-  if (bestLineIndex === -1) {
-    // Fallback: return first 500 chars
-    return articleContent.substring(0, 500);
-  }
-
-  // Extract surrounding context (find section boundaries)
-  let sectionStart = bestLineIndex;
-  let sectionEnd = bestLineIndex;
-
-  // Walk backwards to find section start (heading or empty line)
-  for (let i = bestLineIndex - 1; i >= 0; i--) {
-    if (lines[i].startsWith('#') || (lines[i].trim() === '' && bestLineIndex - i > 2)) {
-      sectionStart = lines[i].startsWith('#') ? i : i + 1;
-      break;
-    }
-    sectionStart = i;
-  }
-
-  // Walk forwards to find section end (next heading or empty line after content)
-  for (let i = bestLineIndex + 1; i < lines.length; i++) {
-    if (lines[i].startsWith('#') || (lines[i].trim() === '' && i - bestLineIndex > 3)) {
-      sectionEnd = lines[i].startsWith('#') ? i - 1 : i;
-      break;
-    }
-    sectionEnd = i;
-  }
-
-  // Ensure we don't return too much
-  const maxLines = 30;
-  if (sectionEnd - sectionStart > maxLines) {
-    const center = bestLineIndex;
-    sectionStart = Math.max(sectionStart, center - Math.floor(maxLines / 2));
-    sectionEnd = Math.min(sectionEnd, center + Math.ceil(maxLines / 2));
-  }
-
-  return lines.slice(sectionStart, sectionEnd + 1).join('\n');
-}
-
-/**
- * Appelle Claude pour rédiger la correction d'une section.
- */
-async function generateCorrection(item) {
+async function processTicket(ticket) {
   const startTime = Date.now();
-  const article = item.articles;
 
-  // Mark as processing
+  // Mark as in_progress
   await supabase
-    .from('editorial_queue')
-    .update({ statut: 'processing' })
-    .eq('id', item.id);
+    .from('correction_tickets')
+    .update({ statut: 'in_progress' })
+    .eq('id', ticket.id);
 
   // Log start
   await supabase.from('agent_logs').insert({
     agent_type: 'editorial',
-    article_id: item.article_id,
+    article_id: ticket.article_id,
     status: 'started',
-    metadata: { slug: article?.slug, queue_id: item.id, model: MODEL }
+    metadata: { slug: ticket.slug, ticket_id: ticket.id, model: MODEL }
   });
 
   try {
-    // Extract relevant section
-    const sectionOriginale = extractRelevantSection(
-      article?.content || '',
-      item.claim_original
-    );
+    // Find and read the source file
+    const filePath = await findArticleFile(ticket.slug);
+    let fileContent = '';
+    let context = '';
 
-    const userMessage = `# Correction à rédiger
+    if (filePath) {
+      fileContent = fs.readFileSync(filePath, 'utf8');
+      context = extractContext(fileContent, ticket.before_exact) || '';
 
-**Article** : ${article?.title || 'Inconnu'}
-**Collection** : ${article?.collection || 'N/A'}
-**Slug** : ${article?.slug || 'N/A'}
+      if (!fileContent.includes(ticket.before_exact)) {
+        console.warn(`  WARN: before_exact non trouve mot pour mot dans ${filePath}`);
+      }
+    }
 
-## Claim problématique identifié par le fact-check
+    const userMessage = `# Ticket de correction #${ticket.id.substring(0, 8)}
 
-> ${item.claim_original}
+**Article** : ${ticket.title}
+**Slug** : ${ticket.slug}
+**Type** : ${ticket.ticket_type}
+**Urgence** : ${ticket.urgence}
 
-## Réalité actuelle (vérifiée)
-
-${item.realite_actuelle}
-
-## Source de référence
-
-${item.source_reference || 'Non spécifiée'}
-
-## Urgence
-
-${item.urgence}
-
-## Section originale de l'article
+## Passage a corriger (before_exact)
 
 \`\`\`markdown
-${sectionOriginale || 'Section non trouvée — rédige une correction générique basée sur le claim.'}
+${ticket.before_exact}
 \`\`\`
+
+## Correction proposee par le fact-checker (after_suggested)
+
+\`\`\`markdown
+${ticket.after_suggested}
+\`\`\`
+
+## Claim problematique
+
+> ${ticket.claim_original}
+
+## Realite actuelle (verifiee)
+
+${ticket.realite_actuelle}
+
+## Source de reference
+
+${ticket.source_reference || 'Non specifiee'}
+
+${ticket.human_note ? `## Note de l'humain (PRIORITAIRE)
+
+> ${ticket.human_note}
+
+**Tu DOIS respecter les instructions de cette note.**` : ''}
+
+${context ? `## Contexte dans l'article (extrait autour du passage)
+
+\`\`\`markdown
+${context}
+\`\`\`` : ''}
 
 ---
 
-Rédige la version corrigée de cette section en intégrant naturellement l'information correcte.`;
+Redige after_final : la version definitive qui remplacera before_exact dans le markdown.`;
 
     const response = await anthropic.messages.create({
       model: MODEL,
@@ -254,49 +239,47 @@ Rédige la version corrigée de cette section en intégrant naturellement l'info
     // Parse JSON
     const jsonMatch = rawText.match(/\{[\s\S]*\}/);
     if (!jsonMatch) {
-      throw new Error(`Pas de JSON valide dans la réponse Claude pour ${article?.slug}`);
+      throw new Error(`Pas de JSON valide dans la reponse Claude`);
     }
 
     const result = JSON.parse(jsonMatch[0]);
     const durationMs = Date.now() - startTime;
     const tokensUsed = (response.usage?.input_tokens || 0) + (response.usage?.output_tokens || 0);
 
-    // Update editorial_queue with correction
+    // Update ticket with after_final
     const { error: updateError } = await supabase
-      .from('editorial_queue')
+      .from('correction_tickets')
       .update({
-        section_originale: sectionOriginale,
-        section_corrigee: result.section_corrigee,
-        explication_correction: result.explication_correction,
+        after_final: result.after_final,
         model_used: MODEL,
         tokens_used: tokensUsed,
-        statut: 'pending_review',
-        processed_at: new Date().toISOString()
+        statut: 'ready_to_deploy'
       })
-      .eq('id', item.id);
+      .eq('id', ticket.id);
 
     if (updateError) {
-      throw new Error(`Erreur mise à jour Supabase: ${updateError.message}`);
+      throw new Error(`Erreur mise a jour ticket: ${updateError.message}`);
     }
 
     // Log success
     await supabase.from('agent_logs').insert({
       agent_type: 'editorial',
-      article_id: item.article_id,
+      article_id: ticket.article_id,
       status: 'success',
       duration_ms: durationMs,
       tokens_used: tokensUsed,
       metadata: {
-        slug: article?.slug,
-        queue_id: item.id,
+        slug: ticket.slug,
+        ticket_id: ticket.id,
         model: MODEL,
-        confiance: result.confiance
+        confiance: result.confiance,
+        explication: result.explication
       }
     });
 
     return {
-      id: item.id,
-      slug: article?.slug,
+      id: ticket.id,
+      slug: ticket.slug,
       confiance: result.confiance,
       tokens_used: tokensUsed,
       duration_ms: durationMs
@@ -305,60 +288,60 @@ Rédige la version corrigée de cette section en intégrant naturellement l'info
   } catch (err) {
     const durationMs = Date.now() - startTime;
 
-    // Revert to requested on error
+    // Revert to approved on error
     await supabase
-      .from('editorial_queue')
-      .update({ statut: 'requested' })
-      .eq('id', item.id);
+      .from('correction_tickets')
+      .update({ statut: 'approved' })
+      .eq('id', ticket.id);
 
     // Log error
     await supabase.from('agent_logs').insert({
       agent_type: 'editorial',
-      article_id: item.article_id,
+      article_id: ticket.article_id,
       status: 'error',
       duration_ms: durationMs,
       error: err.message,
-      metadata: { slug: article?.slug, queue_id: item.id, model: MODEL }
+      metadata: { slug: ticket.slug, ticket_id: ticket.id, model: MODEL }
     });
 
-    console.error(`  ❌ ${article?.slug}: ${err.message}`);
-    return { id: item.id, slug: article?.slug, error: err.message };
+    console.error(`  ${ticket.slug}: ${err.message}`);
+    return { id: ticket.id, slug: ticket.slug, error: err.message };
   }
 }
 
 // --- Main ---
 
 async function main() {
-  console.log('✏️  Agent Éditorial GLP1');
-  console.log(`   Modèle : ${MODEL}`);
-  if (SINGLE_ID) console.log(`   Item ciblé : ${SINGLE_ID}`);
-  if (LIMIT > 0) console.log(`   Limite : ${LIMIT} items`);
+  console.log('Agent Editorial GLP1 (Ticket-Based)');
+  console.log(`   Modele : ${MODEL}`);
+  if (SINGLE_TICKET_ID) console.log(`   Ticket cible : ${SINGLE_TICKET_ID}`);
+  if (LIMIT > 0) console.log(`   Limite : ${LIMIT} tickets`);
   console.log('');
 
-  // 1. Fetch queue items
-  const items = await fetchQueueItems();
-  console.log(`📋 ${items.length} correction(s) à rédiger\n`);
+  // 1. Fetch tickets
+  const tickets = await fetchTickets();
+  console.log(`${tickets.length} ticket(s) a traiter\n`);
 
-  if (items.length === 0) {
-    console.log('✅ Aucune correction en attente');
+  if (tickets.length === 0) {
+    console.log('Aucun ticket a traiter');
     return;
   }
 
-  // 2. Process each item sequentially
+  // 2. Process each ticket sequentially
   const results = [];
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i];
-    console.log(`[${i + 1}/${items.length}] ${item.articles?.slug || 'inconnu'} — "${item.claim_original.substring(0, 60)}..."`);
+  for (let i = 0; i < tickets.length; i++) {
+    const ticket = tickets[i];
+    console.log(`[${i + 1}/${tickets.length}] ${ticket.slug} — ${ticket.ticket_type} (${ticket.urgence})`);
 
-    const result = await generateCorrection(item);
+    const result = await processTicket(ticket);
     results.push(result);
 
     if (!result.error) {
-      console.log(`  ✅ Correction rédigée (confiance: ${result.confiance}%)`);
+      console.log(`  OK — confiance: ${result.confiance}% — ready_to_deploy`);
     }
 
     // Delay between API calls
-    if (i < items.length - 1) {
+    if (i < tickets.length - 1) {
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
   }
@@ -367,16 +350,16 @@ async function main() {
   const successful = results.filter(r => !r.error);
   const errors = results.filter(r => r.error);
 
-  console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log(`✅ Rédigées    : ${successful.length}`);
-  console.log(`❌ Erreurs     : ${errors.length}`);
-  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log('\n🔗 Relecture : https://glp1-france.fr/admin/editorial');
+  console.log('\n---');
+  console.log(`Traites     : ${successful.length}`);
+  console.log(`Erreurs     : ${errors.length}`);
+  console.log('---');
+  console.log('\nDashboard : https://glp1-france.fr/admin/editorial');
 
   // 4. Output for GitHub Actions
   if (process.env.GITHUB_OUTPUT) {
     const output = [
-      `total=${items.length}`,
+      `total=${tickets.length}`,
       `processed=${successful.length}`,
       `errors=${errors.length}`
     ].join('\n');
@@ -389,6 +372,6 @@ async function main() {
 }
 
 main().catch(err => {
-  console.error('💥 Erreur fatale:', err);
+  console.error('Erreur fatale:', err);
   process.exit(1);
 });

--- a/scripts/fact-check-runner.mjs
+++ b/scripts/fact-check-runner.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Agent Fact-Check — Vérifie les articles GLP1 via Claude API avec web search.
+ * Agent Fact-Check — Verifie les articles GLP1 via Claude API avec web search.
+ * Cree des tickets individuels dans correction_tickets pour chaque probleme detecte.
  *
  * Usage :
  *   node scripts/fact-check-runner.mjs                    # tous les articles
@@ -25,7 +26,7 @@ import Anthropic from '@anthropic-ai/sdk';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MODEL = 'claude-sonnet-4-20250514';
-const MAX_TOKENS = 4096;
+const MAX_TOKENS = 8192;
 const SYSTEM_PROMPT_PATH = path.resolve(__dirname, '../n8n/prompts/fact-check-system-prompt.md');
 
 // Parse CLI arguments
@@ -42,11 +43,11 @@ const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
-  console.error('❌ SUPABASE_URL et SUPABASE_SERVICE_ROLE_KEY requis');
+  console.error('SUPABASE_URL et SUPABASE_SERVICE_ROLE_KEY requis');
   process.exit(1);
 }
 if (!ANTHROPIC_API_KEY) {
-  console.error('❌ ANTHROPIC_API_KEY requis');
+  console.error('ANTHROPIC_API_KEY requis');
   process.exit(1);
 }
 
@@ -81,7 +82,7 @@ async function fetchArticles() {
 
   const { data, error } = await query;
   if (error) {
-    console.error('❌ Erreur récupération articles:', error.message);
+    console.error('Erreur recuperation articles:', error.message);
     process.exit(1);
   }
   return data || [];
@@ -99,7 +100,7 @@ async function factCheckArticle(article) {
   });
 
   try {
-    const userMessage = `# Article à vérifier
+    const userMessage = `# Article a verifier
 
 **Titre** : ${article.title}
 **Collection** : ${article.collection}
@@ -113,7 +114,7 @@ ${article.content}`;
       model: MODEL,
       max_tokens: MAX_TOKENS,
       system: systemPrompt,
-      tools: [{ type: 'web_search_20250305', name: 'web_search', max_uses: 10 }],
+      tools: [{ type: 'web_search_20250305', name: 'web_search', max_uses: 15 }],
       messages: [{ role: 'user', content: userMessage }]
     });
 
@@ -124,7 +125,7 @@ ${article.content}`;
     // Parse JSON from response
     const jsonMatch = rawText.match(/\{[\s\S]*\}/);
     if (!jsonMatch) {
-      throw new Error(`Pas de JSON valide dans la réponse Claude pour ${article.slug}`);
+      throw new Error(`Pas de JSON valide dans la reponse Claude pour ${article.slug}`);
     }
 
     const result = JSON.parse(jsonMatch[0]);
@@ -132,20 +133,53 @@ ${article.content}`;
     const tokensUsed = (response.usage?.input_tokens || 0) + (response.usage?.output_tokens || 0);
 
     // Write result to fact_check_results
-    const { error: insertError } = await supabase
+    const { data: factCheckRow, error: insertError } = await supabase
       .from('fact_check_results')
       .insert({
         article_id: article.id,
         score_fiabilite: result.score_fiabilite,
         statut: result.statut,
-        points: result.points || [],
-        sources: (result.points || []).map(p => p.source).filter(Boolean),
+        points: result.tickets || [],
+        sources: (result.tickets || []).map(t => t.source).filter(Boolean),
         model_used: MODEL,
         tokens_used: tokensUsed
-      });
+      })
+      .select('id')
+      .single();
 
     if (insertError) {
-      throw new Error(`Erreur écriture Supabase: ${insertError.message}`);
+      throw new Error(`Erreur ecriture fact_check_results: ${insertError.message}`);
+    }
+
+    const factCheckResultId = factCheckRow.id;
+
+    // Create individual tickets in correction_tickets
+    const tickets = result.tickets || [];
+    let ticketsCreated = 0;
+
+    for (const ticket of tickets) {
+      const { error: ticketError } = await supabase
+        .from('correction_tickets')
+        .insert({
+          article_id: article.id,
+          slug: article.slug,
+          title: article.title,
+          fact_check_result_id: factCheckResultId,
+          ticket_type: ticket.ticket_type || 'info_outdated',
+          urgence: ticket.urgence || 'warning',
+          before_exact: ticket.before_exact,
+          after_suggested: ticket.after_suggested,
+          claim_original: ticket.claim_original,
+          realite_actuelle: ticket.realite_actuelle,
+          source_reference: ticket.source || null,
+          statut: 'pending_review'
+        });
+
+      if (ticketError) {
+        console.error(`  Erreur creation ticket: ${ticketError.message}`);
+      } else {
+        ticketsCreated++;
+      }
     }
 
     // Update last_fact_checked on article
@@ -166,11 +200,20 @@ ${article.content}`;
         model: MODEL,
         score: result.score_fiabilite,
         statut: result.statut,
-        points_count: (result.points || []).length
+        tickets_count: tickets.length,
+        tickets_created: ticketsCreated
       }
     });
 
-    return { slug: article.slug, ...result, tokens_used: tokensUsed, duration_ms: durationMs };
+    return {
+      slug: article.slug,
+      score_fiabilite: result.score_fiabilite,
+      statut: result.statut,
+      tickets_count: tickets.length,
+      tickets_created: ticketsCreated,
+      tokens_used: tokensUsed,
+      duration_ms: durationMs
+    };
   } catch (err) {
     const durationMs = Date.now() - startTime;
 
@@ -184,7 +227,7 @@ ${article.content}`;
       metadata: { slug: article.slug, model: MODEL }
     });
 
-    console.error(`  ❌ ${article.slug}: ${err.message}`);
+    console.error(`  ${article.slug}: ${err.message}`);
     return { slug: article.slug, error: err.message };
   }
 }
@@ -193,37 +236,27 @@ function buildAlertSummary(results) {
   const urgent = results.filter(r => r.statut === 'Urgent');
   if (urgent.length === 0) return null;
 
-  let body = `⚠️ ALERTE FACT-CHECK GLP1\n\n`;
-  body += `${urgent.length} article(s) nécessitent une correction urgente :\n\n`;
+  let body = `ALERTE FACT-CHECK GLP1\n\n`;
+  body += `${urgent.length} article(s) necessitent une correction urgente :\n\n`;
 
   for (const r of urgent) {
-    body += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
-    body += `📄 ${r.slug}\n`;
-    body += `   Score : ${r.score_fiabilite}/100\n`;
-    for (const p of (r.points || [])) {
-      if (p.urgence === 'urgent') {
-        body += `   🔴 ${p.claim_original}\n`;
-        body += `      → ${p.realite_actuelle}\n`;
-      }
-    }
-    body += '\n';
+    body += `---\n`;
+    body += `${r.slug} — Score: ${r.score_fiabilite}/100 — ${r.tickets_count} ticket(s)\n`;
   }
 
-  body += `\n🔗 Dashboard : https://glp1-france.fr/admin/fact-check\n`;
-  return { subject: `[GLP1] ⚠️ ${urgent.length} article(s) urgents — Fact-Check`, body };
+  body += `\nDashboard : https://glp1-france.fr/admin/fact-check\n`;
+  return { subject: `[GLP1] ${urgent.length} article(s) urgents — Fact-Check`, body };
 }
 
 async function sendAlertEmail(alert) {
   const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, ALERT_EMAIL_TO } = process.env;
 
   if (!SMTP_HOST || !ALERT_EMAIL_TO) {
-    console.log('📧 Alerte email non envoyée (SMTP non configuré)');
-    console.log('   Résumé alerte :', alert.subject);
+    console.log('Alerte email non envoyee (SMTP non configure)');
+    console.log('   Resume alerte :', alert.subject);
     return;
   }
 
-  // Dynamic import to avoid requiring nodemailer when not needed
-  // nodemailer is only needed for email alerts
   try {
     const nodemailer = await import('nodemailer');
     const transporter = nodemailer.default.createTransport({
@@ -240,29 +273,28 @@ async function sendAlertEmail(alert) {
       text: alert.body
     });
 
-    console.log(`📧 Alerte envoyée à ${ALERT_EMAIL_TO}`);
+    console.log(`Alerte envoyee a ${ALERT_EMAIL_TO}`);
   } catch (err) {
-    console.error(`📧 Erreur envoi email: ${err.message}`);
-    // Don't fail the whole run for email errors
+    console.error(`Erreur envoi email: ${err.message}`);
   }
 }
 
 // --- Main ---
 
 async function main() {
-  console.log('🔍 Agent Fact-Check GLP1');
-  console.log(`   Modèle : ${MODEL}`);
-  console.log(`   Web search : activé`);
-  if (SINGLE_ARTICLE_ID) console.log(`   Article ciblé : ${SINGLE_ARTICLE_ID}`);
+  console.log('Agent Fact-Check GLP1 (Marche FR)');
+  console.log(`   Modele : ${MODEL}`);
+  console.log(`   Web search : active (15 max/article)`);
+  if (SINGLE_ARTICLE_ID) console.log(`   Article cible : ${SINGLE_ARTICLE_ID}`);
   if (LIMIT > 0) console.log(`   Limite : ${LIMIT} articles`);
   console.log('');
 
   // 1. Fetch articles
   const articles = await fetchArticles();
-  console.log(`📂 ${articles.length} article(s) à vérifier\n`);
+  console.log(`${articles.length} article(s) a verifier\n`);
 
   if (articles.length === 0) {
-    console.log('✅ Aucun article à traiter');
+    console.log('Aucun article a traiter');
     return;
   }
 
@@ -276,8 +308,8 @@ async function main() {
     results.push(result);
 
     if (!result.error) {
-      const icon = result.statut === 'Urgent' ? '🔴' : result.statut === 'À vérifier' ? '🟡' : '🟢';
-      console.log(`  ${icon} Score: ${result.score_fiabilite}/100 — ${result.statut} (${result.points?.length || 0} points)`);
+      const icon = result.statut === 'Urgent' ? '[URGENT]' : result.statut === 'A verifier' ? '[WARN]' : '[OK]';
+      console.log(`  ${icon} Score: ${result.score_fiabilite}/100 — ${result.statut} — ${result.tickets_created} ticket(s) crees`);
     }
 
     // Small delay between API calls to respect rate limits
@@ -289,15 +321,16 @@ async function main() {
   // 3. Summary
   const successful = results.filter(r => !r.error);
   const errors = results.filter(r => r.error);
-  const urgentCount = results.filter(r => r.statut === 'Urgent').length;
+  const totalTickets = successful.reduce((sum, r) => sum + (r.tickets_created || 0), 0);
 
-  console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log(`✅ Vérifiés  : ${successful.length}`);
-  console.log(`❌ Erreurs   : ${errors.length}`);
-  console.log(`🔴 Urgents   : ${urgentCount}`);
-  console.log(`🟡 À vérifier: ${results.filter(r => r.statut === 'À vérifier').length}`);
-  console.log(`🟢 OK        : ${results.filter(r => r.statut === 'OK').length}`);
-  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log('\n---');
+  console.log(`Verifies    : ${successful.length}`);
+  console.log(`Erreurs     : ${errors.length}`);
+  console.log(`Tickets crees: ${totalTickets}`);
+  console.log(`Urgents     : ${results.filter(r => r.statut === 'Urgent').length}`);
+  console.log(`A verifier  : ${results.filter(r => r.statut === 'A verifier').length}`);
+  console.log(`OK          : ${results.filter(r => r.statut === 'OK').length}`);
+  console.log('---');
 
   // 4. Send alert if urgent articles found
   const alert = buildAlertSummary(results);
@@ -311,7 +344,8 @@ async function main() {
       `total=${articles.length}`,
       `checked=${successful.length}`,
       `errors=${errors.length}`,
-      `urgent=${urgentCount}`
+      `urgent=${results.filter(r => r.statut === 'Urgent').length}`,
+      `tickets=${totalTickets}`
     ].join('\n');
     fs.appendFileSync(process.env.GITHUB_OUTPUT, output + '\n');
   }
@@ -323,6 +357,6 @@ async function main() {
 }
 
 main().catch(err => {
-  console.error('💥 Erreur fatale:', err);
+  console.error('Erreur fatale:', err);
   process.exit(1);
 });

--- a/src/pages/admin/editorial.astro
+++ b/src/pages/admin/editorial.astro
@@ -1,46 +1,22 @@
 ---
 // src/pages/admin/editorial.astro
-// Dashboard Éditorial — Corrections rédigées par l'Agent Éditorial (Phase 2)
+// Dashboard Editorial — Tickets Before/After avec Deploy (Phase 3)
 import { supabase } from '../../lib/supabase';
 import { supabaseConfig } from '../../lib/supabase';
 
-// Récupérer les corrections avec infos articles
-const { data: corrections, error } = await supabase
-  .from('editorial_queue')
-  .select(`
-    id,
-    fact_check_id,
-    article_id,
-    claim_original,
-    realite_actuelle,
-    source_reference,
-    urgence,
-    section_originale,
-    section_corrigee,
-    explication_correction,
-    model_used,
-    tokens_used,
-    statut,
-    requested_at,
-    processed_at,
-    reviewed_at,
-    reviewed_by,
-    articles (
-      id,
-      slug,
-      title,
-      collection
-    )
-  `)
-  .order('requested_at', { ascending: false })
+// Recuperer tous les tickets avec after_final ou en attente de traitement editorial
+const { data: tickets, error } = await supabase
+  .from('correction_tickets')
+  .select('*')
+  .in('statut', ['approved', 'in_progress', 'ready_to_deploy', 'deployed', 'revision_needed'])
+  .order('updated_at', { ascending: false })
   .limit(200);
 
 // Grouper par statut
-const pendingReview = (corrections || []).filter(c => c.statut === 'pending_review');
-const requested = (corrections || []).filter(c => c.statut === 'requested' || c.statut === 'processing');
-const approved = (corrections || []).filter(c => c.statut === 'approved');
-const rejected = (corrections || []).filter(c => c.statut === 'rejected');
-const applied = (corrections || []).filter(c => c.statut === 'applied');
+const readyToDeploy = (tickets || []).filter(t => t.statut === 'ready_to_deploy');
+const inProgress = (tickets || []).filter(t => t.statut === 'approved' || t.statut === 'in_progress');
+const revisionNeeded = (tickets || []).filter(t => t.statut === 'revision_needed');
+const deployed = (tickets || []).filter(t => t.statut === 'deployed');
 
 function formatDate(dateStr: string | null) {
   if (!dateStr) return 'N/A';
@@ -49,24 +25,22 @@ function formatDate(dateStr: string | null) {
   });
 }
 
-function urgenceBadge(urgence: string) {
+function urgenceIcon(urgence: string) {
   switch (urgence) {
-    case 'urgent': return { bg: '#fecaca', color: '#991b1b', label: 'Urgent' };
-    case 'moyen': return { bg: '#fde68a', color: '#92400e', label: 'Moyen' };
-    case 'faible': return { bg: '#bbf7d0', color: '#166534', label: 'Faible' };
-    default: return { bg: '#e2e8f0', color: '#475569', label: urgence };
+    case 'urgent': return '🔴';
+    case 'warning': return '🟡';
+    case 'ok': return '🟢';
+    default: return '⚪';
   }
 }
 
-function statutBadge(statut: string) {
-  switch (statut) {
-    case 'requested': return { bg: '#e0e7ff', color: '#4338ca', label: 'En attente' };
-    case 'processing': return { bg: '#fef3c7', color: '#92400e', label: 'En cours' };
-    case 'pending_review': return { bg: '#dbeafe', color: '#1e40af', label: 'A relire' };
-    case 'approved': return { bg: '#d1fae5', color: '#065f46', label: 'Approuve' };
-    case 'rejected': return { bg: '#fee2e2', color: '#991b1b', label: 'Rejete' };
-    case 'applied': return { bg: '#d1fae5', color: '#065f46', label: 'Applique' };
-    default: return { bg: '#e2e8f0', color: '#475569', label: statut };
+function typeLabel(type: string) {
+  switch (type) {
+    case 'price_update': return 'Prix';
+    case 'info_outdated': return 'Info obsolete';
+    case 'false_claim': return 'Claim faux';
+    case 'missing_info': return 'Info manquante';
+    default: return type;
   }
 }
 ---
@@ -111,10 +85,10 @@ function statutBadge(statut: string) {
     }
     .stat-card .stat-value { font-size: 2rem; font-weight: 700; }
     .stat-card .stat-label { font-size: 0.85rem; color: #64748b; margin-top: 0.25rem; }
-    .stat-review { background: #eff6ff; color: #3b82f6; }
-    .stat-waiting { background: #f5f3ff; color: #7c3aed; }
-    .stat-approved { background: #f0fdf4; color: #22c55e; }
-    .stat-rejected { background: #fef2f2; color: #dc2626; }
+    .stat-deploy { background: #d1fae5; color: #065f46; }
+    .stat-progress { background: #f5f3ff; color: #7c3aed; }
+    .stat-revision { background: #fffbeb; color: #f59e0b; }
+    .stat-done { background: #f0fdf4; color: #22c55e; }
     .main { padding: 2rem; max-width: 1400px; margin: 0 auto; }
     .section { margin-bottom: 2rem; }
     .section-title {
@@ -132,29 +106,33 @@ function statutBadge(statut: string) {
       font-size: 0.75rem;
       font-weight: 600;
     }
-    .card {
+
+    /* Ticket card */
+    .ticket {
       background: white;
-      border-radius: 8px;
       border: 1px solid #e2e8f0;
+      border-radius: 8px;
       margin-bottom: 1rem;
       overflow: hidden;
     }
-    .card-header {
+    .ticket-header {
       padding: 1rem 1.25rem;
       display: flex;
       justify-content: space-between;
       align-items: center;
       cursor: pointer;
     }
-    .card-header:hover { background: #f8fafc; }
-    .card-title { font-weight: 500; font-size: 0.95rem; }
-    .card-meta { font-size: 0.8rem; color: #94a3b8; display: flex; gap: 0.75rem; align-items: center; }
-    .card-body {
-      padding: 0 1.25rem 1.25rem;
-      border-top: 1px solid #f1f5f9;
-      display: none;
+    .ticket-header:hover { background: #f8fafc; }
+    .ticket-info {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
     }
-    .card.open .card-body { display: block; }
+    .ticket-title { font-weight: 500; font-size: 0.95rem; }
+    .ticket-meta { font-size: 0.8rem; color: #94a3b8; display: flex; gap: 0.75rem; align-items: center; }
+    .ticket-body { display: none; padding: 0 1.25rem 1.25rem; border-top: 1px solid #f1f5f9; }
+    .ticket.open .ticket-body { display: block; }
+
     .collection-tag {
       display: inline-block;
       padding: 0.15rem 0.5rem;
@@ -163,29 +141,31 @@ function statutBadge(statut: string) {
       background: #e0e7ff;
       color: #4338ca;
     }
-    .diff-block {
-      margin-top: 0.75rem;
+
+    /* Diff blocks */
+    .diff-before, .diff-after {
       border-radius: 6px;
+      margin-top: 0.75rem;
       overflow: hidden;
     }
     .diff-label {
       font-size: 0.8rem;
       font-weight: 600;
-      padding: 0.5rem 0.75rem;
-      display: flex;
-      justify-content: space-between;
+      padding: 0.4rem 0.75rem;
     }
     .diff-content {
       padding: 0.75rem;
       font-size: 0.85rem;
       line-height: 1.6;
       white-space: pre-wrap;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      word-break: break-word;
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
     }
-    .diff-original .diff-label { background: #fef2f2; color: #991b1b; }
-    .diff-original .diff-content { background: #fff5f5; color: #1e293b; border: 1px solid #fecaca; border-top: none; }
-    .diff-corrected .diff-label { background: #f0fdf4; color: #166534; }
-    .diff-corrected .diff-content { background: #f0fdf9; color: #1e293b; border: 1px solid #bbf7d0; border-top: none; }
+    .diff-before .diff-label { background: #fef2f2; color: #991b1b; }
+    .diff-before .diff-content { background: #fff5f5; border: 1px solid #fecaca; border-top: none; text-decoration: line-through; color: #991b1b; }
+    .diff-after .diff-label { background: #f0fdf4; color: #166534; }
+    .diff-after .diff-content { background: #f0fdf9; border: 1px solid #bbf7d0; border-top: none; color: #166534; }
+
     .explanation {
       margin-top: 0.75rem;
       padding: 0.75rem;
@@ -195,25 +175,27 @@ function statutBadge(statut: string) {
       font-size: 0.85rem;
       color: #92400e;
     }
-    .explanation-label { font-weight: 600; margin-bottom: 0.25rem; }
-    .claim-block {
+    .ticket-source {
+      font-size: 0.8rem;
+      color: #3b82f6;
+      margin-top: 0.5rem;
+    }
+    .ticket-source a { color: #3b82f6; }
+    .human-note {
       margin-top: 0.75rem;
       padding: 0.75rem;
-      background: #f8fafc;
-      border-left: 3px solid #94a3b8;
-      border-radius: 0 6px 6px 0;
+      background: #fef3c7;
+      border: 1px solid #fde68a;
+      border-radius: 6px;
+      font-size: 0.85rem;
     }
-    .claim-label { font-size: 0.75rem; font-weight: 600; color: #64748b; margin-bottom: 0.25rem; }
-    .claim-text { font-size: 0.9rem; font-weight: 500; }
-    .realite-text { font-size: 0.85rem; color: #475569; margin-top: 0.25rem; }
-    .source-link { font-size: 0.8rem; color: #3b82f6; margin-top: 0.25rem; }
-    .source-link a { color: #3b82f6; }
-    .card-actions {
-      padding: 0.75rem 1.25rem;
-      border-top: 1px solid #f1f5f9;
+
+    .ticket-actions {
       display: flex;
       gap: 0.5rem;
-      justify-content: flex-end;
+      margin-top: 1rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid #f1f5f9;
     }
     .btn {
       padding: 0.5rem 1rem;
@@ -223,18 +205,15 @@ function statutBadge(statut: string) {
       font-weight: 500;
       cursor: pointer;
       transition: all 0.2s;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
     }
     .btn:disabled { opacity: 0.5; cursor: not-allowed; }
-    .btn-approve { background: #22c55e; color: white; }
-    .btn-approve:hover:not(:disabled) { background: #16a34a; }
-    .btn-reject { background: #ef4444; color: white; }
-    .btn-reject:hover:not(:disabled) { background: #dc2626; }
-    .empty-state {
-      text-align: center;
-      padding: 2rem;
-      color: #94a3b8;
-      font-size: 0.9rem;
-    }
+    .btn-deploy { background: #7c3aed; color: white; }
+    .btn-deploy:hover:not(:disabled) { background: #6d28d9; }
+    .btn-deploy.done { background: #22c55e; }
+
     .toast {
       position: fixed;
       bottom: 2rem;
@@ -252,6 +231,12 @@ function statutBadge(statut: string) {
     .toast.show { transform: translateY(0); opacity: 1; }
     .toast.success { background: #22c55e; }
     .toast.error { background: #dc2626; }
+    .empty-state {
+      text-align: center;
+      padding: 2rem;
+      color: #94a3b8;
+      font-size: 0.9rem;
+    }
   </style>
 </head>
 <body>
@@ -265,21 +250,21 @@ function statutBadge(statut: string) {
 </div>
 
 <div class="stats-bar">
-  <div class="stat-card stat-review">
-    <div class="stat-value">{pendingReview.length}</div>
-    <div class="stat-label">A relire</div>
+  <div class="stat-card stat-deploy">
+    <div class="stat-value">{readyToDeploy.length}</div>
+    <div class="stat-label">Prets a deployer</div>
   </div>
-  <div class="stat-card stat-waiting">
-    <div class="stat-value">{requested.length}</div>
-    <div class="stat-label">En attente</div>
+  <div class="stat-card stat-progress">
+    <div class="stat-value">{inProgress.length}</div>
+    <div class="stat-label">En cours</div>
   </div>
-  <div class="stat-card stat-approved">
-    <div class="stat-value">{approved.length + applied.length}</div>
-    <div class="stat-label">Approuves</div>
+  <div class="stat-card stat-revision">
+    <div class="stat-value">{revisionNeeded.length}</div>
+    <div class="stat-label">En revision</div>
   </div>
-  <div class="stat-card stat-rejected">
-    <div class="stat-value">{rejected.length}</div>
-    <div class="stat-label">Rejetes</div>
+  <div class="stat-card stat-done">
+    <div class="stat-value">{deployed.length}</div>
+    <div class="stat-label">Deployes</div>
   </div>
 </div>
 
@@ -287,183 +272,171 @@ function statutBadge(statut: string) {
 
   {error && (
     <div style="background: #fef2f2; border: 1px solid #fecaca; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; color: #991b1b;">
-      Erreur de connexion Supabase : {error.message}. Assurez-vous que la migration 004 a ete executee.
+      Erreur Supabase : {error.message}
     </div>
   )}
 
-  {(corrections || []).length === 0 && !error && (
+  {(tickets || []).length === 0 && !error && (
     <div class="empty-state">
-      <p style="font-size: 1.2rem; margin-bottom: 0.5rem;">Aucune correction editoriale</p>
-      <p>Envoyez des points depuis le <a href="/admin/fact-check" style="color: #3b82f6;">dashboard fact-check</a>, puis lancez l'agent editorial.</p>
+      <p style="font-size: 1.2rem; margin-bottom: 0.5rem;">Aucun ticket editorial</p>
+      <p>Approuvez des tickets depuis le <a href="/admin/fact-check" style="color: #3b82f6;">dashboard fact-check</a>, puis lancez l'agent editorial.</p>
       <p style="margin-top: 0.5rem;"><code>node scripts/editorial-agent.mjs</code></p>
     </div>
   )}
 
-  <!-- Section: A relire (pending_review) -->
-  {pendingReview.length > 0 && (
+  {/* Ready to deploy */}
+  {readyToDeploy.length > 0 && (
     <div class="section">
       <div class="section-title">
-        <span style="color: #3b82f6;">A relire</span>
-        <span class="badge" style="background: #dbeafe; color: #1e40af;">{pendingReview.length}</span>
+        <span style="color: #065f46;">Prets a deployer</span>
+        <span class="badge" style="background: #d1fae5; color: #065f46;">{readyToDeploy.length}</span>
       </div>
-      {pendingReview.map((c: any) => {
-        const ub = urgenceBadge(c.urgence);
-        return (
-          <div class="card" data-card>
-            <div class="card-header" data-toggle>
-              <div>
-                <span class="card-title">{c.articles?.title || 'Article inconnu'}</span>
-                <span class="collection-tag" style="margin-left: 0.5rem;">{c.articles?.collection}</span>
-                <span class="badge" style={`margin-left: 0.5rem; background: ${ub.bg}; color: ${ub.color};`}>{ub.label}</span>
-              </div>
-              <div class="card-meta">
-                <span>{formatDate(c.processed_at)}</span>
-              </div>
+      {readyToDeploy.map((t: any) => (
+        <div class="ticket" data-card>
+          <div class="ticket-header" data-toggle>
+            <div class="ticket-info">
+              <span>{urgenceIcon(t.urgence)}</span>
+              <span class="ticket-title">{t.title}</span>
+              <span class="badge" style="background: #f5f3ff; color: #7c3aed;">{typeLabel(t.ticket_type)}</span>
             </div>
-            <div class="card-body">
-              <div class="claim-block">
-                <div class="claim-label">Claim problematique</div>
-                <div class="claim-text">{c.claim_original}</div>
-                <div class="realite-text">{c.realite_actuelle}</div>
-                {c.source_reference && (
-                  <div class="source-link">
-                    <a href={c.source_reference} target="_blank" rel="noopener">{c.source_reference}</a>
-                  </div>
-                )}
-              </div>
-
-              {c.section_originale && (
-                <div class="diff-block diff-original">
-                  <div class="diff-label"><span>Section originale</span></div>
-                  <div class="diff-content">{c.section_originale}</div>
-                </div>
-              )}
-
-              {c.section_corrigee && (
-                <div class="diff-block diff-corrected">
-                  <div class="diff-label"><span>Section corrigee</span></div>
-                  <div class="diff-content">{c.section_corrigee}</div>
-                </div>
-              )}
-
-              {c.explication_correction && (
-                <div class="explanation">
-                  <div class="explanation-label">Explication de la correction</div>
-                  <div>{c.explication_correction}</div>
-                </div>
-              )}
-
-              <div class="card-actions">
-                <button class="btn btn-reject" data-review-action="rejected" data-correction-id={c.id}>
-                  Rejeter
-                </button>
-                <button class="btn btn-approve" data-review-action="approved" data-correction-id={c.id}>
-                  Approuver
-                </button>
-              </div>
+            <div class="ticket-meta">
+              <span>{formatDate(t.updated_at)}</span>
             </div>
           </div>
-        );
-      })}
+          <div class="ticket-body">
+            <div class="diff-before">
+              <div class="diff-label">AVANT (before_exact)</div>
+              <div class="diff-content">{t.before_exact}</div>
+            </div>
+            <div class="diff-after">
+              <div class="diff-label">APRES (after_final)</div>
+              <div class="diff-content">{t.after_final}</div>
+            </div>
+            <div class="explanation">
+              <strong>Claim :</strong> {t.claim_original}<br/>
+              <strong>Realite :</strong> {t.realite_actuelle}
+            </div>
+            {t.source_reference && (
+              <div class="ticket-source">
+                Source : <a href={t.source_reference} target="_blank" rel="noopener">{t.source_reference}</a>
+              </div>
+            )}
+            <div class="ticket-actions">
+              <button class="btn btn-deploy" data-deploy data-ticket-id={t.id} data-slug={t.slug}>
+                Deployer
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   )}
 
-  <!-- Section: En attente de traitement -->
-  {requested.length > 0 && (
+  {/* In progress / approved — waiting for editorial agent */}
+  {inProgress.length > 0 && (
     <div class="section">
       <div class="section-title">
-        <span style="color: #7c3aed;">En attente de traitement</span>
-        <span class="badge" style="background: #f5f3ff; color: #7c3aed;">{requested.length}</span>
+        <span style="color: #7c3aed;">En attente de l'agent editorial</span>
+        <span class="badge" style="background: #f5f3ff; color: #7c3aed;">{inProgress.length}</span>
       </div>
       <p style="font-size: 0.85rem; color: #64748b; margin-bottom: 1rem;">
-        Ces points attendent que l'agent editorial les traite. Lancez : <code>node scripts/editorial-agent.mjs</code>
+        Lancez : <code>node scripts/editorial-agent.mjs</code>
       </p>
-      {requested.map((c: any) => {
-        const ub = urgenceBadge(c.urgence);
-        const sb = statutBadge(c.statut);
-        return (
-          <div class="card" data-card>
-            <div class="card-header" data-toggle>
-              <div>
-                <span class="card-title">{c.articles?.title || 'Article inconnu'}</span>
-                <span class="badge" style={`margin-left: 0.5rem; background: ${ub.bg}; color: ${ub.color};`}>{ub.label}</span>
-                <span class="badge" style={`margin-left: 0.5rem; background: ${sb.bg}; color: ${sb.color};`}>{sb.label}</span>
-              </div>
-              <div class="card-meta">
-                <span>{formatDate(c.requested_at)}</span>
-              </div>
+      {inProgress.map((t: any) => (
+        <div class="ticket" data-card>
+          <div class="ticket-header" data-toggle>
+            <div class="ticket-info">
+              <span>{urgenceIcon(t.urgence)}</span>
+              <span class="ticket-title">{t.title}</span>
+              <span class="badge" style="background: #e0e7ff; color: #4338ca;">{t.statut === 'in_progress' ? 'En cours' : 'Approuve'}</span>
             </div>
-            <div class="card-body">
-              <div class="claim-block">
-                <div class="claim-label">Claim problematique</div>
-                <div class="claim-text">{c.claim_original}</div>
-                <div class="realite-text">{c.realite_actuelle}</div>
-              </div>
+            <div class="ticket-meta">
+              <span>{formatDate(t.updated_at)}</span>
             </div>
           </div>
-        );
-      })}
+          <div class="ticket-body">
+            <div class="diff-before">
+              <div class="diff-label">AVANT</div>
+              <div class="diff-content">{t.before_exact}</div>
+            </div>
+            <div class="diff-after">
+              <div class="diff-label">CORRECTION PROPOSEE</div>
+              <div class="diff-content">{t.after_suggested}</div>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   )}
 
-  <!-- Section: Approuves / Appliques -->
-  {(approved.length + applied.length) > 0 && (
+  {/* Revision needed */}
+  {revisionNeeded.length > 0 && (
     <div class="section">
       <div class="section-title">
-        <span style="color: #22c55e;">Approuves</span>
-        <span class="badge" style="background: #d1fae5; color: #065f46;">{approved.length + applied.length}</span>
+        <span style="color: #f59e0b;">En revision</span>
+        <span class="badge" style="background: #fef3c7; color: #92400e;">{revisionNeeded.length}</span>
       </div>
-      {[...approved, ...applied].map((c: any) => {
-        const sb = statutBadge(c.statut);
-        return (
-          <div class="card" data-card>
-            <div class="card-header" data-toggle>
-              <div>
-                <span class="card-title">{c.articles?.title || 'Article inconnu'}</span>
-                <span class="badge" style={`margin-left: 0.5rem; background: ${sb.bg}; color: ${sb.color};`}>{sb.label}</span>
-              </div>
-              <div class="card-meta">
-                <span>Relu {formatDate(c.reviewed_at)}</span>
-              </div>
+      <p style="font-size: 0.85rem; color: #64748b; margin-bottom: 1rem;">
+        Ces tickets ont ete rejetes avec note. Lancez l'agent editorial pour les reviser.
+      </p>
+      {revisionNeeded.map((t: any) => (
+        <div class="ticket" data-card>
+          <div class="ticket-header" data-toggle>
+            <div class="ticket-info">
+              <span>{urgenceIcon(t.urgence)}</span>
+              <span class="ticket-title">{t.title}</span>
             </div>
-            <div class="card-body">
-              <div class="claim-block">
-                <div class="claim-label">Correction appliquee</div>
-                <div class="claim-text">{c.claim_original}</div>
-              </div>
-              {c.section_corrigee && (
-                <div class="diff-block diff-corrected">
-                  <div class="diff-label"><span>Section corrigee</span></div>
-                  <div class="diff-content">{c.section_corrigee}</div>
-                </div>
-              )}
+            <div class="ticket-meta">
+              <span>{formatDate(t.updated_at)}</span>
             </div>
           </div>
-        );
-      })}
+          <div class="ticket-body">
+            {t.human_note && (
+              <div class="human-note">
+                <strong>Note humaine :</strong> {t.human_note}
+              </div>
+            )}
+            <div class="diff-before">
+              <div class="diff-label">AVANT</div>
+              <div class="diff-content">{t.before_exact}</div>
+            </div>
+            <div class="diff-after">
+              <div class="diff-label">CORRECTION PROPOSEE</div>
+              <div class="diff-content">{t.after_suggested}</div>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   )}
 
-  <!-- Section: Rejetes -->
-  {rejected.length > 0 && (
+  {/* Deployed */}
+  {deployed.length > 0 && (
     <div class="section">
       <div class="section-title">
-        <span style="color: #ef4444;">Rejetes</span>
-        <span class="badge" style="background: #fee2e2; color: #991b1b;">{rejected.length}</span>
+        <span style="color: #22c55e;">Deployes</span>
+        <span class="badge" style="background: #bbf7d0; color: #166534;">{deployed.length}</span>
       </div>
-      {rejected.map((c: any) => (
-        <div class="card" data-card>
-          <div class="card-header" data-toggle>
-            <div>
-              <span class="card-title">{c.articles?.title || 'Article inconnu'}</span>
+      {deployed.map((t: any) => (
+        <div class="ticket" data-card>
+          <div class="ticket-header" data-toggle>
+            <div class="ticket-info">
+              <span>{urgenceIcon(t.urgence)}</span>
+              <span class="ticket-title">{t.title}</span>
+              <span class="badge" style="background: #bbf7d0; color: #166534;">Deploye</span>
             </div>
-            <div class="card-meta">
-              <span>Rejete {formatDate(c.reviewed_at)}</span>
+            <div class="ticket-meta">
+              <span>Deploye {formatDate(t.deployed_at)}</span>
             </div>
           </div>
-          <div class="card-body">
-            <div class="claim-block">
-              <div class="claim-text">{c.claim_original}</div>
+          <div class="ticket-body">
+            <div class="diff-before">
+              <div class="diff-label">AVANT</div>
+              <div class="diff-content">{t.before_exact}</div>
+            </div>
+            <div class="diff-after">
+              <div class="diff-label">APRES (final)</div>
+              <div class="diff-content">{t.after_final}</div>
             </div>
           </div>
         </div>
@@ -495,20 +468,20 @@ function statutBadge(statut: string) {
     });
   });
 
-  // Approve / Reject actions
-  document.querySelectorAll('[data-review-action]').forEach(btn => {
+  // Deploy action — marks ticket as deployed
+  // In production, this would trigger the integration agent (commit + PR)
+  document.querySelectorAll('[data-deploy]').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();
       const button = e.currentTarget;
-      const action = button.dataset.reviewAction;
-      const correctionId = button.dataset.correctionId;
+      const ticketId = button.dataset.ticketId;
+      const slug = button.dataset.slug;
 
       button.disabled = true;
-      const originalText = button.textContent;
-      button.textContent = '...';
+      button.textContent = 'Deploiement...';
 
       try {
-        const response = await fetch(`${SUPABASE_URL}/rest/v1/editorial_queue?id=eq.${correctionId}`, {
+        const response = await fetch(`${SUPABASE_URL}/rest/v1/correction_tickets?id=eq.${ticketId}`, {
           method: 'PATCH',
           headers: {
             'apikey': SUPABASE_ANON_KEY,
@@ -517,9 +490,8 @@ function statutBadge(statut: string) {
             'Prefer': 'return=minimal'
           },
           body: JSON.stringify({
-            statut: action,
-            reviewed_at: new Date().toISOString(),
-            reviewed_by: 'admin'
+            statut: 'deployed',
+            deployed_at: new Date().toISOString()
           })
         });
 
@@ -527,19 +499,14 @@ function statutBadge(statut: string) {
           throw new Error(await response.text());
         }
 
-        const card = button.closest('[data-card]');
-        if (card) {
-          card.style.opacity = '0.5';
-          card.style.pointerEvents = 'none';
-        }
+        button.textContent = 'Deploye';
+        button.classList.add('done');
+        showToast(`Ticket deploye pour ${slug}`);
 
-        showToast(action === 'approved' ? 'Correction approuvee' : 'Correction rejetee');
-
-        // Reload after a short delay
         setTimeout(() => { window.location.reload(); }, 1500);
       } catch (err) {
         button.disabled = false;
-        button.textContent = originalText;
+        button.textContent = 'Deployer';
         showToast('Erreur: ' + err.message, 'error');
       }
     });

--- a/src/pages/admin/fact-check.astro
+++ b/src/pages/admin/fact-check.astro
@@ -1,35 +1,48 @@
 ---
 // src/pages/admin/fact-check.astro
-// Dashboard Fact-Check — Phase 1 & 2 Agent GLP1
+// Dashboard Fact-Check — Tickets Before/After (Phase 3)
 import { supabase } from '../../lib/supabase';
 import { supabaseConfig } from '../../lib/supabase';
 
-// Récupérer les derniers résultats de fact-check avec les infos articles
-const { data: results, error } = await supabase
+// Recuperer les resultats fact-check avec articles
+const { data: results, error: resultsError } = await supabase
   .from('fact_check_results')
   .select(`
     id,
     score_fiabilite,
     statut,
-    points,
-    sources,
     checked_at,
     model_used,
-    tokens_used,
     articles (
       id,
       slug,
       title,
-      collection,
-      last_fact_checked
+      collection
     )
   `)
   .order('checked_at', { ascending: false })
-  .limit(200);
+  .limit(100);
 
-// Grouper par statut
+// Recuperer les tickets
+const { data: tickets, error: ticketsError } = await supabase
+  .from('correction_tickets')
+  .select('*')
+  .order('created_at', { ascending: false })
+  .limit(500);
+
+const error = resultsError || ticketsError;
+
+// Grouper tickets par article (fact_check_result_id)
+const ticketsByResult = new Map();
+for (const t of (tickets || [])) {
+  const key = t.fact_check_result_id;
+  if (!ticketsByResult.has(key)) ticketsByResult.set(key, []);
+  ticketsByResult.get(key).push(t);
+}
+
+// Grouper resultats par statut
 const urgent = (results || []).filter(r => r.statut === 'Urgent');
-const aVerifier = (results || []).filter(r => r.statut === 'À vérifier');
+const aVerifier = (results || []).filter(r => r.statut === 'A verifier');
 const ok = (results || []).filter(r => r.statut === 'OK');
 
 // Stats
@@ -37,6 +50,8 @@ const totalChecked = (results || []).length;
 const avgScore = totalChecked > 0
   ? Math.round((results || []).reduce((sum, r) => sum + (r.score_fiabilite || 0), 0) / totalChecked)
   : 0;
+const totalTickets = (tickets || []).length;
+const pendingTickets = (tickets || []).filter(t => t.statut === 'pending_review').length;
 
 function formatDate(dateStr: string | null) {
   if (!dateStr) return 'N/A';
@@ -45,12 +60,35 @@ function formatDate(dateStr: string | null) {
   });
 }
 
-function urgenceColor(urgence: string) {
+function urgenceIcon(urgence: string) {
   switch (urgence) {
-    case 'urgent': return '#dc2626';
-    case 'moyen': return '#f59e0b';
-    case 'faible': return '#22c55e';
-    default: return '#6b7280';
+    case 'urgent': return '🔴';
+    case 'warning': return '🟡';
+    case 'ok': return '🟢';
+    default: return '⚪';
+  }
+}
+
+function typeLabel(type: string) {
+  switch (type) {
+    case 'price_update': return 'Prix';
+    case 'info_outdated': return 'Info obsolete';
+    case 'false_claim': return 'Claim faux';
+    case 'missing_info': return 'Info manquante';
+    default: return type;
+  }
+}
+
+function statutLabel(statut: string) {
+  switch (statut) {
+    case 'pending_review': return 'En attente';
+    case 'approved': return 'Approuve';
+    case 'rejected': return 'Rejete';
+    case 'in_progress': return 'En cours';
+    case 'ready_to_deploy': return 'Pret';
+    case 'deployed': return 'Deploye';
+    case 'revision_needed': return 'Revision';
+    default: return statut;
   }
 }
 ---
@@ -99,6 +137,7 @@ function urgenceColor(urgence: string) {
     .stat-warning { background: #fffbeb; color: #f59e0b; }
     .stat-ok { background: #f0fdf4; color: #22c55e; }
     .stat-info { background: #eff6ff; color: #3b82f6; }
+    .stat-tickets { background: #f5f3ff; color: #7c3aed; }
     .main { padding: 2rem; max-width: 1400px; margin: 0 auto; }
     .section { margin-bottom: 2rem; }
     .section-title {
@@ -116,57 +155,25 @@ function urgenceColor(urgence: string) {
       font-size: 0.75rem;
       font-weight: 600;
     }
-    .badge-urgent { background: #fecaca; color: #991b1b; }
-    .badge-warning { background: #fde68a; color: #92400e; }
-    .badge-ok { background: #bbf7d0; color: #166534; }
-    .card {
+    .article-card {
       background: white;
       border-radius: 8px;
       border: 1px solid #e2e8f0;
-      margin-bottom: 0.75rem;
+      margin-bottom: 1rem;
       overflow: hidden;
     }
-    .card-header {
+    .article-header {
       padding: 1rem 1.25rem;
       display: flex;
       justify-content: space-between;
       align-items: center;
       cursor: pointer;
     }
-    .card-header:hover { background: #f8fafc; }
-    .card-title { font-weight: 500; font-size: 0.95rem; }
-    .card-meta { font-size: 0.8rem; color: #94a3b8; display: flex; gap: 1rem; align-items: center; }
-    .card-body {
-      padding: 0 1.25rem 1.25rem;
-      border-top: 1px solid #f1f5f9;
-      display: none;
-    }
-    .card.open .card-body { display: block; }
-    .point {
-      padding: 0.75rem;
-      margin-top: 0.5rem;
-      border-radius: 6px;
-      background: #f8fafc;
-      border-left: 3px solid;
-      position: relative;
-    }
-    .point-claim { font-weight: 500; margin-bottom: 0.35rem; font-size: 0.9rem; }
-    .point-reality { font-size: 0.85rem; color: #475569; margin-bottom: 0.25rem; }
-    .point-source { font-size: 0.8rem; color: #3b82f6; }
-    .point-source a { color: #3b82f6; }
-    .score-pill {
-      display: inline-block;
-      padding: 0.2rem 0.5rem;
-      border-radius: 6px;
-      font-size: 0.8rem;
-      font-weight: 600;
-    }
-    .empty-state {
-      text-align: center;
-      padding: 2rem;
-      color: #94a3b8;
-      font-size: 0.9rem;
-    }
+    .article-header:hover { background: #f8fafc; }
+    .article-title { font-weight: 500; font-size: 0.95rem; }
+    .article-meta { font-size: 0.8rem; color: #94a3b8; display: flex; gap: 1rem; align-items: center; }
+    .article-body { display: none; padding: 0 1.25rem 1.25rem; }
+    .article-card.open .article-body { display: block; }
     .collection-tag {
       display: inline-block;
       padding: 0.15rem 0.5rem;
@@ -175,24 +182,112 @@ function urgenceColor(urgence: string) {
       background: #e0e7ff;
       color: #4338ca;
     }
-    .btn-editorial {
+    .score-pill {
+      display: inline-block;
+      padding: 0.2rem 0.5rem;
+      border-radius: 6px;
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+
+    /* Ticket card */
+    .ticket {
+      margin-top: 0.75rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .ticket-header {
+      padding: 0.75rem 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #f8fafc;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .ticket-type {
+      font-weight: 600;
+      font-size: 0.85rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .ticket-statut {
+      font-size: 0.75rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+      font-weight: 500;
+    }
+    .ticket-body { padding: 1rem; }
+
+    /* Diff blocks */
+    .diff-before, .diff-after {
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+      overflow: hidden;
+    }
+    .diff-label {
+      font-size: 0.8rem;
+      font-weight: 600;
+      padding: 0.4rem 0.75rem;
+    }
+    .diff-content {
+      padding: 0.75rem;
+      font-size: 0.85rem;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    }
+    .diff-before .diff-label { background: #fef2f2; color: #991b1b; }
+    .diff-before .diff-content { background: #fff5f5; border: 1px solid #fecaca; border-top: none; text-decoration: line-through; color: #991b1b; }
+    .diff-after .diff-label { background: #f0fdf4; color: #166534; }
+    .diff-after .diff-content { background: #f0fdf9; border: 1px solid #bbf7d0; border-top: none; color: #166534; }
+
+    .ticket-source {
+      font-size: 0.8rem;
+      color: #3b82f6;
+      margin-bottom: 0.75rem;
+    }
+    .ticket-source a { color: #3b82f6; }
+    .ticket-realite {
+      font-size: 0.85rem;
+      color: #475569;
+      margin-bottom: 0.75rem;
+      padding: 0.5rem 0.75rem;
+      background: #fffbeb;
+      border: 1px solid #fde68a;
+      border-radius: 6px;
+    }
+
+    /* Action buttons */
+    .ticket-actions {
+      display: flex;
+      gap: 0.5rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid #f1f5f9;
+    }
+    .btn {
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
       display: inline-flex;
       align-items: center;
       gap: 0.35rem;
-      margin-top: 0.5rem;
-      padding: 0.4rem 0.75rem;
-      background: #7c3aed;
-      color: white;
-      border: none;
-      border-radius: 6px;
-      font-size: 0.8rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: background 0.2s;
     }
-    .btn-editorial:hover { background: #6d28d9; }
-    .btn-editorial:disabled { background: #a78bfa; cursor: not-allowed; }
-    .btn-editorial.sent { background: #22c55e; }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-approve { background: #22c55e; color: white; }
+    .btn-approve:hover:not(:disabled) { background: #16a34a; }
+    .btn-reject { background: #ef4444; color: white; }
+    .btn-reject:hover:not(:disabled) { background: #dc2626; }
+    .btn-note { background: #f59e0b; color: white; }
+    .btn-note:hover:not(:disabled) { background: #d97706; }
+    .btn.done { background: #94a3b8; color: white; cursor: default; }
+
     .toast {
       position: fixed;
       bottom: 2rem;
@@ -210,29 +305,52 @@ function urgenceColor(urgence: string) {
     .toast.show { transform: translateY(0); opacity: 1; }
     .toast.success { background: #22c55e; }
     .toast.error { background: #dc2626; }
-    .card-actions {
-      padding: 0.75rem 1.25rem;
-      border-top: 1px solid #f1f5f9;
+
+    /* Modal */
+    .modal-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      z-index: 900;
+      align-items: center;
+      justify-content: center;
+    }
+    .modal-overlay.active { display: flex; }
+    .modal {
+      background: white;
+      border-radius: 12px;
+      padding: 1.5rem;
+      width: 90%;
+      max-width: 500px;
+    }
+    .modal h3 { margin-bottom: 1rem; }
+    .modal textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      font-size: 0.9rem;
+      font-family: inherit;
+      resize: vertical;
+    }
+    .modal-actions {
       display: flex;
       gap: 0.5rem;
       justify-content: flex-end;
+      margin-top: 1rem;
     }
-    .btn-send-all {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-      padding: 0.5rem 1rem;
-      background: #7c3aed;
-      color: white;
-      border: none;
-      border-radius: 6px;
-      font-size: 0.85rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: background 0.2s;
+    .btn-cancel { background: #e2e8f0; color: #475569; }
+    .btn-cancel:hover { background: #cbd5e1; }
+    .btn-send-note { background: #f59e0b; color: white; }
+    .btn-send-note:hover { background: #d97706; }
+    .empty-state {
+      text-align: center;
+      padding: 2rem;
+      color: #94a3b8;
+      font-size: 0.9rem;
     }
-    .btn-send-all:hover { background: #6d28d9; }
-    .btn-send-all:disabled { background: #a78bfa; cursor: not-allowed; }
   </style>
 </head>
 <body>
@@ -262,183 +380,148 @@ function urgenceColor(urgence: string) {
     <div class="stat-value">{avgScore}/100</div>
     <div class="stat-label">Score moyen</div>
   </div>
+  <div class="stat-card stat-tickets">
+    <div class="stat-value">{pendingTickets}/{totalTickets}</div>
+    <div class="stat-label">Tickets en attente</div>
+  </div>
 </div>
 
 <div class="main">
 
   {error && (
     <div style="background: #fef2f2; border: 1px solid #fecaca; padding: 1rem; border-radius: 8px; margin-bottom: 1rem; color: #991b1b;">
-      Erreur de connexion Supabase : {error.message}. Assurez-vous que la migration 003 a ete executee et que des resultats existent.
+      Erreur Supabase : {error.message}
     </div>
   )}
 
   {totalChecked === 0 && !error && (
     <div class="empty-state">
       <p style="font-size: 1.2rem; margin-bottom: 0.5rem;">Aucun resultat de fact-check</p>
-      <p>Lancez le workflow GitHub Actions ou executez le script manuellement pour commencer.</p>
-      <p style="margin-top: 0.5rem;"><code>node scripts/fact-check-runner.mjs --limit 5</code></p>
+      <p><code>node scripts/fact-check-runner.mjs --limit 5</code></p>
     </div>
   )}
 
-  <!-- Section Urgents -->
-  {urgent.length > 0 && (
+  {/* Render each status group */}
+  {[
+    { items: urgent, label: 'Urgents', color: '#dc2626', badgeBg: '#fecaca', badgeColor: '#991b1b', scoreBg: '#fecaca', scoreColor: '#991b1b' },
+    { items: aVerifier, label: 'A verifier', color: '#f59e0b', badgeBg: '#fde68a', badgeColor: '#92400e', scoreBg: '#fde68a', scoreColor: '#92400e' },
+    { items: ok, label: 'OK', color: '#22c55e', badgeBg: '#bbf7d0', badgeColor: '#166534', scoreBg: '#bbf7d0', scoreColor: '#166534' },
+  ].map(group => group.items.length > 0 && (
     <div class="section">
       <div class="section-title">
-        <span style="color: #dc2626;">Urgents</span>
-        <span class="badge badge-urgent">{urgent.length}</span>
+        <span style={`color: ${group.color};`}>{group.label}</span>
+        <span class="badge" style={`background: ${group.badgeBg}; color: ${group.badgeColor};`}>{group.items.length}</span>
       </div>
-      {urgent.map((r: any) => (
-        <div class="card" data-card>
-          <div class="card-header" data-toggle>
-            <div>
-              <span class="card-title">{r.articles?.title || 'Article inconnu'}</span>
-              <span class="collection-tag" style="margin-left: 0.5rem;">{r.articles?.collection}</span>
-            </div>
-            <div class="card-meta">
-              <span class="score-pill" style="background: #fecaca; color: #991b1b;">{r.score_fiabilite}/100</span>
-              <span>{formatDate(r.checked_at)}</span>
-            </div>
-          </div>
-          <div class="card-body">
-            {(r.points || []).map((p: any, idx: number) => (
-              <div class="point" style={`border-color: ${urgenceColor(p.urgence)}`}>
-                <div class="point-claim">{p.claim_original}</div>
-                <div class="point-reality">{p.realite_actuelle}</div>
-                {p.source && (
-                  <div class="point-source">
-                    <a href={p.source} target="_blank" rel="noopener">{p.source}</a>
-                  </div>
+      {group.items.map((r: any) => {
+        const articleTickets = ticketsByResult.get(r.id) || [];
+        return (
+          <div class="article-card" data-card>
+            <div class="article-header" data-toggle>
+              <div>
+                <span class="article-title">{r.articles?.title || 'Article inconnu'}</span>
+                <span class="collection-tag" style="margin-left: 0.5rem;">{r.articles?.collection}</span>
+                {articleTickets.length > 0 && (
+                  <span class="badge" style="margin-left: 0.5rem; background: #f5f3ff; color: #7c3aed;">
+                    {articleTickets.length} ticket(s)
+                  </span>
                 )}
-                <button
-                  class="btn-editorial"
-                  data-send-editorial
-                  data-fact-check-id={r.id}
-                  data-article-id={r.articles?.id}
-                  data-claim={p.claim_original}
-                  data-realite={p.realite_actuelle}
-                  data-source={p.source || ''}
-                  data-urgence={p.urgence || 'moyen'}
-                >
-                  Envoyer a l'Editorial
-                </button>
               </div>
-            ))}
-            <div class="card-actions">
-              <button
-                class="btn-send-all"
-                data-send-all-editorial
-                data-fact-check-id={r.id}
-                data-article-id={r.articles?.id}
-                data-points={JSON.stringify(r.points || [])}
-              >
-                Envoyer tous les points
-              </button>
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  )}
-
-  <!-- Section A verifier -->
-  {aVerifier.length > 0 && (
-    <div class="section">
-      <div class="section-title">
-        <span style="color: #f59e0b;">A verifier</span>
-        <span class="badge badge-warning">{aVerifier.length}</span>
-      </div>
-      {aVerifier.map((r: any) => (
-        <div class="card" data-card>
-          <div class="card-header" data-toggle>
-            <div>
-              <span class="card-title">{r.articles?.title || 'Article inconnu'}</span>
-              <span class="collection-tag" style="margin-left: 0.5rem;">{r.articles?.collection}</span>
-            </div>
-            <div class="card-meta">
-              <span class="score-pill" style="background: #fde68a; color: #92400e;">{r.score_fiabilite}/100</span>
-              <span>{formatDate(r.checked_at)}</span>
-            </div>
-          </div>
-          <div class="card-body">
-            {(r.points || []).map((p: any) => (
-              <div class="point" style={`border-color: ${urgenceColor(p.urgence)}`}>
-                <div class="point-claim">{p.claim_original}</div>
-                <div class="point-reality">{p.realite_actuelle}</div>
-                {p.source && (
-                  <div class="point-source">
-                    <a href={p.source} target="_blank" rel="noopener">{p.source}</a>
-                  </div>
-                )}
-                <button
-                  class="btn-editorial"
-                  data-send-editorial
-                  data-fact-check-id={r.id}
-                  data-article-id={r.articles?.id}
-                  data-claim={p.claim_original}
-                  data-realite={p.realite_actuelle}
-                  data-source={p.source || ''}
-                  data-urgence={p.urgence || 'moyen'}
-                >
-                  Envoyer a l'Editorial
-                </button>
+              <div class="article-meta">
+                <span class="score-pill" style={`background: ${group.scoreBg}; color: ${group.scoreColor};`}>{r.score_fiabilite}/100</span>
+                <span>{formatDate(r.checked_at)}</span>
               </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  )}
-
-  <!-- Section OK -->
-  {ok.length > 0 && (
-    <div class="section">
-      <div class="section-title">
-        <span style="color: #22c55e;">OK</span>
-        <span class="badge badge-ok">{ok.length}</span>
-      </div>
-      {ok.map((r: any) => (
-        <div class="card" data-card>
-          <div class="card-header" data-toggle>
-            <div>
-              <span class="card-title">{r.articles?.title || 'Article inconnu'}</span>
-              <span class="collection-tag" style="margin-left: 0.5rem;">{r.articles?.collection}</span>
             </div>
-            <div class="card-meta">
-              <span class="score-pill" style="background: #bbf7d0; color: #166534;">{r.score_fiabilite}/100</span>
-              <span>{formatDate(r.checked_at)}</span>
-            </div>
-          </div>
-          <div class="card-body">
-            {(r.points || []).length === 0 ? (
-              <p style="padding: 0.75rem; color: #22c55e;">Aucun probleme detecte.</p>
-            ) : (
-              (r.points || []).map((p: any) => (
-                <div class="point" style={`border-color: ${urgenceColor(p.urgence)}`}>
-                  <div class="point-claim">{p.claim_original}</div>
-                  <div class="point-reality">{p.realite_actuelle}</div>
-                  {p.source && (
-                    <div class="point-source">
-                      <a href={p.source} target="_blank" rel="noopener">{p.source}</a>
+            <div class="article-body">
+              {articleTickets.length === 0 ? (
+                <p style="padding: 0.5rem; color: #94a3b8;">Aucun ticket pour cet article.</p>
+              ) : (
+                articleTickets.map((t: any) => (
+                  <div class="ticket" data-ticket-id={t.id}>
+                    <div class="ticket-header">
+                      <div class="ticket-type">
+                        <span>{urgenceIcon(t.urgence)}</span>
+                        <span style={`text-transform: uppercase;`}>{t.urgence}</span>
+                        <span style="color: #64748b; font-weight: 400;">·</span>
+                        <span>{typeLabel(t.ticket_type)}</span>
+                      </div>
+                      <span class="ticket-statut" style={`background: ${
+                        t.statut === 'pending_review' ? '#dbeafe' :
+                        t.statut === 'approved' ? '#d1fae5' :
+                        t.statut === 'rejected' ? '#fee2e2' :
+                        t.statut === 'ready_to_deploy' ? '#d1fae5' :
+                        t.statut === 'deployed' ? '#bbf7d0' :
+                        t.statut === 'revision_needed' ? '#fef3c7' : '#e2e8f0'
+                      }; color: ${
+                        t.statut === 'pending_review' ? '#1e40af' :
+                        t.statut === 'approved' ? '#065f46' :
+                        t.statut === 'rejected' ? '#991b1b' :
+                        t.statut === 'ready_to_deploy' ? '#065f46' :
+                        t.statut === 'deployed' ? '#166534' :
+                        t.statut === 'revision_needed' ? '#92400e' : '#475569'
+                      };`}>{statutLabel(t.statut)}</span>
                     </div>
-                  )}
-                </div>
-              ))
-            )}
+                    <div class="ticket-body">
+                      <div class="diff-before">
+                        <div class="diff-label">AVANT</div>
+                        <div class="diff-content">{t.before_exact}</div>
+                      </div>
+                      <div class="diff-after">
+                        <div class="diff-label">APRES</div>
+                        <div class="diff-content">{t.after_suggested}</div>
+                      </div>
+                      <div class="ticket-realite">{t.realite_actuelle}</div>
+                      {t.source_reference && (
+                        <div class="ticket-source">
+                          Source : <a href={t.source_reference} target="_blank" rel="noopener">{t.source_reference}</a>
+                        </div>
+                      )}
+                      {t.human_note && (
+                        <div style="font-size: 0.85rem; color: #92400e; background: #fffbeb; padding: 0.5rem 0.75rem; border-radius: 6px; margin-bottom: 0.75rem; border: 1px solid #fde68a;">
+                          <strong>Note :</strong> {t.human_note}
+                        </div>
+                      )}
+                      {t.statut === 'pending_review' && (
+                        <div class="ticket-actions">
+                          <button class="btn btn-approve" data-action="approve" data-ticket-id={t.id}>Approuver</button>
+                          <button class="btn btn-reject" data-action="reject" data-ticket-id={t.id}>Rejeter</button>
+                          <button class="btn btn-note" data-action="note" data-ticket-id={t.id}>+ Note</button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
-  )}
+  ))}
 
 </div>
 
-<!-- Toast notifications -->
+<!-- Modal note de rejet -->
+<div class="modal-overlay" id="noteModal">
+  <div class="modal">
+    <h3>Rejeter avec note</h3>
+    <p style="font-size: 0.85rem; color: #64748b; margin-bottom: 0.75rem;">
+      Cette note sera transmise a l'Agent Editorial pour revision.
+    </p>
+    <textarea id="noteText" placeholder="Instructions pour la revision..."></textarea>
+    <div class="modal-actions">
+      <button class="btn btn-cancel" id="noteCancel">Annuler</button>
+      <button class="btn btn-send-note" id="noteSend">Envoyer</button>
+    </div>
+  </div>
+</div>
+
+<!-- Toast -->
 <div id="toast" class="toast"></div>
 
 <script define:vars={{ supabaseUrl: supabaseConfig.url, supabaseAnonKey: supabaseConfig.anonKey }}>
-  // --- Supabase client-side (inline, no import needed for static build) ---
   const SUPABASE_URL = supabaseUrl;
   const SUPABASE_ANON_KEY = supabaseAnonKey;
+  let pendingNoteTicketId = null;
 
   function showToast(message, type = 'success') {
     const toast = document.getElementById('toast');
@@ -447,33 +530,24 @@ function urgenceColor(urgence: string) {
     setTimeout(() => { toast.classList.remove('show'); }, 3000);
   }
 
-  async function insertEditorialRequest(data) {
-    const response = await fetch(`${SUPABASE_URL}/rest/v1/editorial_queue`, {
-      method: 'POST',
+  async function updateTicket(ticketId, updates) {
+    const response = await fetch(`${SUPABASE_URL}/rest/v1/correction_tickets?id=eq.${ticketId}`, {
+      method: 'PATCH',
       headers: {
         'apikey': SUPABASE_ANON_KEY,
         'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
         'Content-Type': 'application/json',
         'Prefer': 'return=minimal'
       },
-      body: JSON.stringify({
-        fact_check_id: data.factCheckId,
-        article_id: data.articleId,
-        claim_original: data.claim,
-        realite_actuelle: data.realite,
-        source_reference: data.source || null,
-        urgence: data.urgence || 'moyen',
-        statut: 'requested'
-      })
+      body: JSON.stringify(updates)
     });
 
     if (!response.ok) {
-      const err = await response.text();
-      throw new Error(err);
+      throw new Error(await response.text());
     }
   }
 
-  // Toggle cards
+  // Toggle article cards
   document.querySelectorAll('[data-toggle]').forEach(header => {
     header.addEventListener('click', () => {
       const card = header.closest('[data-card]');
@@ -481,79 +555,101 @@ function urgenceColor(urgence: string) {
     });
   });
 
-  // Single point → editorial
-  document.querySelectorAll('[data-send-editorial]').forEach(btn => {
+  // Approve / Reject actions
+  document.querySelectorAll('[data-action]').forEach(btn => {
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();
       const button = e.currentTarget;
+      const action = button.dataset.action;
+      const ticketId = button.dataset.ticketId;
+
+      if (action === 'note') {
+        // Open modal
+        pendingNoteTicketId = ticketId;
+        document.getElementById('noteModal').classList.add('active');
+        document.getElementById('noteText').value = '';
+        document.getElementById('noteText').focus();
+        return;
+      }
+
       button.disabled = true;
-      button.textContent = 'Envoi...';
+      const originalText = button.textContent;
+      button.textContent = '...';
 
       try {
-        await insertEditorialRequest({
-          factCheckId: button.dataset.factCheckId,
-          articleId: button.dataset.articleId,
-          claim: button.dataset.claim,
-          realite: button.dataset.realite,
-          source: button.dataset.source,
-          urgence: button.dataset.urgence
-        });
+        if (action === 'approve') {
+          await updateTicket(ticketId, {
+            statut: 'approved',
+            reviewed_at: new Date().toISOString()
+          });
+          showToast('Ticket approuve — pret pour l\'editorial');
+        } else if (action === 'reject') {
+          await updateTicket(ticketId, {
+            statut: 'rejected',
+            reviewed_at: new Date().toISOString()
+          });
+          showToast('Ticket rejete');
+        }
 
-        button.textContent = 'Envoye';
-        button.classList.add('sent');
-        showToast('Point envoye a l\'editorial');
+        // Fade out ticket
+        const ticket = button.closest('[data-ticket-id]');
+        if (ticket) {
+          ticket.style.opacity = '0.4';
+          ticket.style.pointerEvents = 'none';
+        }
+
+        setTimeout(() => { window.location.reload(); }, 1500);
       } catch (err) {
         button.disabled = false;
-        button.textContent = 'Envoyer a l\'Editorial';
+        button.textContent = originalText;
         showToast('Erreur: ' + err.message, 'error');
       }
     });
   });
 
-  // All points → editorial
-  document.querySelectorAll('[data-send-all-editorial]').forEach(btn => {
-    btn.addEventListener('click', async (e) => {
-      e.stopPropagation();
-      const button = e.currentTarget;
-      button.disabled = true;
-      button.textContent = 'Envoi...';
+  // Modal: cancel
+  document.getElementById('noteCancel').addEventListener('click', () => {
+    document.getElementById('noteModal').classList.remove('active');
+    pendingNoteTicketId = null;
+  });
 
-      try {
-        const points = JSON.parse(button.dataset.points);
-        const factCheckId = button.dataset.factCheckId;
-        const articleId = button.dataset.articleId;
+  // Modal: send note
+  document.getElementById('noteSend').addEventListener('click', async () => {
+    const note = document.getElementById('noteText').value.trim();
+    if (!note) {
+      showToast('Veuillez saisir une note', 'error');
+      return;
+    }
 
-        for (const p of points) {
-          await insertEditorialRequest({
-            factCheckId,
-            articleId,
-            claim: p.claim_original,
-            realite: p.realite_actuelle,
-            source: p.source || '',
-            urgence: p.urgence || 'moyen'
-          });
-        }
+    const sendBtn = document.getElementById('noteSend');
+    sendBtn.disabled = true;
+    sendBtn.textContent = '...';
 
-        button.textContent = `${points.length} point(s) envoye(s)`;
-        button.classList.add('sent');
+    try {
+      await updateTicket(pendingNoteTicketId, {
+        statut: 'revision_needed',
+        human_note: note,
+        reviewed_at: new Date().toISOString()
+      });
 
-        // Disable individual buttons for this card
-        const card = button.closest('[data-card]');
-        if (card) {
-          card.querySelectorAll('[data-send-editorial]').forEach(b => {
-            b.disabled = true;
-            b.textContent = 'Envoye';
-            b.classList.add('sent');
-          });
-        }
+      document.getElementById('noteModal').classList.remove('active');
+      showToast('Ticket renvoye en revision avec note');
 
-        showToast(`${points.length} point(s) envoye(s) a l'editorial`);
-      } catch (err) {
-        button.disabled = false;
-        button.textContent = 'Envoyer tous les points';
-        showToast('Erreur: ' + err.message, 'error');
+      // Fade out ticket
+      const ticket = document.querySelector(`[data-ticket-id="${pendingNoteTicketId}"]`);
+      if (ticket) {
+        ticket.style.opacity = '0.4';
+        ticket.style.pointerEvents = 'none';
       }
-    });
+
+      setTimeout(() => { window.location.reload(); }, 1500);
+    } catch (err) {
+      sendBtn.disabled = false;
+      sendBtn.textContent = 'Envoyer';
+      showToast('Erreur: ' + err.message, 'error');
+    }
+
+    pendingNoteTicketId = null;
   });
 </script>
 

--- a/supabase/migrations/005_tickets_system.sql
+++ b/supabase/migrations/005_tickets_system.sql
@@ -1,0 +1,105 @@
+-- Migration : Systeme de Tickets Before/After (Phase 3)
+-- Date: 2026-03-07
+-- Description: Remplace editorial_queue par un systeme de tickets granulaires
+--   1 probleme detecte = 1 ticket independant avec diff Before/After
+
+-- =============================================================================
+-- Table `correction_tickets` : Tickets de correction individuels
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS correction_tickets (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+
+  -- Reference article
+  article_id UUID NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL,
+  title TEXT NOT NULL,
+
+  -- Reference fact-check
+  fact_check_result_id UUID NOT NULL REFERENCES fact_check_results(id) ON DELETE CASCADE,
+
+  -- Classification
+  ticket_type VARCHAR(30) NOT NULL DEFAULT 'info_outdated'
+    CHECK (ticket_type IN ('price_update', 'info_outdated', 'false_claim', 'missing_info')),
+  urgence VARCHAR(20) NOT NULL DEFAULT 'warning'
+    CHECK (urgence IN ('urgent', 'warning', 'ok')),
+
+  -- Diff Before/After
+  before_exact TEXT NOT NULL,          -- Citation mot pour mot du markdown source
+  after_suggested TEXT NOT NULL,       -- Correction proposee par le fact-checker
+  after_final TEXT,                    -- Version finale redigee par l'Agent Editorial
+
+  -- Contexte fact-check
+  claim_original TEXT NOT NULL,        -- Resume du claim pour affichage humain
+  realite_actuelle TEXT NOT NULL,      -- Explication detaillee + source
+  source_reference TEXT,               -- URL de la source
+
+  -- Feedback humain
+  human_note TEXT,                     -- Note de rejet optionnelle
+
+  -- Workflow
+  statut VARCHAR(30) NOT NULL DEFAULT 'pending_review'
+    CHECK (statut IN (
+      'pending_review',    -- En attente de review humaine
+      'approved',          -- Approuve, pret pour l'editorial
+      'rejected',          -- Rejete, archive
+      'in_progress',       -- Agent editorial en cours
+      'ready_to_deploy',   -- after_final pret, en attente deploy
+      'deployed',          -- Applique au markdown + PR creee
+      'revision_needed'    -- Rejete avec note, renvoye a l'editorial
+    )),
+
+  -- Metadata agent
+  model_used VARCHAR(100),
+  tokens_used INTEGER,
+
+  -- Timestamps
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  reviewed_at TIMESTAMP WITH TIME ZONE,
+  deployed_at TIMESTAMP WITH TIME ZONE
+);
+
+-- =============================================================================
+-- Index
+-- =============================================================================
+CREATE INDEX idx_tickets_statut ON correction_tickets(statut);
+CREATE INDEX idx_tickets_article_id ON correction_tickets(article_id);
+CREATE INDEX idx_tickets_fact_check_id ON correction_tickets(fact_check_result_id);
+CREATE INDEX idx_tickets_urgence ON correction_tickets(urgence);
+CREATE INDEX idx_tickets_type ON correction_tickets(ticket_type);
+CREATE INDEX idx_tickets_created_at ON correction_tickets(created_at DESC);
+
+-- =============================================================================
+-- Trigger updated_at
+-- =============================================================================
+CREATE OR REPLACE FUNCTION update_ticket_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_ticket_updated_at
+  BEFORE UPDATE ON correction_tickets
+  FOR EACH ROW
+  EXECUTE FUNCTION update_ticket_updated_at();
+
+-- =============================================================================
+-- Row Level Security
+-- =============================================================================
+ALTER TABLE correction_tickets ENABLE ROW LEVEL SECURITY;
+
+-- Lecture publique (dashboard admin)
+CREATE POLICY "tickets_read_all" ON correction_tickets FOR SELECT USING (true);
+
+-- Ecriture service_role (agents)
+CREATE POLICY "tickets_write_service" ON correction_tickets FOR ALL USING (auth.role() = 'service_role');
+
+-- Update anon (actions dashboard : approve/reject/note)
+CREATE POLICY "tickets_update_anon" ON correction_tickets
+  FOR UPDATE
+  USING (true)
+  WITH CHECK (
+    statut IN ('approved', 'rejected', 'revision_needed', 'pending_review')
+  );


### PR DESCRIPTION
## Summary
- Systeme de tickets Before/After granulaires (1 probleme = 1 ticket) remplacant editorial_queue
- Fact-checker reecrit pour le marche FR exclusivement : zero donnee hardcodee, web search systematique sur HAS/ANSM/AMELI/Vidal/CNAM
- Contexte EU/FR des marques GLP-1 (Zepbound=US, Mounjaro=EU) verifie par web search a chaque run
- Migration 005 : table correction_tickets avec before_exact/after_suggested/after_final, workflow complet
- Dashboards reconstruits avec diff visuel Before/After, approve/reject/note par ticket, bouton deploy

## Test plan
- [ ] Executer migration 005_tickets_system.sql sur Supabase
- [ ] Lancer `node scripts/fact-check-runner.mjs --limit 1` et verifier les tickets crees
- [ ] Verifier que before_exact est retrouvable mot pour mot dans le markdown source
- [ ] Tester approve/reject/note sur /admin/fact-check
- [ ] Lancer `node scripts/editorial-agent.mjs` et verifier after_final
- [ ] Tester le deploy depuis /admin/editorial
- [ ] Build Astro passe (verifie)

https://claude.ai/code/session_01W7ojMsQ5bGPu78izX9zNtn