### PR TITLE
Add Ozempic prescription guide and fix content type definitions

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -1,0 +1,199 @@
+declare module 'astro:content' {
+	export interface RenderResult {
+		Content: import('astro/runtime/server/index.js').AstroComponentFactory;
+		headings: import('astro').MarkdownHeading[];
+		remarkPluginFrontmatter: Record<string, any>;
+	}
+	interface Render {
+		'.md': Promise<RenderResult>;
+	}
+
+	export interface RenderedContent {
+		html: string;
+		metadata?: {
+			imagePaths: Array<string>;
+			[key: string]: unknown;
+		};
+	}
+}
+
+declare module 'astro:content' {
+	type Flatten<T> = T extends { [K: string]: infer U } ? U : never;
+
+	export type CollectionKey = keyof AnyEntryMap;
+	export type CollectionEntry<C extends CollectionKey> = Flatten<AnyEntryMap[C]>;
+
+	export type ContentCollectionKey = keyof ContentEntryMap;
+	export type DataCollectionKey = keyof DataEntryMap;
+
+	type AllValuesOf<T> = T extends any ? T[keyof T] : never;
+	type ValidContentEntrySlug<C extends keyof ContentEntryMap> = AllValuesOf<
+		ContentEntryMap[C]
+	>['slug'];
+
+	export type ReferenceDataEntry<
+		C extends CollectionKey,
+		E extends keyof DataEntryMap[C] = string,
+	> = {
+		collection: C;
+		id: E;
+	};
+	export type ReferenceContentEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {}) = string,
+	> = {
+		collection: C;
+		slug: E;
+	};
+	export type ReferenceLiveEntry<C extends keyof LiveContentConfig['collections']> = {
+		collection: C;
+		id: string;
+	};
+
+	/** @deprecated Use `getEntry` instead. */
+	export function getEntryBySlug<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {}),
+	>(
+		collection: C,
+		// Note that this has to accept a regular string too, for SSR
+		entrySlug: E,
+	): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+
+	/** @deprecated Use `getEntry` instead. */
+	export function getDataEntryById<C extends keyof DataEntryMap, E extends keyof DataEntryMap[C]>(
+		collection: C,
+		entryId: E,
+	): Promise<CollectionEntry<C>>;
+
+	export function getCollection<C extends keyof AnyEntryMap, E extends CollectionEntry<C>>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => entry is E,
+	): Promise<E[]>;
+	export function getCollection<C extends keyof AnyEntryMap>(
+		collection: C,
+		filter?: (entry: CollectionEntry<C>) => unknown,
+	): Promise<CollectionEntry<C>[]>;
+
+	export function getLiveCollection<C extends keyof LiveContentConfig['collections']>(
+		collection: C,
+		filter?: LiveLoaderCollectionFilterType<C>,
+	): Promise<
+		import('astro').LiveDataCollectionResult<LiveLoaderDataType<C>, LiveLoaderErrorType<C>>
+	>;
+
+	export function getEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {}),
+	>(
+		entry: ReferenceContentEntry<C, E>,
+	): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {}),
+	>(
+		entry: ReferenceDataEntry<C, E>,
+	): E extends keyof DataEntryMap[C]
+		? Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof ContentEntryMap,
+		E extends ValidContentEntrySlug<C> | (string & {}),
+	>(
+		collection: C,
+		slug: E,
+	): E extends ValidContentEntrySlug<C>
+		? Promise<CollectionEntry<C>>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getEntry<
+		C extends keyof DataEntryMap,
+		E extends keyof DataEntryMap[C] | (string & {}),
+	>(
+		collection: C,
+		id: E,
+	): E extends keyof DataEntryMap[C]
+		? string extends keyof DataEntryMap[C]
+			? Promise<DataEntryMap[C][E]> | undefined
+			: Promise<DataEntryMap[C][E]>
+		: Promise<CollectionEntry<C> | undefined>;
+	export function getLiveEntry<C extends keyof LiveContentConfig['collections']>(
+		collection: C,
+		filter: string | LiveLoaderEntryFilterType<C>,
+	): Promise<import('astro').LiveDataEntryResult<LiveLoaderDataType<C>, LiveLoaderErrorType<C>>>;
+
+	/** Resolve an array of entry references from the same collection */
+	export function getEntries<C extends keyof ContentEntryMap>(
+		entries: ReferenceContentEntry<C, ValidContentEntrySlug<C>>[],
+	): Promise<CollectionEntry<C>[]>;
+	export function getEntries<C extends keyof DataEntryMap>(
+		entries: ReferenceDataEntry<C, keyof DataEntryMap[C]>[],
+	): Promise<CollectionEntry<C>[]>;
+
+	export function render<C extends keyof AnyEntryMap>(
+		entry: AnyEntryMap[C][string],
+	): Promise<RenderResult>;
+
+	export function reference<C extends keyof AnyEntryMap>(
+		collection: C,
+	): import('astro/zod').ZodEffects<
+		import('astro/zod').ZodString,
+		C extends keyof ContentEntryMap
+			? ReferenceContentEntry<C, ValidContentEntrySlug<C>>
+			: ReferenceDataEntry<C, keyof DataEntryMap[C]>
+	>;
+	// Allow generic `string` to avoid excessive type errors in the config
+	// if `dev` is not running to update as you edit.
+	// Invalid collection names will be caught at build time.
+	export function reference<C extends string>(
+		collection: C,
+	): import('astro/zod').ZodEffects<import('astro/zod').ZodString, never>;
+
+	type ReturnTypeOrOriginal<T> = T extends (...args: any[]) => infer R ? R : T;
+	type InferEntrySchema<C extends keyof AnyEntryMap> = import('astro/zod').infer<
+		ReturnTypeOrOriginal<Required<ContentConfig['collections'][C]>['schema']>
+	>;
+
+	type ContentEntryMap = {
+		
+	};
+
+	type DataEntryMap = {
+		
+	};
+
+	type AnyEntryMap = ContentEntryMap & DataEntryMap;
+
+	type ExtractLoaderTypes<T> = T extends import('astro/loaders').LiveLoader<
+		infer TData,
+		infer TEntryFilter,
+		infer TCollectionFilter,
+		infer TError
+	>
+		? { data: TData; entryFilter: TEntryFilter; collectionFilter: TCollectionFilter; error: TError }
+		: { data: never; entryFilter: never; collectionFilter: never; error: never };
+	type ExtractDataType<T> = ExtractLoaderTypes<T>['data'];
+	type ExtractEntryFilterType<T> = ExtractLoaderTypes<T>['entryFilter'];
+	type ExtractCollectionFilterType<T> = ExtractLoaderTypes<T>['collectionFilter'];
+	type ExtractErrorType<T> = ExtractLoaderTypes<T>['error'];
+
+	type LiveLoaderDataType<C extends keyof LiveContentConfig['collections']> =
+		LiveContentConfig['collections'][C]['schema'] extends undefined
+			? ExtractDataType<LiveContentConfig['collections'][C]['loader']>
+			: import('astro/zod').infer<
+					Exclude<LiveContentConfig['collections'][C]['schema'], undefined>
+				>;
+	type LiveLoaderEntryFilterType<C extends keyof LiveContentConfig['collections']> =
+		ExtractEntryFilterType<LiveContentConfig['collections'][C]['loader']>;
+	type LiveLoaderCollectionFilterType<C extends keyof LiveContentConfig['collections']> =
+		ExtractCollectionFilterType<LiveContentConfig['collections'][C]['loader']>;
+	type LiveLoaderErrorType<C extends keyof LiveContentConfig['collections']> = ExtractErrorType<
+		LiveContentConfig['collections'][C]['loader']
+	>;
+
+	export type ContentConfig = never;
+	export type LiveContentConfig = never;
+}

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,2 @@
 /// <reference types="astro/client" />
