### PR TITLE
Revamp admin SEO page with prompt, history, and ideas tracking

### DIFF
--- a/src/pages/admin/seo.astro
+++ b/src/pages/admin/seo.astro
@@ -1,6 +1,6 @@
 ---
 // src/pages/admin/seo.astro
-// Agent SEO — Empty state (Phase 2)
+// Dashboard SEO Opportunites — Prompt + Historique + Future agent
 import AdminNav from '../../components/AdminNav.astro';
 ---
 
@@ -9,103 +9,245 @@ import AdminNav from '../../components/AdminNav.astro';
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SEO - GLP1 Admin</title>
+  <title>SEO Opportunites - GLP1 Admin</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: #f1f5f9;
       color: #1e293b;
+      font-size: 14px;
     }
     .admin-layout { margin-left: 260px; min-height: 100vh; }
     .page-header {
       background: white;
       border-bottom: 1px solid #e2e8f0;
       padding: 1.5rem 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
     }
     .page-header h1 { font-size: 1.5rem; font-weight: 700; color: #0f172a; }
     .page-header p { font-size: 0.88rem; color: #64748b; margin-top: 0.25rem; }
-
-    .main { padding: 2rem; }
-
-    .coming-soon {
-      max-width: 560px;
-      margin: 4rem auto;
-      text-align: center;
-    }
-    .coming-icon {
-      width: 80px;
-      height: 80px;
+    .header-badge {
+      display: inline-block;
+      padding: 0.3rem 0.75rem;
       border-radius: 20px;
-      background: linear-gradient(135deg, #fef3c7, #fde68a);
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: 600;
+      background: #dbeafe;
+      color: #1e40af;
+    }
+
+    .main { padding: 2rem; max-width: 1200px; }
+
+    /* Tabs */
+    .tabs {
+      display: flex;
+      gap: 0;
+      border-bottom: 2px solid #e2e8f0;
       margin-bottom: 1.5rem;
     }
-    .coming-icon svg { color: #d97706; }
-    .coming-title {
-      font-size: 1.35rem;
-      font-weight: 700;
-      margin-bottom: 0.5rem;
-      color: #0f172a;
-    }
-    .coming-desc {
-      font-size: 0.95rem;
+    .tab {
+      padding: 0.75rem 1.25rem;
+      font-size: 0.88rem;
+      font-weight: 600;
       color: #64748b;
-      line-height: 1.6;
-      margin-bottom: 2rem;
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+      transition: all 0.15s;
+      background: none;
+      border-top: none;
+      border-left: none;
+      border-right: none;
     }
-    .feature-list {
+    .tab:hover { color: #334155; }
+    .tab.active {
+      color: #1e40af;
+      border-bottom-color: #3b82f6;
+    }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+
+    /* Cards */
+    .card {
+      background: white;
+      border-radius: 12px;
+      border: 1px solid #e2e8f0;
+      padding: 1.5rem;
+      margin-bottom: 1.25rem;
+    }
+    .card-title {
+      font-size: 1rem;
+      font-weight: 700;
+      color: #0f172a;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .card-subtitle {
+      font-size: 0.82rem;
+      color: #64748b;
+      margin-bottom: 1rem;
+      line-height: 1.5;
+    }
+
+    /* Prompt block */
+    .prompt-block {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1.25rem;
+      font-family: 'Courier New', monospace;
+      font-size: 0.82rem;
+      line-height: 1.7;
+      color: #334155;
+      white-space: pre-wrap;
+      max-height: 500px;
+      overflow-y: auto;
+      position: relative;
+    }
+    .copy-btn {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+      padding: 0.4rem 0.75rem;
+      background: #3b82f6;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .copy-btn:hover { background: #2563eb; }
+    .copy-btn.copied { background: #16a34a; }
+
+    /* History table */
+    .history-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    .history-table th {
       text-align: left;
+      font-size: 0.75rem;
+      font-weight: 700;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 0.75rem 1rem;
+      border-bottom: 2px solid #e2e8f0;
+    }
+    .history-table td {
+      padding: 0.85rem 1rem;
+      border-bottom: 1px solid #f1f5f9;
+      font-size: 0.88rem;
+      color: #334155;
+    }
+    .history-table tr:hover td { background: #f8fafc; }
+
+    /* Status badges */
+    .status {
+      display: inline-block;
+      padding: 0.2rem 0.6rem;
+      border-radius: 12px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .status-published { background: #dcfce7; color: #166534; }
+    .status-draft { background: #fef3c7; color: #92400e; }
+    .status-idea { background: #dbeafe; color: #1e40af; }
+
+    /* Keyword tags */
+    .kw-tag {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      background: #f1f5f9;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      color: #475569;
+      margin: 0.15rem 0.15rem 0.15rem 0;
+    }
+
+    /* Stats */
+    .stats-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .stat-card {
       background: white;
       border-radius: 12px;
       border: 1px solid #e2e8f0;
       padding: 1.25rem;
+      text-align: center;
     }
-    .feature-list h3 {
-      font-size: 0.88rem;
-      font-weight: 700;
-      color: #475569;
-      margin-bottom: 0.75rem;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
+    .stat-value {
+      font-size: 2rem;
+      font-weight: 800;
+      color: #0f172a;
     }
-    .feature-item {
+    .stat-label {
+      font-size: 0.8rem;
+      color: #64748b;
+      margin-top: 0.25rem;
+    }
+
+    /* Ideas list */
+    .idea-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.85rem 0;
+      border-bottom: 1px solid #f1f5f9;
+    }
+    .idea-item:last-child { border-bottom: none; }
+    .idea-kw { font-weight: 600; color: #0f172a; }
+    .idea-vol { font-size: 0.82rem; color: #64748b; }
+    .idea-diff {
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 0.2rem 0.5rem;
+      border-radius: 4px;
+    }
+    .diff-easy { background: #dcfce7; color: #166534; }
+    .diff-medium { background: #fef3c7; color: #92400e; }
+    .diff-hard { background: #fee2e2; color: #991b1b; }
+
+    /* Future agent section */
+    .agent-status {
       display: flex;
       align-items: center;
       gap: 0.75rem;
-      padding: 0.65rem 0;
-      border-bottom: 1px solid #f1f5f9;
-      font-size: 0.88rem;
-      color: #475569;
+      padding: 1rem;
+      background: #fffbeb;
+      border: 1px solid #fde68a;
+      border-radius: 8px;
+      margin-top: 1rem;
     }
-    .feature-item:last-child { border-bottom: none; }
-    .feature-dot {
-      width: 8px;
-      height: 8px;
+    .agent-dot {
+      width: 10px;
+      height: 10px;
       border-radius: 50%;
-      background: #e2e8f0;
+      background: #f59e0b;
       flex-shrink: 0;
     }
-    .phase-badge {
-      display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.8rem;
-      font-weight: 600;
-      background: #fef3c7;
-      color: #92400e;
-      margin-bottom: 1.5rem;
-    }
+    .agent-status-text { font-size: 0.85rem; color: #92400e; }
 
     @media (max-width: 1024px) {
       .admin-layout { margin-left: 0; padding-top: 56px; }
     }
     @media (max-width: 768px) {
       .main { padding: 1rem; }
-      .page-header { padding: 1rem; }
-      .coming-soon { margin: 2rem auto; }
+      .page-header { padding: 1rem; flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+      .tabs { overflow-x: auto; }
+      .stats-row { grid-template-columns: 1fr 1fr; }
+      .history-table { font-size: 0.8rem; }
+      .history-table th, .history-table td { padding: 0.6rem 0.5rem; }
     }
   </style>
 </head>
@@ -115,51 +257,356 @@ import AdminNav from '../../components/AdminNav.astro';
 
 <div class="admin-layout">
   <div class="page-header">
-    <h1>SEO</h1>
-    <p>Agent Opportunite SEO</p>
+    <div>
+      <h1>SEO Opportunites</h1>
+      <p>Recherche d'opportunites, prompt reutilisable et historique de contenu</p>
+    </div>
+    <span class="header-badge">Phase 2 - Manuel</span>
   </div>
 
   <div class="main">
-    <div class="coming-soon">
-      <div class="coming-icon">
-        <svg width="40" height="40" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-        </svg>
+    <!-- Stats -->
+    <div class="stats-row" id="statsRow">
+      <div class="stat-card">
+        <div class="stat-value" id="statArticles">-</div>
+        <div class="stat-label">Articles SEO crees</div>
       </div>
-      <div class="phase-badge">Phase 2</div>
-      <h2 class="coming-title">Agent Opportunite SEO</h2>
-      <p class="coming-desc">
-        L'agent SEO analysera automatiquement les opportunites de positionnement
-        pour les articles GLP-1, identifiera les mots-cles manques et proposera
-        des optimisations de contenu.
-      </p>
+      <div class="stat-card">
+        <div class="stat-value" id="statKeywords">-</div>
+        <div class="stat-label">Mots-cles cibles</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value" id="statCollections">-</div>
+        <div class="stat-label">Collections couvertes</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value" id="statIdeas">-</div>
+        <div class="stat-label">Idees en attente</div>
+      </div>
+    </div>
 
-      <div class="feature-list">
-        <h3>Fonctionnalites prevues</h3>
-        <div class="feature-item">
-          <div class="feature-dot"></div>
-          <span>Analyse automatique des positions Google</span>
+    <!-- Tabs -->
+    <div class="tabs">
+      <button class="tab active" data-tab="prompt">Prompt SEO</button>
+      <button class="tab" data-tab="history">Historique</button>
+      <button class="tab" data-tab="ideas">Idees & Opportunites</button>
+    </div>
+
+    <!-- TAB: Prompt -->
+    <div class="tab-panel active" id="tab-prompt">
+      <div class="card">
+        <div class="card-title">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="#3b82f6"><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
+          Prompt de recherche d'opportunites SEO
         </div>
-        <div class="feature-item">
-          <div class="feature-dot"></div>
-          <span>Detection des opportunites de mots-cles</span>
+        <p class="card-subtitle">
+          Copiez ce prompt et utilisez-le avec Claude (ou un autre LLM avec web search) pour identifier de nouvelles opportunites de contenu SEO dans la niche GLP-1 France.
+          Quand Claude Loops sera disponible, ce prompt sera execute automatiquement par l'agent SEO.
+        </p>
+        <div class="prompt-block" id="promptBlock">
+          <button class="copy-btn" id="copyBtn" onclick="copyPrompt()">Copier</button>Tu es un expert SEO specialise dans le domaine de la sante et des traitements GLP-1 en France.
+
+## Objectif
+Identifie des opportunites de contenu SEO pour un site francophone specialise dans les traitements GLP-1 (Ozempic, Wegovy, Mounjaro, Saxenda, Rybelsus, Victoza, Trulicity, Zepbound).
+
+## Contexte du site
+- Site : guide informatif sur les GLP-1 en France
+- Audience : patients, curieux, professionnels de sante
+- Ton : medical fiable, accessible, pas de vente directe de medicaments
+- Collections existantes :
+  - traitements-glp1 (guides par molecule)
+  - glp1-perte-de-poids
+  - effets-secondaires-glp1
+  - glp1-cout (prix, remboursement)
+  - glp1-diabete
+  - medecins-glp1-france
+  - recherche-glp1
+  - regime-glp1
+  - alternatives-glp1
+
+## Articles deja publies
+(consulter l'historique dans la page admin SEO pour eviter les doublons)
+
+## Tache
+1. **Recherche web** : Utilise le web search pour analyser les tendances actuelles de recherche en France sur les GLP-1
+2. **Identifie 5-10 opportunites** de mots-cles a fort potentiel :
+   - Volume de recherche estime (faible/moyen/eleve)
+   - Difficulte estimee (facile/moyen/difficile)
+   - Intent utilisateur (informationnel, transactionnel, navigationnel)
+   - Collection cible sur le site
+3. **Priorise** les opportunites par ratio volume/difficulte
+4. **Pour la meilleure opportunite**, redige un article complet :
+   - Frontmatter Astro avec title, description, author, tags, pubDate, mainKeyword, secondaryKeywords
+   - Structure H2/H3 optimisee SEO
+   - Contenu factuel source (ANSM, HAS, ameli.fr, VIDAL)
+   - Section FAQ avec schema-friendly questions
+   - Liens internes vers les autres articles du site
+   - Disclaimer medical en fin d'article
+
+## Format de sortie
+```markdown
+## Opportunites identifiees
+
+| Mot-cle | Volume | Difficulte | Intent | Collection | Priorite |
+|---------|--------|------------|--------|------------|----------|
+| ...     | ...    | ...        | ...    | ...        | ...      |
+
+## Article recommande
+(article complet en markdown avec frontmatter)
+```
+
+## Regles
+- Contenu en francais
+- Sources officielles FR uniquement
+- Ne jamais encourager l'achat sans ordonnance
+- Dates et reglementation a jour (2026)
+- Pas de claims medicaux non sources</div>
+      </div>
+
+      <div class="card">
+        <div class="card-title">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="#f59e0b"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>
+          Comment utiliser ce prompt
         </div>
-        <div class="feature-item">
-          <div class="feature-dot"></div>
-          <span>Suggestions d'optimisation de contenu</span>
+        <ol style="padding-left: 1.25rem; font-size: 0.88rem; color: #475569; line-height: 1.8;">
+          <li>Copiez le prompt ci-dessus</li>
+          <li>Ouvrez Claude (claude.ai) avec le web search active ou utilisez Claude Code</li>
+          <li>Collez le prompt — Claude analysera les tendances et proposera des opportunites</li>
+          <li>Recuperez l'article genere et placez-le dans <code>src/content/[collection]/</code></li>
+          <li>Ajoutez l'entree dans l'historique ci-dessous pour suivi</li>
+          <li><strong>Futur</strong> : Quand Claude Loops sera disponible, cet agent tournera automatiquement</li>
+        </ol>
+
+        <div class="agent-status">
+          <div class="agent-dot"></div>
+          <span class="agent-status-text">
+            <strong>Agent automatique :</strong> En attente de Claude Loops. L'agent SEO sera capable de tourner en continu, detecter les opportunites, generer les articles et creer des PRs automatiquement.
+          </span>
         </div>
-        <div class="feature-item">
-          <div class="feature-dot"></div>
-          <span>Suivi des performances par article</span>
+      </div>
+    </div>
+
+    <!-- TAB: History -->
+    <div class="tab-panel" id="tab-history">
+      <div class="card">
+        <div class="card-title">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="#3b82f6"><path d="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>
+          Historique des contenus SEO crees
         </div>
-        <div class="feature-item">
-          <div class="feature-dot"></div>
-          <span>Integration avec Google Search Console</span>
+        <p class="card-subtitle">Suivi de tous les articles crees via la recherche d'opportunites SEO.</p>
+
+        <table class="history-table" id="historyTable">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Article</th>
+              <th>Mot-cle principal</th>
+              <th>Collection</th>
+              <th>Statut</th>
+            </tr>
+          </thead>
+          <tbody id="historyBody">
+            <!-- Filled by JS -->
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- TAB: Ideas -->
+    <div class="tab-panel" id="tab-ideas">
+      <div class="card">
+        <div class="card-title">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="#8b5cf6"><path d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7z"/></svg>
+          Idees & Opportunites en attente
         </div>
+        <p class="card-subtitle">
+          Mots-cles identifies comme opportunites a exploiter. Ajoutez de nouvelles idees manuellement ou via le prompt.
+        </p>
+        <div id="ideasList">
+          <!-- Filled by JS -->
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title">Ajouter une opportunite</div>
+        <form id="addIdeaForm" style="display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: flex-end;">
+          <div style="flex: 2; min-width: 200px;">
+            <label style="display: block; font-size: 0.75rem; font-weight: 600; color: #64748b; margin-bottom: 0.3rem;">Mot-cle</label>
+            <input type="text" id="ideaKeyword" placeholder="ex: mounjaro effets secondaires" style="width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.88rem;">
+          </div>
+          <div style="flex: 1; min-width: 120px;">
+            <label style="display: block; font-size: 0.75rem; font-weight: 600; color: #64748b; margin-bottom: 0.3rem;">Collection</label>
+            <select id="ideaCollection" style="width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.88rem;">
+              <option value="traitements-glp1">traitements-glp1</option>
+              <option value="glp1-perte-de-poids">glp1-perte-de-poids</option>
+              <option value="effets-secondaires-glp1">effets-secondaires-glp1</option>
+              <option value="glp1-cout">glp1-cout</option>
+              <option value="glp1-diabete">glp1-diabete</option>
+              <option value="medecins-glp1-france">medecins-glp1-france</option>
+              <option value="recherche-glp1">recherche-glp1</option>
+              <option value="regime-glp1">regime-glp1</option>
+              <option value="alternatives-glp1">alternatives-glp1</option>
+            </select>
+          </div>
+          <div style="flex: 1; min-width: 100px;">
+            <label style="display: block; font-size: 0.75rem; font-weight: 600; color: #64748b; margin-bottom: 0.3rem;">Difficulte</label>
+            <select id="ideaDifficulty" style="width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #e2e8f0; border-radius: 6px; font-size: 0.88rem;">
+              <option value="easy">Facile</option>
+              <option value="medium">Moyen</option>
+              <option value="hard">Difficile</option>
+            </select>
+          </div>
+          <button type="submit" style="padding: 0.5rem 1.25rem; background: #3b82f6; color: white; border: none; border-radius: 6px; font-weight: 600; font-size: 0.88rem; cursor: pointer;">Ajouter</button>
+        </form>
       </div>
     </div>
   </div>
 </div>
+
+<script is:inline>
+  // ===== DATA (localStorage-based for static hosting) =====
+  const STORAGE_KEY = 'glp1_seo_data';
+
+  function loadData() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+    // Default data with initial history
+    return {
+      history: [
+        {
+          date: '2026-03-09',
+          title: 'Ozempic Sans Ordonnance en France',
+          slug: 'ozempic-sans-ordonnance',
+          keyword: 'ozempic sans ordonnance',
+          secondaryKeywords: ['acheter ozempic sans ordonnance', 'ozempic prescription', 'ozempic pharmacie france'],
+          collection: 'traitements-glp1',
+          status: 'published',
+          source: 'Claude Code - session manuelle'
+        }
+      ],
+      ideas: [
+        { keyword: 'wegovy prix france 2026', collection: 'glp1-cout', difficulty: 'easy', added: '2026-03-09' },
+        { keyword: 'mounjaro vs ozempic comparatif', collection: 'traitements-glp1', difficulty: 'medium', added: '2026-03-09' },
+        { keyword: 'glp1 naturel alternatives', collection: 'alternatives-glp1', difficulty: 'easy', added: '2026-03-09' },
+        { keyword: 'ozempic perte de poids temoignage', collection: 'glp1-perte-de-poids', difficulty: 'medium', added: '2026-03-09' },
+        { keyword: 'semaglutide oral france', collection: 'traitements-glp1', difficulty: 'hard', added: '2026-03-09' },
+        { keyword: 'remboursement wegovy securite sociale', collection: 'glp1-cout', difficulty: 'easy', added: '2026-03-09' },
+        { keyword: 'effets secondaires ozempic long terme', collection: 'effets-secondaires-glp1', difficulty: 'medium', added: '2026-03-09' },
+      ]
+    };
+  }
+
+  function saveData(data) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }
+
+  // ===== RENDER =====
+  function render() {
+    const data = loadData();
+
+    // Stats
+    document.getElementById('statArticles').textContent = data.history.length;
+    const allKw = data.history.reduce((acc, h) => acc + 1 + (h.secondaryKeywords?.length || 0), 0);
+    document.getElementById('statKeywords').textContent = allKw;
+    const collections = new Set(data.history.map(h => h.collection));
+    document.getElementById('statCollections').textContent = collections.size;
+    document.getElementById('statIdeas').textContent = data.ideas.length;
+
+    // History
+    const tbody = document.getElementById('historyBody');
+    tbody.innerHTML = data.history.map(h => `
+      <tr>
+        <td>${h.date}</td>
+        <td>
+          <strong>${h.title}</strong>
+          <br><span style="font-size:0.75rem;color:#64748b;">${h.source || ''}</span>
+        </td>
+        <td>
+          <span class="kw-tag">${h.keyword}</span>
+          ${(h.secondaryKeywords || []).map(k => `<span class="kw-tag">${k}</span>`).join('')}
+        </td>
+        <td><span class="kw-tag">${h.collection}</span></td>
+        <td><span class="status status-${h.status}">${h.status === 'published' ? 'Publie' : h.status === 'draft' ? 'Brouillon' : 'Idee'}</span></td>
+      </tr>
+    `).join('');
+
+    // Ideas
+    const ideasEl = document.getElementById('ideasList');
+    if (data.ideas.length === 0) {
+      ideasEl.innerHTML = '<p style="color:#64748b;font-size:0.88rem;padding:1rem 0;">Aucune idee en attente. Utilisez le prompt pour en trouver !</p>';
+    } else {
+      ideasEl.innerHTML = data.ideas.map((idea, i) => {
+        const diffClass = idea.difficulty === 'easy' ? 'diff-easy' : idea.difficulty === 'hard' ? 'diff-hard' : 'diff-medium';
+        const diffLabel = idea.difficulty === 'easy' ? 'Facile' : idea.difficulty === 'hard' ? 'Difficile' : 'Moyen';
+        return `
+          <div class="idea-item">
+            <div>
+              <span class="idea-kw">${idea.keyword}</span>
+              <span class="kw-tag" style="margin-left:0.5rem;">${idea.collection}</span>
+            </div>
+            <div style="display:flex;align-items:center;gap:0.5rem;">
+              <span class="idea-diff ${diffClass}">${diffLabel}</span>
+              <button onclick="removeIdea(${i})" style="background:none;border:none;color:#94a3b8;cursor:pointer;font-size:1.1rem;" title="Supprimer">&times;</button>
+            </div>
+          </div>
+        `;
+      }).join('');
+    }
+  }
+
+  // ===== ACTIONS =====
+  function copyPrompt() {
+    const block = document.getElementById('promptBlock');
+    const btn = document.getElementById('copyBtn');
+    // Get text without the button text
+    const text = block.textContent.replace('Copier', '').replace('Copie !', '').trim();
+    navigator.clipboard.writeText(text).then(() => {
+      btn.textContent = 'Copie !';
+      btn.classList.add('copied');
+      setTimeout(() => {
+        btn.textContent = 'Copier';
+        btn.classList.remove('copied');
+      }, 2000);
+    });
+  }
+
+  function removeIdea(index) {
+    const data = loadData();
+    data.ideas.splice(index, 1);
+    saveData(data);
+    render();
+  }
+
+  // Add idea form
+  document.getElementById('addIdeaForm').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const keyword = document.getElementById('ideaKeyword').value.trim();
+    if (!keyword) return;
+    const data = loadData();
+    data.ideas.push({
+      keyword,
+      collection: document.getElementById('ideaCollection').value,
+      difficulty: document.getElementById('ideaDifficulty').value,
+      added: new Date().toISOString().split('T')[0]
+    });
+    saveData(data);
+    document.getElementById('ideaKeyword').value = '';
+    render();
+  });
+
+  // Tabs
+  document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+    });
+  });
+
+  // Init
+  render();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Replace placeholder "Phase 2" page with functional dashboard:
- Reusable SEO opportunity prompt (copyable, ready for Claude/LLM)
- History tab tracking all SEO content created (localStorage)
- Ideas & opportunities tab with add/remove functionality
- Stats overview (articles, keywords, collections, pending ideas)
- Pre-seeded with initial data (ozempic-sans-ordonnance article)
- Pre-seeded with 7 keyword opportunities for future content
- Ready for future Claude Loops automated agent integration

https://claude.ai/code/session_01BWYZQYpR7HGDJedi77cGzS