### PR TITLE
Fix mon-espace auth flow, Supabase CDN loading, and AI coach prompt

### DIFF
--- a/src/components/AiCoach.astro
+++ b/src/components/AiCoach.astro
@@ -34,8 +34,8 @@ import { supabaseConfig } from '../lib/supabase.js';
     </div>
 
     <div id="coach-messages">
-      <!-- Message de bienvenue -->
-      <div class="coach-msg coach-msg-assistant">
+      <!-- Message de bienvenue (sera remplace si utilisateur connecte) -->
+      <div class="coach-msg coach-msg-assistant" id="coach-welcome-msg">
         <div class="coach-bubble coach-bubble-assistant">
           Bonjour ! Je suis le Coach GLP-1, votre assistant d'information sur les traitements GLP-1 en France.<br><br>
           Comment puis-je vous aider ?
@@ -273,36 +273,7 @@ import { supabaseConfig } from '../lib/supabase.js';
     background: #f0fdf4;
     padding: 0 0.5rem;
   }
-  .signup-input {
-    width: 100%;
-    padding: 0.5rem 0.6rem;
-    border-radius: 6px;
-    border: 1px solid #d1d5db;
-    font-size: 0.78rem;
-    margin-bottom: 0.4rem;
-    outline: none;
-  }
-  .signup-input:focus { border-color: #16a34a; box-shadow: 0 0 0 2px rgba(22,163,74,0.15); }
-  .signup-form-btns {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-    margin-top: 0.3rem;
-  }
-  .signup-submit {
-    flex: 1;
-    padding: 0.5rem;
-    border-radius: 6px;
-    border: none;
-    background: #16a34a;
-    color: white;
-    font-size: 0.78rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.2s;
-  }
-  .signup-submit:hover { background: #15803d; }
-  .signup-submit:disabled { opacity: 0.5; }
+  /* Old inline form styles removed — unified funnel via /mon-espace/ */
   .signup-login-toggle {
     background: none;
     border: none;
@@ -312,6 +283,20 @@ import { supabaseConfig } from '../lib/supabase.js';
     white-space: nowrap;
   }
   .signup-login-toggle:hover { text-decoration: underline; }
+  .signup-cta-link {
+    display: block;
+    width: 100%;
+    padding: 0.65rem;
+    border-radius: 8px;
+    background: #16a34a;
+    color: white !important;
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-align: center;
+    text-decoration: none;
+    transition: background 0.2s;
+  }
+  .signup-cta-link:hover { background: #15803d; }
   .signup-error {
     font-size: 0.72rem;
     color: #dc2626;
@@ -322,7 +307,7 @@ import { supabaseConfig } from '../lib/supabase.js';
     position: relative;
   }
   .coach-input-blocked::after {
-    content: 'Inscrivez-vous pour continuer ↑';
+    content: 'Creez votre espace pour continuer ↑';
     position: absolute;
     top: 0; left: 0; right: 0; bottom: 0;
     background: rgba(255,255,255,0.92);
@@ -504,15 +489,30 @@ import { supabaseConfig } from '../lib/supabase.js';
   const sessionId = getSessionId();
 
   // ===== SUPABASE AUTH =====
+  let userProfile = null;
+
+  function loadSupabaseSDK() {
+    if (window.supabase) return Promise.resolve();
+    return new Promise(function(resolve, reject) {
+      var s = document.createElement('script');
+      s.src = 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js';
+      s.onload = resolve;
+      s.onerror = function() { reject(new Error('Failed to load Supabase SDK')); };
+      document.head.appendChild(s);
+    });
+  }
+
   async function initAuth() {
     if (sbClient) return sbClient;
-    const mod = await import('https://esm.sh/@supabase/supabase-js@2');
-    sbClient = mod.createClient(SB_URL, SB_KEY);
+    await loadSupabaseSDK();
+    sbClient = window.supabase.createClient(SB_URL, SB_KEY);
     // Check existing session
     const { data: { session } } = await sbClient.auth.getSession();
     if (session) {
       currentUser = session.user;
       signupPromptShown = true; // no need to show prompt
+      // Load profile if exists
+      loadUserProfile(session.user.id);
     }
     // Listen for auth changes (Google redirect callback)
     sbClient.auth.onAuthStateChange(function(event, session) {
@@ -521,6 +521,8 @@ import { supabaseConfig } from '../lib/supabase.js';
         signupPromptShown = true;
         // Link session conversations to user
         linkSessionToUser(session.user.id);
+        // Load profile
+        loadUserProfile(session.user.id);
         hideSignupPrompt();
         // Unblock input
         var inputArea = document.getElementById('coach-input-area');
@@ -534,6 +536,37 @@ import { supabaseConfig } from '../lib/supabase.js';
     return sbClient;
   }
 
+  async function loadUserProfile(userId) {
+    if (!sbClient) return;
+    try {
+      var { data } = await sbClient.from('user_profiles').select('*').eq('user_id', userId).single();
+      if (data) {
+        userProfile = data;
+        // Show personalized welcome if panel is open
+        updateWelcomeForProfile();
+      }
+    } catch(e) { /* no profile yet */ }
+  }
+
+  function updateWelcomeForProfile() {
+    if (!userProfile) return;
+    var statusEl = document.getElementById('coach-status');
+    var name = userProfile.prenom || (currentUser && currentUser.email ? currentUser.email.split('@')[0] : '');
+    if (statusEl && name) {
+      statusEl.textContent = name + ' — En ligne';
+    }
+    // Update welcome message
+    var welcomeEl = document.getElementById('coach-welcome-msg');
+    if (welcomeEl && name) {
+      var treatNames = { ozempic: 'Ozempic', wegovy: 'Wegovy', mounjaro: 'Mounjaro', saxenda: 'Saxenda' };
+      var treatText = treatNames[userProfile.treatment] ? ' sur ' + treatNames[userProfile.treatment] : '';
+      welcomeEl.querySelector('.coach-bubble').innerHTML =
+        'Bonjour <strong>' + escapeHtml(name) + '</strong> ! 👋<br><br>' +
+        'Je connais votre profil' + treatText + '. Posez-moi vos questions, je vous repondrai de facon personnalisee.<br><br>' +
+        '<a href="/mon-espace/" style="color:#16a34a;font-weight:600;font-size:0.8rem;">📊 Mon espace &rarr;</a>';
+    }
+  }
+
   async function linkSessionToUser(userId) {
     if (!sbClient) return;
     // Update all conversations from this session to be owned by the user
@@ -541,34 +574,7 @@ import { supabaseConfig } from '../lib/supabase.js';
     await sbClient.from('coach_messages').update({ user_id: userId }).eq('session_id', sessionId);
   }
 
-  async function signUpWithEmail(email, password) {
-    const sb = await initAuth();
-    const { data, error } = await sb.auth.signUp({
-      email: email,
-      password: password,
-      options: { data: { source: 'coach_widget' } }
-    });
-    if (error) return { error: error.message };
-    return { data };
-  }
-
-  async function signInWithEmail(email, password) {
-    const sb = await initAuth();
-    const { data, error } = await sb.auth.signInWithPassword({ email, password });
-    if (error) return { error: error.message };
-    return { data };
-  }
-
-  async function signInWithGoogle() {
-    const sb = await initAuth();
-    const { data, error } = await sb.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo: window.location.origin + window.location.pathname }
-    });
-    if (error) {
-      addAssistantMessage("Erreur de connexion Google. Essayez par email.");
-    }
-  }
+  // Auth functions removed — signup/login now handled by /mon-espace/ (unified funnel)
 
   function showSignupPrompt() {
     if (signupPromptShown || currentUser) return;
@@ -580,22 +586,21 @@ import { supabaseConfig } from '../lib/supabase.js';
     div.id = 'coach-signup-prompt';
     div.innerHTML = `
       <div class="coach-bubble coach-bubble-assistant coach-signup-bubble">
-        <div class="signup-text">Creez un compte pour <strong>retrouver votre historique</strong> de conversation a tout moment.</div>
+        <div class="signup-text">
+          <strong>Creez votre espace personnalise</strong> pour beneficier d'un suivi complet : historique de conversation, suivi du poids, programme nutrition, rappels d'injection...
+        </div>
         <div class="signup-actions">
-          <button class="signup-google-btn" onclick="window._coachGoogleSignIn()">
+          <button class="signup-google-btn" onclick="window._coachGoToEspace('google')">
             <svg width="16" height="16" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
             Continuer avec Google
           </button>
-          <div class="signup-divider"><span>ou par email</span></div>
-          <form class="signup-form" onsubmit="return window._coachEmailAuth(event)">
-            <input type="email" placeholder="votre@email.com" required class="signup-input" id="coach-signup-email">
-            <input type="password" placeholder="mot de passe (6+ car.)" required minlength="6" class="signup-input" id="coach-signup-password">
-            <div class="signup-form-btns">
-              <button type="submit" class="signup-submit" data-mode="signup">Creer un compte</button>
-              <button type="button" class="signup-login-toggle" onclick="window._coachToggleLogin()">Deja inscrit ?</button>
-            </div>
-            <div class="signup-error" id="coach-signup-error"></div>
-          </form>
+          <div class="signup-divider"><span>ou</span></div>
+          <a href="/mon-espace/" class="signup-cta-link" onclick="window._coachSaveReturnUrl()">
+            ✨ Creer mon espace personnalise
+          </a>
+          <div style="text-align:center;margin-top:0.5rem;">
+            <button type="button" class="signup-login-toggle" onclick="window._coachGoToEspace('login')">Deja inscrit ? Se connecter</button>
+          </div>
         </div>
       </div>
     `;
@@ -609,45 +614,40 @@ import { supabaseConfig } from '../lib/supabase.js';
   }
 
   // Global handlers for onclick in HTML
-  window._coachGoogleSignIn = signInWithGoogle;
-  window._coachToggleLogin = function() {
-    var btn = document.querySelector('.signup-submit');
-    if (btn.dataset.mode === 'signup') {
-      btn.dataset.mode = 'login';
-      btn.textContent = 'Se connecter';
+  window._coachSaveReturnUrl = function() {
+    localStorage.setItem('glp1_return_url', window.location.pathname);
+  };
+  window._coachGoToEspace = function(mode) {
+    localStorage.setItem('glp1_return_url', window.location.pathname);
+    if (mode === 'google') {
+      // Sign in with Google, redirect to /mon-espace/
+      signInWithGoogle_redirect();
+    } else if (mode === 'login') {
+      window.location.href = '/mon-espace/?tab=login';
     } else {
-      btn.dataset.mode = 'signup';
-      btn.textContent = 'Creer un compte';
+      window.location.href = '/mon-espace/';
     }
   };
-  window._coachEmailAuth = async function(e) {
-    e.preventDefault();
-    var email = document.getElementById('coach-signup-email').value;
-    var password = document.getElementById('coach-signup-password').value;
-    var btn = document.querySelector('.signup-submit');
-    var errorEl = document.getElementById('coach-signup-error');
-    btn.disabled = true;
-    btn.textContent = '...';
 
-    var result;
-    if (btn.dataset.mode === 'login') {
-      result = await signInWithEmail(email, password);
-    } else {
-      result = await signUpWithEmail(email, password);
+  async function signInWithGoogle_redirect() {
+    var sb = await initAuth();
+    var { error } = await sb.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: window.location.origin + '/mon-espace/' }
+    });
+    if (error) {
+      addAssistantMessage("Erreur de connexion Google. Essayez par email.");
     }
-
-    if (result.error) {
-      errorEl.textContent = result.error;
-      btn.disabled = false;
-      btn.textContent = btn.dataset.mode === 'login' ? 'Se connecter' : 'Creer un compte';
-    } else if (btn.dataset.mode === 'signup') {
-      hideSignupPrompt();
-      addAssistantMessage('Un email de confirmation a ete envoye. Verifiez votre boite mail pour activer votre compte.');
-    }
-  };
+  }
 
   // Init auth on load (check for existing session or Google redirect)
   initAuth();
+
+  // Auto-open if redirected from mon-espace Coach CTA
+  if (localStorage.getItem('glp1_open_coach') === '1') {
+    localStorage.removeItem('glp1_open_coach');
+    setTimeout(function() { if (!isOpen) togglePanel(); }, 500);
+  }
 
   // ===== DOM REFS =====
   const toggleBtn = document.getElementById('coach-toggle');
@@ -743,7 +743,16 @@ import { supabaseConfig } from '../lib/supabase.js';
           message: text,
           conversation_id: conversationId,
           page_url: window.location.pathname,
-          user_id: currentUser ? currentUser.id : null
+          user_id: currentUser ? currentUser.id : null,
+          user_context: userProfile ? {
+            prenom: userProfile.prenom,
+            treatment: userProfile.treatment,
+            status: userProfile.status,
+            weight_current: userProfile.weight_current,
+            weight_goal: userProfile.weight_goal,
+            sport_level: userProfile.sport_level,
+            diet_type: userProfile.diet_type
+          } : null
         })
       });
 

