### PR TITLE
fix: switch FTP to FTPS for Hostinger deploy

### DIFF
--- a/.github/workflows/deploy-hostinger.yml
+++ b/.github/workflows/deploy-hostinger.yml
@@ -32,7 +32,7 @@ jobs:
         local-dir: ./dist/
         server-dir: /domains/glp1-france.fr/public_html/
         port: 21
-        protocol: ftp
+        protocol: ftps
         exclude: |
           **/.git*
           **/.git*/**


### PR DESCRIPTION
## Summary
- FTP deploy times out from GitHub Actions (Hostinger blocks plain FTP or requires TLS)
- Switch protocol from `ftp` to `ftps` (FTP over TLS)

## If this doesn't work
- Try SFTP via a different action (eg. `appleboy/scp-action`)
- Check Hostinger panel: Security > SSH Access to confirm SFTP port (usually 65002)

https://claude.ai/code/session_01W7ojMsQ5bGPu78izX9zNtn