### PR TITLE
Disable hourly scheduled run for integration agent

### DIFF
--- a/.github/workflows/integration-agent.yml
+++ b/.github/workflows/integration-agent.yml
@@ -1,11 +1,7 @@
 name: "Agent Integration GLP1"
 
 on:
-  # Execution automatique toutes les heures (9h-20h UTC, lun-ven)
-  schedule:
-    - cron: "0 9-20 * * 1-5"
-
-  # Declenchement manuel depuis l'onglet Actions
+  # Declenchement manuel uniquement depuis l'onglet Actions
   workflow_dispatch:
     inputs:
       limit:


### PR DESCRIPTION
Remove the cron schedule (0 9-20 * * 1-5) that triggered the integration agent every hour. The workflow is now manual-only (workflow_dispatch).

https://claude.ai/code/session_01YEYdLvftcGDJf3tjABr8DQ