--- a/src/pages/admin/chats.astro
+++ b/src/pages/admin/chats.astro
@@ -344,12 +344,16 @@ import { supabaseConfig } from '../../lib/supabase';
     </div>
   </div>
 
+  <script is:inline src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
   <script is:inline define:vars={{ supabaseUrl: supabaseConfig.url, supabaseKey: supabaseConfig.anonKey }}>
     // Supabase client
     let sb;
-    async function initSupabase() {
-      const mod = await import('https://esm.sh/@supabase/supabase-js@2');
-      sb = mod.createClient(supabaseUrl, supabaseKey);
+    function initSupabase() {
+      if (sb) return;
+      if (!window.supabase || !window.supabase.createClient) {
+        throw new Error('Supabase JS not loaded');
+      }
+      sb = window.supabase.createClient(supabaseUrl, supabaseKey);
     }
 
     let allConversations = [];
@@ -357,68 +361,74 @@ import { supabaseConfig } from '../../lib/supabase';
     let currentFilter = 'all';
 
     async function loadData() {
-      if (!sb) await initSupabase();
+      try {
+        if (!sb) initSupabase();
 
-      // Load conversations
-      const { data: convs } = await sb
-        .from('coach_conversations')
-        .select('*')
-        .order('last_message_at', { ascending: false })
-        .limit(200);
+        // Load conversations
+        const { data: convs, error: convErr } = await sb
+          .from('coach_conversations')
+          .select('*')
+          .order('last_message_at', { ascending: false })
+          .limit(200);
 
-      allConversations = convs || [];
+        if (convErr) { console.error('convs error:', convErr); }
+        allConversations = convs || [];
 
-      // Load stats
-      const { count: totalMsgs } = await sb
-        .from('coach_messages')
-        .select('*', { count: 'exact', head: true });
+        // Load stats
+        const { count: totalMsgs } = await sb
+          .from('coach_messages')
+          .select('*', { count: 'exact', head: true });
 
-      const today = new Date().toISOString().split('T')[0];
-      const { count: todayMsgs } = await sb
-        .from('coach_messages')
-        .select('*', { count: 'exact', head: true })
-        .gte('created_at', today);
+        const today = new Date().toISOString().split('T')[0];
+        const { count: todayMsgs } = await sb
+          .from('coach_messages')
+          .select('*', { count: 'exact', head: true })
+          .gte('created_at', today);
 
-      const todayConvs = allConversations.filter(c =>
-        c.last_message_at && c.last_message_at.startsWith(today)
-      ).length;
+        const todayConvs = allConversations.filter(c =>
+          c.last_message_at && c.last_message_at.startsWith(today)
+        ).length;
 
-      // Unique sessions
-      const uniqueSessions = new Set(allConversations.map(c => c.session_id)).size;
+        // Unique sessions
+        const uniqueSessions = new Set(allConversations.map(c => c.session_id)).size;
 
-      // LLM vs fallback
-      const { count: llmCount } = await sb
-        .from('coach_messages')
-        .select('*', { count: 'exact', head: true })
-        .eq('role', 'assistant')
-        .eq('model', 'llama-3.1-8b-instant');
+        // LLM vs fallback
+        const { count: llmCount } = await sb
+          .from('coach_messages')
+          .select('*', { count: 'exact', head: true })
+          .eq('role', 'assistant')
+          .eq('model', 'llama-3.1-8b-instant');
 
-      const { count: fallbackCount } = await sb
-        .from('coach_messages')
-        .select('*', { count: 'exact', head: true })
-        .eq('role', 'assistant')
-        .eq('model', 'fallback-v1');
+        const { count: fallbackCount } = await sb
+          .from('coach_messages')
+          .select('*', { count: 'exact', head: true })
+          .eq('role', 'assistant')
+          .eq('model', 'fallback-v1');
 
-      const totalAssistant = (llmCount || 0) + (fallbackCount || 0);
-      const llmPct = totalAssistant > 0 ? Math.round((llmCount / totalAssistant) * 100) : 0;
+        const totalAssistant = (llmCount || 0) + (fallbackCount || 0);
+        const llmPct = totalAssistant > 0 ? Math.round((llmCount / totalAssistant) * 100) : 0;
 
-      // Avg msgs per conv
-      const avgMsgs = allConversations.length > 0
-        ? Math.round((totalMsgs || 0) / allConversations.length)
-        : 0;
+        // Avg msgs per conv
+        const avgMsgs = allConversations.length > 0
+          ? Math.round((totalMsgs || 0) / allConversations.length)
+          : 0;
 
-      // Update stats
-      document.getElementById('statConvs').textContent = allConversations.length;
-      document.getElementById('statConvsToday').textContent = "aujourd'hui: " + todayConvs;
-      document.getElementById('statMsgs').textContent = totalMsgs || 0;
-      document.getElementById('statMsgsToday').textContent = "aujourd'hui: " + (todayMsgs || 0);
-      document.getElementById('statVisitors').textContent = uniqueSessions;
-      document.getElementById('statLlmPct').textContent = llmPct + '%';
-      document.getElementById('statFallback').textContent = 'fallback: ' + (fallbackCount || 0);
-      document.getElementById('statAvgMsgs').textContent = avgMsgs;
-      document.getElementById('lastUpdate').textContent = 'MAJ ' + new Date().toLocaleTimeString('fr-FR');
+        // Update stats
+        document.getElementById('statConvs').textContent = allConversations.length;
+        document.getElementById('statConvsToday').textContent = "aujourd'hui: " + todayConvs;
+        document.getElementById('statMsgs').textContent = totalMsgs || 0;
+        document.getElementById('statMsgsToday').textContent = "aujourd'hui: " + (todayMsgs || 0);
+        document.getElementById('statVisitors').textContent = uniqueSessions;
+        document.getElementById('statLlmPct').textContent = llmPct + '%';
+        document.getElementById('statFallback').textContent = 'fallback: ' + (fallbackCount || 0);
+        document.getElementById('statAvgMsgs').textContent = avgMsgs;
+        document.getElementById('lastUpdate').textContent = 'MAJ ' + new Date().toLocaleTimeString('fr-FR');
 
-      renderConvList();
+        renderConvList();
+      } catch(e) {
+        console.error('loadData error:', e);
+        document.getElementById('convListContent').innerHTML = '<div class="conv-empty">Erreur de chargement — voir console</div>';
+      }
     }
 
     function filterConvs(filter, btn) {
@@ -467,7 +477,7 @@ import { supabaseConfig } from '../../lib/supabase';
     }
 
     async function loadConversation(convId, el) {
-      if (!sb) await initSupabase();
+      if (!sb) initSupabase();
 
       // Active state
       document.querySelectorAll('.conv-item').forEach(i => i.classList.remove('active'));
@@ -521,6 +531,11 @@ import { supabaseConfig } from '../../lib/supabase';
       if (!str) return '';
       return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
+
+    // Expose functions to global scope for onclick handlers
+    window.loadData = loadData;
+    window.loadConversation = loadConversation;
+    window.filterConvs = filterConvs;
 
     // Auto-load
     loadData();

--- a/src/pages/admin/leads.astro
+++ b/src/pages/admin/leads.astro
@@ -354,12 +354,15 @@ import { supabaseConfig } from '../../lib/supabase';
     </div>
   </div>
 
+  <script is:inline src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
   <script is:inline define:vars={{ supabaseUrl: supabaseConfig.url, supabaseKey: supabaseConfig.anonKey }}>
     let sb;
-    async function initSb() {
+    function initSb() {
       if (sb) return sb;
-      const mod = await import('https://esm.sh/@supabase/supabase-js@2');
-      sb = mod.createClient(supabaseUrl, supabaseKey);
+      if (!window.supabase || !window.supabase.createClient) {
+        throw new Error('Supabase JS not loaded');
+      }
+      sb = window.supabase.createClient(supabaseUrl, supabaseKey);
       return sb;
     }
 
@@ -643,6 +646,12 @@ import { supabaseConfig } from '../../lib/supabase';
       d.textContent = str;
       return d.innerHTML;
     }
+
+    // Expose functions to global scope for onclick handlers
+    window.loadAllData = loadAllData;
+    window.filterSource = filterSource;
+    window.showDetail = showDetail;
+    window.closeModal = closeModal;
 
     // Auto-load + refresh
     loadAllData();

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -723,17 +723,15 @@ import StaticLayout from '../layouts/StaticLayout.astro';
     }
   </style>
 
+  <script is:inline src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
   <script is:inline>
     // Load Supabase from CDN and handle contact form
-    (async function() {
+    (function() {
       try {
-        // Import Supabase from CDN
-        const { createClient } = await import('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm');
-        
         // Initialize Supabase client with public credentials
         const supabaseUrl = 'https://zmdzbhvxprldvvlnjzhu.supabase.co';
         const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InptZHpiaHZ4cHJsZHZ2bG5qemh1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3MjQzMjU5OTEsImV4cCI6MjAzOTkwMTk5MX0.6CPDkaNBWVZgQzlvBRFWVEY6m4Y4wDn3-FsKl8gHpAg';
-        const supabase = createClient(supabaseUrl, supabaseKey);
+        const supabase = window.supabase.createClient(supabaseUrl, supabaseKey);
         
         console.log('🚀 Supabase client initialized');
         

--- a/src/pages/mon-espace/index.astro
+++ b/src/pages/mon-espace/index.astro
@@ -9,7 +9,7 @@ import { supabaseConfig } from '../../lib/supabase';
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mon Espace - Coach GLP-1</title>
   <meta name="robots" content="noindex, nofollow">
-  <style>
+  <style is:inline>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -858,7 +858,7 @@ import { supabaseConfig } from '../../lib/supabase';
       <div class="coach-cta">
         <h3>Une question ?</h3>
         <p>Votre coach IA connait votre profil et peut vous aider en temps reel</p>
-        <a href="/" class="btn-coach">💬 Parler au Coach</a>
+        <a href="/#coach" class="btn-coach" onclick="localStorage.setItem('glp1_open_coach','1')">💬 Parler au Coach</a>
       </div>
     </div>
   </div>
@@ -881,13 +881,16 @@ import { supabaseConfig } from '../../lib/supabase';
     </div>
   </div>
 
+  <script is:inline src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
   <script is:inline define:vars={{ supabaseUrl: supabaseConfig.url, supabaseKey: supabaseConfig.anonKey }}>
     let sb, currentUser, profile;
 
-    async function initSb() {
+    function initSb() {
       if (sb) return sb;
-      const mod = await import('https://esm.sh/@supabase/supabase-js@2');
-      sb = mod.createClient(supabaseUrl, supabaseKey);
+      if (!window.supabase || !window.supabase.createClient) {
+        throw new Error('Supabase JS not loaded');
+      }
+      sb = window.supabase.createClient(supabaseUrl, supabaseKey);
       return sb;
     }
 
@@ -918,42 +921,48 @@ import { supabaseConfig } from '../../lib/supabase';
     }
 
     async function signInGoogle() {
-      var s = await initSb();
-      var { error } = await s.auth.signInWithOAuth({
-        provider: 'google',
-        options: { redirectTo: window.location.origin + '/mon-espace/' }
-      });
-      if (error) showAuthError(error.message);
+      try {
+        var s = initSb();
+        var { error } = await s.auth.signInWithOAuth({
+          provider: 'google',
+          options: { redirectTo: window.location.origin + '/mon-espace/' }
+        });
+        if (error) showAuthError(error.message);
+      } catch(e) { showAuthError('Erreur de connexion. Rechargez la page.'); console.error(e); }
     }
 
     async function signUpEmail() {
-      var s = await initSb();
-      var email = document.getElementById('signupEmail').value.trim();
-      var pw = document.getElementById('signupPassword').value;
-      var name = document.getElementById('signupName').value.trim();
-      if (!email || !pw) return showAuthError('Email et mot de passe requis');
-      if (pw.length < 6) return showAuthError('Mot de passe : 6 caracteres minimum');
+      try {
+        var s = initSb();
+        var email = document.getElementById('signupEmail').value.trim();
+        var pw = document.getElementById('signupPassword').value;
+        var name = document.getElementById('signupName').value.trim();
+        if (!email || !pw) return showAuthError('Email et mot de passe requis');
+        if (pw.length < 6) return showAuthError('Mot de passe : 6 caracteres minimum');
 
-      var { data, error } = await s.auth.signUp({
-        email: email,
-        password: pw,
-        options: { data: { prenom: name } }
-      });
-      if (error) return showAuthError(error.message);
-      currentUser = data.user;
-      if (currentUser) onUserReady(name);
+        var { data, error } = await s.auth.signUp({
+          email: email,
+          password: pw,
+          options: { data: { prenom: name } }
+        });
+        if (error) return showAuthError(error.message);
+        currentUser = data.user;
+        if (currentUser) onUserReady(name);
+      } catch(e) { showAuthError('Erreur de connexion. Rechargez la page.'); console.error(e); }
     }
 
     async function signInEmail() {
-      var s = await initSb();
-      var email = document.getElementById('loginEmail').value.trim();
-      var pw = document.getElementById('loginPassword').value;
-      if (!email || !pw) return showAuthError('Email et mot de passe requis');
+      try {
+        var s = initSb();
+        var email = document.getElementById('loginEmail').value.trim();
+        var pw = document.getElementById('loginPassword').value;
+        if (!email || !pw) return showAuthError('Email et mot de passe requis');
 
-      var { data, error } = await s.auth.signInWithPassword({ email: email, password: pw });
-      if (error) return showAuthError(error.message);
-      currentUser = data.user;
-      if (currentUser) onUserReady();
+        var { data, error } = await s.auth.signInWithPassword({ email: email, password: pw });
+        if (error) return showAuthError(error.message);
+        currentUser = data.user;
+        if (currentUser) onUserReady();
+      } catch(e) { showAuthError('Erreur de connexion. Rechargez la page.'); console.error(e); }
     }
 
     async function doLogout() {
@@ -966,6 +975,10 @@ import { supabaseConfig } from '../../lib/supabase';
 
     async function onUserReady(prenomHint) {
       var s = await initSb();
+
+      // Link chat session to this user (unified funnel)
+      linkChatSession(currentUser.id);
+
       // Check if profile exists
       var { data } = await s.from('user_profiles').select('*').eq('user_id', currentUser.id).single();
       if (data) {
@@ -976,6 +989,17 @@ import { supabaseConfig } from '../../lib/supabase';
         showScreen('Onboarding');
         renderObStep();
       }
+    }
+
+    async function linkChatSession(userId) {
+      // Link any anonymous chat conversations from the widget to this user
+      var sessionId = localStorage.getItem('glp1_coach_session');
+      if (!sessionId) return;
+      var s = await initSb();
+      try {
+        await s.from('coach_conversations').update({ user_id: userId }).eq('session_id', sessionId).is('user_id', null);
+        await s.from('coach_messages').update({ user_id: userId }).eq('session_id', sessionId).is('user_id', null);
+      } catch(e) { /* ignore */ }
     }
 
     // ===== ONBOARDING =====
@@ -1501,23 +1525,51 @@ import { supabaseConfig } from '../../lib/supabase';
 
     // ===== INIT =====
     async function init() {
-      var s = await initSb();
-      var { data: { session } } = await s.auth.getSession();
-      if (session && session.user) {
-        currentUser = session.user;
-        onUserReady();
-      } else {
+      try {
+        var s = initSb();
+        var { data: { session } } = await s.auth.getSession();
+        if (session && session.user) {
+          currentUser = session.user;
+          onUserReady();
+        } else {
+          showScreen('Auth');
+          // Handle ?tab=login from chat widget redirect
+          var params = new URLSearchParams(window.location.search);
+          if (params.get('tab') === 'login') {
+            switchAuthTab('login');
+          }
+        }
+
+        // Listen for auth changes (OAuth redirect)
+        s.auth.onAuthStateChange(function(event, session) {
+          if (event === 'SIGNED_IN' && session && session.user) {
+            currentUser = session.user;
+            onUserReady(session.user.user_metadata?.prenom);
+          }
+        });
+      } catch(e) {
+        console.error('Init error:', e);
+        // Show auth screen even if Supabase fails to load
         showScreen('Auth');
       }
-
-      // Listen for auth changes (OAuth redirect)
-      s.auth.onAuthStateChange(function(event, session) {
-        if (event === 'SIGNED_IN' && session && session.user) {
-          currentUser = session.user;
-          onUserReady(session.user.user_metadata?.prenom);
-        }
-      });
     }
+
+    // Expose functions to global scope for onclick handlers
+    window.switchAuthTab = switchAuthTab;
+    window.signInGoogle = signInGoogle;
+    window.signUpEmail = signUpEmail;
+    window.signInEmail = signInEmail;
+    window.doLogout = doLogout;
+    window.editProfile = editProfile;
+    window.saveCheckin = saveCheckin;
+    window.exportAllCalendar = exportAllCalendar;
+    window.exportICS = exportICS;
+    window.subscribe = subscribe;
+    window.closePaywall = closePaywall;
+    window.obSelect = obSelect;
+    window.obPrev = obPrev;
+    window.obNext = obNext;
+    window.obFinish = obFinish;
 
     init();
   </script>

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -20,37 +20,45 @@ const RATE_LIMIT_HOURLY_MAX = 60;
 
 const SYSTEM_PROMPT = `Tu es le Coach GLP-1 France, un assistant d'information specialise dans les traitements agonistes du recepteur GLP-1 (semaglutide, tirzepatide, liraglutide, dulaglutide) en France.
 
+TON APPROCHE — ECOUTER D'ABORD, INFORMER ENSUITE :
+- Tu commences TOUJOURS par comprendre la situation de la personne avant de donner des informations.
+- Tu poses des questions courtes et bienveillantes pour clarifier : quel produit ? quel contexte ? quel objectif ? suivi medical ?
+- Tu ne fais JAMAIS peur inutilement. Tu restes calme, rassurant et factuel.
+- Tu ne tires JAMAIS de conclusions hatives sur la situation de quelqu'un.
+- Quand quelqu'un mentionne un produit douteux, tu poses d'abord des questions (quel produit exactement ? ou achete ? prescrit par un medecin ?) avant de donner ton avis.
+
 REGLES ABSOLUES :
-1. Tu ne poses JAMAIS de diagnostic medical. Tu ne recommandes JAMAIS un traitement specifique a quelqu'un.
-2. Tu renvoies TOUJOURS vers un medecin (medecin traitant, endocrinologue, centre specialise obesite) pour toute decision medicale.
+1. Tu ne poses JAMAIS de diagnostic medical. Tu ne recommandes JAMAIS un traitement specifique.
+2. Tu renvoies TOUJOURS vers un medecin pour toute decision medicale.
 3. Tu ne prescris RIEN. Tu informes uniquement.
-4. Si quelqu'un decrit des symptomes graves (douleur abdominale severe, vomissements persistants, pensees suicidaires, reaction allergique, pancreatite), tu dis d'appeler le 15 (SAMU) ou le 112 immediatement. Ne temporise pas.
-5. Tu ne vends RIEN. GLP-1 France est un site d'information independant, PAS une pharmacie, PAS un vendeur.
-6. Si quelqu'un mentionne un achat en ligne sans ordonnance, tu alertes SYSTEMATIQUEMENT sur le risque d'arnaque et de contrefacon. Oriente vers signal.conso.gouv.fr et pre-plainte-en-ligne.gouv.fr si victime.
+4. UNIQUEMENT si quelqu'un decrit des symptomes graves ACTUELS et URGENTS (douleur abdominale severe, vomissements persistants, pensees suicidaires, reaction allergique), tu dis d'appeler le 15 (SAMU). Sinon, tu orientes calmement vers un medecin.
+5. Tu ne vends RIEN. GLP-1 France est un site d'information independant.
+6. Si quelqu'un mentionne un achat en ligne ou un produit suspect : pose d'abord 2-3 questions pour comprendre (quel produit ? ou achete ? avec ordonnance ?). Ne suppose PAS d'emblee qu'il s'agit d'une arnaque. Donne ensuite une information mesuree selon les reponses.
 7. Tu reponds UNIQUEMENT en francais.
-8. Tu utilises un ton chaleureux, accessible, bienveillant mais professionnel. Tutoiement si l'utilisateur tutoie, vouvoiement sinon.
-9. Tu gardes tes reponses concises (max 120 mots). Va droit au but, pas de formules creuses.
+8. Ton chaleureux, accessible, bienveillant mais professionnel. Tutoiement si l'utilisateur tutoie, vouvoiement sinon.
+9. Reponses concises (max 150 mots). Va droit au but, pas de formules creuses.
 10. N'ajoute JAMAIS de disclaimer medical en fin de reponse (il y en a deja un affiche sous le chat).
-11. Ne dis JAMAIS "d'apres nos articles", "selon nos guides", "consultez nos guides specialises" ou toute formulation qui s'appuie sur "nos" contenus. Enonce simplement les faits.
-12. Ne termine JAMAIS par une phrase promotionnelle du style "Pour approfondir, consultez nos guides sur..." — si la reponse est complete, arrete-toi.
+11. Ne dis JAMAIS "d'apres nos articles", "selon nos guides" ou toute formulation qui s'appuie sur "nos" contenus.
+12. Ne termine JAMAIS par une phrase promotionnelle.
 
 CONTEXTE IMPORTANT :
-- Les vrais GLP-1 (Ozempic, Wegovy, Mounjaro, Saxenda, Trulicity, Victoza) ne se vendent QU'en pharmacie sur ordonnance en France
-- Beaucoup d'utilisateurs ont ete victimes d'arnaques (faux GLP-1 en gelules, flacons, achetes en ligne)
+- Les vrais GLP-1 injectables (Ozempic, Wegovy, Mounjaro, Saxenda, Trulicity, Victoza) ne se vendent QU'en pharmacie sur ordonnance en France
+- Il existe des arnaques (faux GLP-1 en gelules vendus en ligne) mais il existe aussi des complements alimentaires legaux (berbérine, etc.) — ne pas tout melanger
+- Si quelqu'un a achete un produit douteux et s'inquiete : le rassurer d'abord, poser des questions, puis informer factuellement
 - Prix approximatifs : Ozempic ~77 EUR/mois (rembourse 65% pour diabete T2), Wegovy ~300 EUR/mois (non rembourse), Mounjaro ~350 EUR/mois (non rembourse)
-- Wegovy est en attente de negociation de prix avec le CEPS pour un eventuel remboursement`;
+- Si la personne est victime d'arnaque averee : orienter calmement vers signal.conso.gouv.fr et pre-plainte-en-ligne.gouv.fr`;
 
 // --- Fallback v1 (rules engine) ---
 const INTENT_PATTERNS: Array<{ intent: string; pattern: RegExp; response: string }> = [
   {
     intent: 'scam',
-    pattern: /arnaque|faux|fraud|escroqu|command.*re[cç]u|gel[ue]le|contref|fak/i,
-    response: "⚠️ ATTENTION : de nombreux sites frauduleux vendent de faux GLP-1 (gelules, flacons). Ces produits sont illegaux et potentiellement dangereux.\n\nSi vous avez ete victime :\n1. Faites opposition sur votre carte bancaire\n2. Signalez sur signal.conso.gouv.fr\n3. Portez plainte sur pre-plainte-en-ligne.gouv.fr\n\nLes vrais traitements GLP-1 ne se vendent QU'en pharmacie, sur ordonnance."
+    pattern: /arnaque|fraud|escroqu|contref|fak/i,
+    response: "Je comprends votre inquietude. Pour mieux vous aider, j'aurais besoin de quelques details :\n\n• Quel produit avez-vous achete exactement ?\n• Sur quel site ou plateforme ?\n• Avez-vous deja recu le produit ?\n\nSi vous pensez avoir ete victime d'une arnaque, sachez que vous pouvez signaler sur signal.conso.gouv.fr et faire opposition sur votre carte bancaire."
   },
   {
     intent: 'selling',
     pattern: /vend|achet|command|produit|stock|livr/i,
-    response: "GLP-1 France est un site d'information independant. Nous ne vendons aucun produit.\n\nLes traitements GLP-1 sont des medicaments sur ordonnance. Le parcours legal :\n1. Consultation medecin traitant ou endocrinologue\n2. Ordonnance si indique medicalement\n3. Achat en pharmacie uniquement\n\n⚠️ Mefiez-vous des sites qui vendent du GLP-1 en ligne sans ordonnance."
+    response: "GLP-1 France est un site d'information independant, nous ne vendons aucun produit.\n\nLes traitements GLP-1 injectables sont des medicaments sur ordonnance. Le parcours :\n1. Consultation medecin traitant ou endocrinologue\n2. Ordonnance si indique medicalement\n3. Achat en pharmacie uniquement\n\nVous cherchez un traitement en particulier ? Je peux vous informer."
   },
   {
     intent: 'price',


### PR DESCRIPTION
- Switch Supabase JS from broken ESM dynamic import to UMD script tag
- Fix Astro scoped CSS preventing dynamically-generated onboarding from being styled (style is:inline)
- Add error handling (try/catch) on all auth functions
- Expose functions on window for inline onclick handlers (define:vars scope fix)
- Unified signup funnel: chat widget redirects to /mon-espace/ for auth
- Improve AI coach system prompt: ask questions first, don't alarm users
- Fix admin/chats and admin/leads CDN loading