### PR TITLE
fix: idempotent migration 005 + fix script

### DIFF
--- a/supabase/migrations/005_tickets_system.sql
+++ b/supabase/migrations/005_tickets_system.sql
@@ -60,17 +60,17 @@ CREATE TABLE IF NOT EXISTS correction_tickets (
 );
 
 -- =============================================================================
--- Index
+-- Index (idempotent)
 -- =============================================================================
-CREATE INDEX idx_tickets_statut ON correction_tickets(statut);
-CREATE INDEX idx_tickets_article_id ON correction_tickets(article_id);
-CREATE INDEX idx_tickets_fact_check_id ON correction_tickets(fact_check_result_id);
-CREATE INDEX idx_tickets_urgence ON correction_tickets(urgence);
-CREATE INDEX idx_tickets_type ON correction_tickets(ticket_type);
-CREATE INDEX idx_tickets_created_at ON correction_tickets(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tickets_statut ON correction_tickets(statut);
+CREATE INDEX IF NOT EXISTS idx_tickets_article_id ON correction_tickets(article_id);
+CREATE INDEX IF NOT EXISTS idx_tickets_fact_check_id ON correction_tickets(fact_check_result_id);
+CREATE INDEX IF NOT EXISTS idx_tickets_urgence ON correction_tickets(urgence);
+CREATE INDEX IF NOT EXISTS idx_tickets_type ON correction_tickets(ticket_type);
+CREATE INDEX IF NOT EXISTS idx_tickets_created_at ON correction_tickets(created_at DESC);
 
 -- =============================================================================
--- Trigger updated_at
+-- Trigger updated_at (idempotent)
 -- =============================================================================
 CREATE OR REPLACE FUNCTION update_ticket_updated_at()
 RETURNS TRIGGER AS $$
@@ -80,23 +80,24 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trigger_ticket_updated_at ON correction_tickets;
 CREATE TRIGGER trigger_ticket_updated_at
   BEFORE UPDATE ON correction_tickets
   FOR EACH ROW
   EXECUTE FUNCTION update_ticket_updated_at();
 
 -- =============================================================================
--- Row Level Security
+-- Row Level Security (idempotent)
 -- =============================================================================
 ALTER TABLE correction_tickets ENABLE ROW LEVEL SECURITY;
 
--- Lecture publique (dashboard admin)
+DROP POLICY IF EXISTS "tickets_read_all" ON correction_tickets;
 CREATE POLICY "tickets_read_all" ON correction_tickets FOR SELECT USING (true);
 
--- Ecriture service_role (agents)
+DROP POLICY IF EXISTS "tickets_write_service" ON correction_tickets;
 CREATE POLICY "tickets_write_service" ON correction_tickets FOR ALL USING (auth.role() = 'service_role');
 
--- Update anon (actions dashboard : approve/reject/note)
+DROP POLICY IF EXISTS "tickets_update_anon" ON correction_tickets;
 CREATE POLICY "tickets_update_anon" ON correction_tickets
   FOR UPDATE
   USING (true)

--- a/supabase/migrations/005_tickets_system_fix.sql
+++ b/supabase/migrations/005_tickets_system_fix.sql
@@ -1,0 +1,49 @@
+-- Migration 005 FIX : Indexes et policies pour correction_tickets
+-- A executer si la table existe deja mais les index ont echoue
+
+-- Drop indexes if they exist, then recreate
+DROP INDEX IF EXISTS idx_tickets_statut;
+DROP INDEX IF EXISTS idx_tickets_article_id;
+DROP INDEX IF EXISTS idx_tickets_fact_check_id;
+DROP INDEX IF EXISTS idx_tickets_urgence;
+DROP INDEX IF EXISTS idx_tickets_type;
+DROP INDEX IF EXISTS idx_tickets_created_at;
+
+CREATE INDEX idx_tickets_statut ON correction_tickets(statut);
+CREATE INDEX idx_tickets_article_id ON correction_tickets(article_id);
+CREATE INDEX idx_tickets_fact_check_id ON correction_tickets(fact_check_result_id);
+CREATE INDEX idx_tickets_urgence ON correction_tickets(urgence);
+CREATE INDEX idx_tickets_type ON correction_tickets(ticket_type);
+CREATE INDEX idx_tickets_created_at ON correction_tickets(created_at DESC);
+
+-- Trigger (idempotent)
+CREATE OR REPLACE FUNCTION update_ticket_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_ticket_updated_at ON correction_tickets;
+CREATE TRIGGER trigger_ticket_updated_at
+  BEFORE UPDATE ON correction_tickets
+  FOR EACH ROW
+  EXECUTE FUNCTION update_ticket_updated_at();
+
+-- RLS
+ALTER TABLE correction_tickets ENABLE ROW LEVEL SECURITY;
+
+-- Policies (drop first to avoid duplicates)
+DROP POLICY IF EXISTS "tickets_read_all" ON correction_tickets;
+DROP POLICY IF EXISTS "tickets_write_service" ON correction_tickets;
+DROP POLICY IF EXISTS "tickets_update_anon" ON correction_tickets;
+
+CREATE POLICY "tickets_read_all" ON correction_tickets FOR SELECT USING (true);
+CREATE POLICY "tickets_write_service" ON correction_tickets FOR ALL USING (auth.role() = 'service_role');
+CREATE POLICY "tickets_update_anon" ON correction_tickets
+  FOR UPDATE
+  USING (true)
+  WITH CHECK (
+    statut IN ('approved', 'rejected', 'revision_needed', 'pending_review')
+  );


### PR DESCRIPTION
## Summary
- Migration 005 failed mid-way (indexes already existed from partial run)
- Made all indexes, triggers, and policies idempotent (DROP IF EXISTS + CREATE)
- Added `005_tickets_system_fix.sql` for environments where the table exists but indexes/policies are incomplete

## Action
Run `005_tickets_system_fix.sql` in Supabase SQL Editor to complete the setup.

https://claude.ai/code/session_01W7ojMsQ5bGPu78izX9zNtn