-/// <reference path="astro/content.d.ts" />
+/// <reference path="content.d.ts" />

--- a/src/content/traitements-glp1/ozempic-sans-ordonnance.md
+++ b/src/content/traitements-glp1/ozempic-sans-ordonnance.md
@@ -1,0 +1,147 @@
+---
+title: "Ozempic Sans Ordonnance en France : Pourquoi C'est Interdit et Comment Obtenir une Prescription"
+description: "Peut-on acheter Ozempic sans ordonnance en France ? Risques, réglementation 2026, alternatives légales et démarches pour obtenir une prescription médicale."
+author: "Dr. Marie Dubois"
+image: "/images/thumbnails/ozempic-sans-ordonnance.jpg"
+collection: "traitements-glp1"
+category: "traitements-glp1"
+tags: ["ozempic", "ordonnance", "prescription", "glp-1", "réglementation", "pharmacie"]
+pubDate: 2026-03-08
+featured: true
+mainKeyword: "ozempic sans ordonnance"
+secondaryKeywords: ["acheter ozempic sans ordonnance", "ozempic prescription", "ozempic pharmacie france", "ozempic ordonnance obligatoire", "ozempic en ligne"]
+---
+
+# Ozempic Sans Ordonnance en France : Ce Que Vous Devez Savoir en 2026
+
+Vous avez entendu parler des résultats impressionnants d'Ozempic pour la perte de poids et vous cherchez à vous en procurer sans ordonnance ? Vous n'êtes pas seul : « ozempic sans ordonnance » est l'une des recherches les plus fréquentes en France sur le sujet des traitements GLP-1. Pourtant, la réponse est claire et sans appel : **il est strictement interdit et dangereux d'acheter Ozempic sans ordonnance en France**. Ce guide vous explique pourquoi, quels sont les risques, et surtout comment obtenir légalement une prescription.
+
+## Pourquoi Ozempic Nécessite une Ordonnance Obligatoire
+
+Ozempic (sémaglutide) est un médicament classé sur **liste I** par l'Agence nationale de sécurité du médicament (ANSM). Cette classification signifie qu'il ne peut être délivré que sur présentation d'une ordonnance médicale valide.
+
+### Les raisons de cette obligation
+
+- **Risques d'effets secondaires** : Ozempic peut provoquer des nausées, vomissements, pancréatite, et dans de rares cas des problèmes thyroïdiens. Un suivi médical est indispensable.
+- **Contre-indications médicales** : Certaines pathologies (antécédents de cancer médullaire de la thyroïde, néoplasie endocrinienne multiple de type 2) sont des contre-indications absolues que seul un médecin peut évaluer.
+- **Indication spécifique** : Ozempic est autorisé uniquement pour le **diabète de type 2** en France. Son utilisation pour la perte de poids seule relève du mésusage.
+- **Dosage personnalisé** : La posologie doit être adaptée progressivement par un professionnel de santé (0,25 mg, 0,5 mg, puis 1 mg).
+
+## Les Nouvelles Règles de Prescription Depuis 2025
+
+Le cadre réglementaire s'est considérablement renforcé en France pour lutter contre le détournement des GLP-1.
+
+### Le formulaire obligatoire (février 2025)
+
+Depuis le 1er février 2025, un **formulaire de justification** doit accompagner chaque prescription d'Ozempic. Ce document, établi par le médecin prescripteur, doit être présenté au pharmacien lors de chaque délivrance. Sans ce justificatif, le médicament ne peut être ni délivré ni remboursé.
+
+### Contrôle renforcé de l'Assurance Maladie
+
+L'Assurance Maladie vérifie désormais systématiquement que les prescriptions d'Ozempic correspondent à une indication de **diabète de type 2 confirmé**. Les prescriptions hors AMM (autorisation de mise sur le marché) ne sont plus remboursées.
+
+### Actions contre les ventes illégales
+
+En 2025, l'ANSM et les autorités sanitaires européennes (EMA) ont mené plusieurs actions de police sanitaire contre des sites vendant des GLP-1 contrefaits en ligne. Sept sites ont été fermés lors d'une opération en novembre 2025.
+
+## Les Dangers de l'Achat d'Ozempic Sans Ordonnance
+
+Acheter Ozempic sur internet ou par des circuits non autorisés présente des **risques majeurs pour votre santé**.
+
+### Contrefaçons et produits dangereux
+
+Les médicaments vendus sans ordonnance en ligne sont souvent des **contrefaçons**. Ces produits peuvent :
+
+- Ne contenir aucun principe actif (vous payez pour un placebo)
+- Contenir des substances toxiques non identifiées
+- Être mal dosés, provoquant des hypoglycémies sévères
+- Avoir été stockés dans de mauvaises conditions (Ozempic nécessite une réfrigération entre 2°C et 8°C)
+
+### Absence de suivi médical
+
+Sans suivi médical, vous risquez :
+
+- De ne pas détecter une **pancréatite** (inflammation du pancréas), effet secondaire rare mais grave
+- De développer des **calculs biliaires** sans le savoir
+- D'aggraver une pathologie thyroïdienne non diagnostiquée
+- De subir une **hypoglycémie sévère** si vous prenez d'autres médicaments incompatibles
+
+### Sanctions légales
+
+L'achat de médicaments sur ordonnance sans prescription est une infraction en France. Les pharmacies en ligne non autorisées par l'ARS (Agence Régionale de Santé) opèrent dans l'illégalité.
+
+## Comment Obtenir Légalement une Prescription d'Ozempic
+
+Si vous pensez qu'Ozempic pourrait vous aider, voici les démarches à suivre dans le cadre légal.
+
+### Étape 1 : Consulter votre médecin traitant
+
+Prenez rendez-vous avec votre médecin généraliste. Depuis l'actualisation des règles par l'ANSM, **tout médecin peut désormais prescrire des analogues du GLP-1**, y compris en initiation de traitement. Vous n'avez plus besoin de consulter un spécialiste en première intention.
+
+### Étape 2 : Réaliser les examens nécessaires
+
+Votre médecin prescrira des analyses pour confirmer un diagnostic de diabète de type 2 :
+
+- **HbA1c** (hémoglobine glyquée) : supérieure à 6,5 % pour confirmer le diabète
+- **Glycémie à jeun** : supérieure à 1,26 g/L à deux reprises
+- **Bilan rénal et hépatique** : pour vérifier l'absence de contre-indications
+
+### Étape 3 : Évaluer les traitements de première intention
+
+Ozempic est prescrit en **deuxième intention**, après échec ou insuffisance de la metformine. Votre médecin vérifiera que les traitements oraux classiques ont été essayés.
+
+### Étape 4 : Obtenir le formulaire de justification
+
+Une fois la prescription établie, votre médecin remplira le **formulaire de justification** obligatoire depuis février 2025, à présenter en pharmacie.
+
+## Ozempic Pour la Perte de Poids : Quelles Alternatives Légales ?
+
+Si vous n'êtes pas diabétique mais souhaitez un traitement GLP-1 pour perdre du poids, des alternatives existent.
+
+### Wegovy (sémaglutide haute dose)
+
+[Wegovy](/collections/traitements-glp1/guide-complet-wegovy) contient la même molécule qu'Ozempic (sémaglutide) mais à des doses plus élevées (jusqu'à 2,4 mg contre 1 mg). Il est **autorisé pour la perte de poids** chez les adultes avec un IMC ≥ 30 kg/m² (ou ≥ 27 avec comorbidités). Attention : Wegovy n'est pas remboursé par la Sécurité Sociale.
+
+### Mounjaro (tirzépatide)
+
+[Mounjaro](/collections/traitements-glp1/guide-complet-mounjaro) est un double agoniste GIP/GLP-1 qui a montré des résultats supérieurs au sémaglutide pour la perte de poids (jusqu'à 20-25 % du poids initial). Il est disponible en France depuis novembre 2024 mais n'est pas encore remboursé.
+
+### Saxenda (liraglutide)
+
+[Saxenda](/collections/traitements-glp1/guide-complet-saxenda) est un autre analogue du GLP-1 indiqué pour l'obésité. Il nécessite une injection quotidienne (contre hebdomadaire pour Ozempic) et est également non remboursé.
+
+## Prix d'Ozempic en Pharmacie en France
+
+Le prix officiel d'Ozempic en France est réglementé :
+
+| Dosage | Prix par stylo | Remboursement |
+|--------|---------------|---------------|
+| 0,25 mg / 0,5 mg | 59,90 € | 65 % (diabète T2) |
+| 1 mg | 59,90 € | 65 % (diabète T2) |
+
+Avec le remboursement à 65 % par la Sécurité Sociale et la prise en charge complémentaire par votre mutuelle, votre reste à charge peut être de **21 à 42 € par mois** pour un patient diabétique de type 2. Consultez notre [guide complet des prix Ozempic](/collections/glp1-cout/prix-ozempic-france) pour plus de détails.
+
+## Questions Fréquentes sur Ozempic Sans Ordonnance
+
+### Peut-on acheter Ozempic en pharmacie sans ordonnance ?
+
+Non. Ozempic est un médicament de liste I soumis à prescription médicale obligatoire. Aucune pharmacie en France ne peut le délivrer sans ordonnance valide accompagnée du formulaire de justification depuis février 2025.
+
+### Existe-t-il un générique d'Ozempic disponible sans ordonnance ?
+
+Non. Il n'existe pas de générique d'Ozempic (sémaglutide) disponible en France en 2026. Le brevet de Novo Nordisk est toujours actif. Méfiez-vous des sites proposant des « génériques » : il s'agit de contrefaçons.
+
+### Peut-on obtenir Ozempic via une consultation en ligne ?
+
+Oui, une téléconsultation avec un médecin peut aboutir à une prescription d'Ozempic si les conditions médicales sont remplies (diagnostic de diabète de type 2 confirmé). Le médecin doit néanmoins établir le formulaire de justification obligatoire.
+
+### Les sites internet vendant Ozempic sans ordonnance sont-ils fiables ?
+
+Non. Ces sites opèrent dans l'illégalité. Les produits vendus sont potentiellement contrefaits et dangereux. L'ANSM et l'EMA ont alerté à plusieurs reprises sur les faux GLP-1 vendus en ligne. Seules les pharmacies en ligne autorisées par l'ARS peuvent vendre des médicaments, et uniquement sans ordonnance pour les médicaments qui le permettent.
+
+### Quels sont les risques si j'utilise Ozempic sans suivi médical ?
+
+Les risques incluent : pancréatite aiguë, calculs biliaires, hypoglycémie sévère (surtout en combinaison avec d'autres médicaments), réactions allergiques graves, et aggravation de pathologies non diagnostiquées. Un suivi médical régulier est indispensable pour ajuster le dosage et surveiller les effets secondaires.
+
+---
+
+**Important** : Cet article est fourni à titre informatif uniquement. Il ne remplace en aucun cas l'avis d'un professionnel de santé. Consultez votre médecin avant de débuter tout traitement. Sources : [ANSM](https://ansm.sante.fr/actualites/ozempic-semaglutide-un-medicament-a-utiliser-uniquement-dans-le-traitement-du-diabete-de-type-2), [Ameli.fr](https://www.ameli.fr/assure/actualites/ozempic-et-autres-antidiabetiques-l-assurance-maladie-renforce-le-controle-des-prescriptions).


### PR DESCRIPTION
## Summary
This PR adds a comprehensive guide about obtaining Ozempic prescriptions legally in France and updates the Astro content type definitions to properly reference the generated content module.

## Key Changes

- **Added new content article**: `src/content/traitements-glp1/ozempic-sans-ordonnance.md`
  - Comprehensive guide covering legal requirements for Ozempic prescriptions in France
  - Explains why prescriptions are mandatory, regulatory changes since 2025, and health risks of obtaining medication without proper medical oversight
  - Provides step-by-step instructions for legally obtaining prescriptions
  - Includes pricing information, FAQs, and alternative GLP-1 treatments
  - Properly formatted with frontmatter metadata for SEO and content organization

- **Updated type definitions**: `.astro/types.d.ts`
  - Fixed reference path from `astro/content.d.ts` to `content.d.ts` to correctly point to the generated content type definitions

- **Generated content types**: `.astro/content.d.ts`
  - Auto-generated TypeScript definitions for Astro content collections
  - Provides type safety for content queries and rendering
  - Includes interfaces for render results, collection entries, and live content loaders

## Implementation Details

The new article follows the established content structure with comprehensive metadata including author, publication date, featured status, and SEO keywords. The type definition update ensures proper TypeScript support for the content collection system while maintaining compatibility with Astro's content layer.

https://claude.ai/code/session_01BWYZQYpR7HGDJedi77cGzS