### PR TITLE
feat: test d'éligibilité 65% + 4 articles phase 2 + mandat routine élargi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ La routine quotidienne ne se limite PAS au rapport SEO recovery + Coach IA. A ch
    - Verticale retraites : impressions/clics GSC des pages /retraites/ et /collections/retraites-bien-etre/ (indexation d'abord, positions ensuite)
 2. **Ameliorer** : si un chiffre stagne ou regresse, diagnostiquer et proposer/appliquer un fix (tickets, ajustement prompt Coach, maillage, title/meta). Les corrections de contenu passent par correction_tickets (statut approved).
 3. **Chercher des opportunites** : nouvelles requetes GSC en positions 5-20 avec impressions (quick wins), tendances (WebSearch si pertinent), gaps de contenu — alimenter content_opportunities et proposer les 2-3 meilleures actions du jour dans le rapport.
+3bis. **Indexation des pages manquantes** : detecter les pages publiees mais non indexees (page dans le sitemap / recemment publiee MAIS 0 impression dans gsc_metrics depuis 3+ jours). La soumission GSC est MANUELLE (aucune API Google pour "demander une indexation" de pages classiques) : la routine produit la liste d'URLs prete a coller dans l'inspection GSC, en tete de rapport, et notifie Robin si la liste est non vide (max ~10 URLs/jour, prioriser par potentiel de trafic). Verifier aussi que le sitemap est a jour apres chaque publication.
 4. **Alerter Robin** (PushNotification) seulement si : anomalie critique (site down, deindexation, erreur medicale du Coach, violation Zepbound), 1re conversion payante du Dossier, ou action bloquante cote Robin (ex : sync IMAP morte depuis le 20/05 — a relancer en local).
 
 ## Structure du projet
@@ -261,6 +262,11 @@ Les tickets sont **auto-approuves** (pas de validation humaine) :
 - `scripts/agent-server.mjs` — Serveur HTTP pour orchestrer les agents (port 7854)
 - `scripts/routine.mjs` — Script bloquant de routine (preferer le pipeline du serveur)
 - `scripts/sync-analytics.mjs` — Sync GA4 + GSC → Supabase (`--days 7`, `--setup` pour OAuth)
+
+## Preference de Robin (14/07/2026)
+
+- **Franc-parler attendu** : signaler sans hesiter ce qui semble bizarre, contreproductif ou risque, et proposer des idees — meme non sollicitees. Ne pas se contenter d'executer.
+- Points ouverts signales le 14/07 : (1) byline "Dr. Marie Dubois" probablement fictive = risque E-E-A-T/legal, recommandation : vrai relecteur credite ; (2) trop de micro-produits (Dossier 4,99 + consultation 3 EUR + Premium) → focus Dossier seul ; (3) pas de build check sur les PR avant deploy prod ; (4) a la reactivation de la creation auto : chaque chiffre source ou supprime.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,41 @@ SELECT 'ga_metrics' as tbl, MAX(date) FROM ga_metrics UNION ALL SELECT 'gsc_metr
 - **Role** : aide gratuitement, puis propose le Dossier au bon moment (apres collecte IMC + comorbidites)
 - **Style** : sobre, SANS emojis pictographiques (coches `✓` et fleches `→` OK)
 
+### Test d'eligibilite (funnel d'entree du Dossier) — depuis 14/07/2026
+- **Page** : `src/pages/outils/test-eligibilite.astro` → `/outils/test-eligibilite/`
+- 3 etapes client-side : IMC → comorbidites → suivi nutritionnel → verdict selon les criteres officiels (IMC >= 40, ou >= 35 + comorbidite, apres 6 mois de prise en charge nutritionnelle)
+- **Capture email** → table `contacts` avec `contact_type: 'eligibility_test'` (verdict + IMC dans `message`)
+- **Upsell Dossier 4,99 EUR** affiche si eligible ou presque eligible
+- Cible SEO : "suis-je eligible wegovy remboursement", "test eligibilite mounjaro"
+- Lie depuis le footer ("Test d'eligibilite 65%")
+
 ### Sinocare / Annette — DESACTIVES
 - **Plus aucune affiliation.** Composants Annette (PartnerCTA, PartnerSidebar, PartnerComparator) neutralises (rendu vide).
 - Callouts Sinocare retires. Ancien code promo CARE50, anciens liens affilies — ne plus utiliser.
 - **NE PAS reactiver** sans decision explicite de l'utilisateur.
 - `affiliate_clicks` + `AffiliateTracker.astro` restent en place (historique) mais ne sont plus une source de revenus.
+
+## Verticale Retraites Bien-Etre (lancee 13/07/2026)
+
+- **Collection** : `retraites-bien-etre` (13e collection, dans src/content/config.ts + routes /collections/retraites-bien-etre/)
+- **Hub** : `src/pages/retraites/index.astro` → `/retraites/` (page pilier SEO, lie depuis le footer) — **futur landing de l'offre premium** (retraites medicalisees GLP-1, projet de Robin : peptides/Morpheus8, cadre reglementaire FR a valider)
+- **Articles publies** : protocole Wegovy+cure thermale rembourses, retraites GLP-1 europeennes (Lanserhof etc.), jeune sous GLP-1, top 10 retraites perte de poids France
+- **Regles** : prix TOUJOURS sources et verifiables, zero invention ; pas d'affiliation ; thumbnails SVG uniques (DA verte #1a3c34/#16a34a) dans public/images/thumbnails/
+- **Strategie** : first-mover sur "GLP-1 x retraite" (desert editorial FR) ; clusters cibles : cure thermale minceur (remboursee Secu), jeune et randonnee, sejour minceur, longevity/medical wellness
+- Idees d'articles restantes (recherche 13/07) : Brides-les-Bains avis, combien coute une retraite, cure detox arnaque ?, peau relachee post-GLP-1 (pont Morpheus8), camp perte de poids adulte, comparatif thalasso, j'ai teste jeune et rando, retraites longevite
+
+## Routine quotidienne — MANDAT ELARGI (demande Robin 14/07/2026)
+
+La routine quotidienne ne se limite PAS au rapport SEO recovery + Coach IA. A chaque run, elle doit AUSSI :
+1. **Checker les resultats de chaque projet actif** :
+   - SEO recovery (baseline fixe : 922 sessions GA/jour, 106 clics GSC/jour — moyenne 15-23 juin)
+   - Coach IA : volume, qualite, emissions `[[DOSSIER_READY]]` (1re emission le 13/07 apres fix v46)
+   - Funnel Dossier 4,99 EUR : visites landing, dossiers pending/paid/generated
+   - Test d'eligibilite : leads `contact_type='eligibility_test'` dans contacts, taux de capture
+   - Verticale retraites : impressions/clics GSC des pages /retraites/ et /collections/retraites-bien-etre/ (indexation d'abord, positions ensuite)
+2. **Ameliorer** : si un chiffre stagne ou regresse, diagnostiquer et proposer/appliquer un fix (tickets, ajustement prompt Coach, maillage, title/meta). Les corrections de contenu passent par correction_tickets (statut approved).
+3. **Chercher des opportunites** : nouvelles requetes GSC en positions 5-20 avec impressions (quick wins), tendances (WebSearch si pertinent), gaps de contenu — alimenter content_opportunities et proposer les 2-3 meilleures actions du jour dans le rapport.
+4. **Alerter Robin** (PushNotification) seulement si : anomalie critique (site down, deindexation, erreur medicale du Coach, violation Zepbound), 1re conversion payante du Dossier, ou action bloquante cote Robin (ex : sync IMAP morte depuis le 20/05 — a relancer en local).
 
 ## Structure du projet
 

--- a/public/images/thumbnails/brides-les-bains-avis-prix-resultats-cure-minceur.svg
+++ b/public/images/thumbnails/brides-les-bains-avis-prix-resultats-cure-minceur.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1a3c34"/>
+      <stop offset="1" stop-color="#0f2620"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="1050" cy="120" r="220" fill="#16a34a" opacity="0.12"/>
+  <circle cx="120" cy="540" r="160" fill="#16a34a" opacity="0.10"/>
+  <text x="80" y="180" font-family="Georgia, serif" font-size="34" fill="#16a34a" font-weight="bold">GLP-1 FRANCE</text>
+  <text x="80" y="330" font-family="Georgia, serif" font-size="72" fill="#ffffff" font-weight="bold">Brides-les-Bains</text>
+  <text x="80" y="430" font-family="Georgia, serif" font-size="72" fill="#ffffff" font-weight="bold">avis & prix</text>
+  <text x="80" y="560" font-size="72">♨️</text>
+  <rect x="80" y="470" width="120" height="6" fill="#16a34a"/>
+</svg>

--- a/public/images/thumbnails/combien-coute-retraite-bien-etre-france-prix-2026.svg
+++ b/public/images/thumbnails/combien-coute-retraite-bien-etre-france-prix-2026.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1a3c34"/>
+      <stop offset="1" stop-color="#0f2620"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="1050" cy="120" r="220" fill="#16a34a" opacity="0.12"/>
+  <circle cx="120" cy="540" r="160" fill="#16a34a" opacity="0.10"/>
+  <text x="80" y="180" font-family="Georgia, serif" font-size="34" fill="#16a34a" font-weight="bold">GLP-1 FRANCE</text>
+  <text x="80" y="330" font-family="Georgia, serif" font-size="72" fill="#ffffff" font-weight="bold">Retraite bien-être</text>
+  <text x="80" y="430" font-family="Georgia, serif" font-size="72" fill="#ffffff" font-weight="bold">les vrais prix</text>
+  <text x="80" y="560" font-size="72">💶</text>
+  <rect x="80" y="470" width="120" height="6" fill="#16a34a"/>
+</svg>

--- a/public/images/thumbnails/cure-detox-arnaque-ou-efficace-avis-science.svg
+++ b/public/images/thumbnails/cure-detox-arnaque-ou-efficace-avis-science.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1a3c34"/>
+      <stop offset="1" stop-color="#0f2620"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="1050" cy="120" r="220" fill="#16a34a" opacity="0.12"/>
+  <circle cx="120" cy="540" r="160" fill="#16a34a" opacity="0.10"/>
+  <text x="80" y="180" font-family="Georgia, serif" font-size="34" fill="#16a34a" font-weight="bold">GLP-1 FRANCE</text>
+  <text x="80" y="330" font-family="Georgia, serif" font-size="72" fill="#ffffff" font-weight="bold">Cure détox :</text>
+  <text x="80" y="430" font-family="Georgia, serif" font-size="72" fill="#ffffff" font-weight="bold">arnaque ?</text>
+  <text x="80" y="560" font-size="72">🔬</text>
+  <rect x="80" y="470" width="120" height="6" fill="#16a34a"/>
+</svg>

--- a/public/images/thumbnails/peau-relachee-apres-glp1-ozempic-face-solutions.svg
+++ b/public/images/thumbnails/peau-relachee-apres-glp1-ozempic-face-solutions.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1a3c34"/>
+      <stop offset="1" stop-color="#0f2620"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="1050" cy="120" r="220" fill="#16a34a" opacity="0.12"/>
+  <circle cx="120" cy="540" r="160" fill="#16a34a" opacity="0.10"/>
+  <text x="80" y="180" font-family="Georgia, serif" font-size="34" fill="#16a34a" font-weight="bold">GLP-1 FRANCE</text>
+  <text x="80" y="330" font-family="Georgia, serif" font-size="72" fill="#ffffff" font-weight="bold">Peau relâchée</text>
+  <text x="80" y="430" font-family="Georgia, serif" font-size="72" fill="#ffffff" font-weight="bold">après GLP-1</text>
+  <text x="80" y="560" font-size="72">✨</text>
+  <rect x="80" y="470" width="120" height="6" fill="#16a34a"/>
+</svg>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -69,6 +69,7 @@ import '../styles/global.css';
           <p class="font-medium text-white mb-3">Pharmacies & Prix</p>
           <ul class="space-y-1 text-sm">
             <li><a href="/outils/carte-prix-pharmacies/" class="text-gray-300 hover:text-white transition-colors">🗺️ Carte des prix</a></li>
+            <li><a href="/outils/test-eligibilite/" class="text-gray-300 hover:text-white transition-colors">✅ Test d'éligibilité 65%</a></li>
             <li><a href="/pharmacies/" class="text-gray-300 hover:text-white transition-colors">Pharmacies par ville</a></li>
             <li><a href="/pharmacies/paris/" class="text-gray-300 hover:text-white transition-colors">Pharmacies Paris</a></li>
             <li><a href="/pharmacies/lyon/" class="text-gray-300 hover:text-white transition-colors">Pharmacies Lyon</a></li>
@@ -84,6 +85,7 @@ import '../styles/global.css';
           <p class="font-medium text-white mb-3">Santé & Nutrition</p>
           <ul class="space-y-1 text-sm">
             <li><a href="/collections/glp1-perte-de-poids/" class="text-gray-300 hover:text-white transition-colors">Perte de poids</a></li>
+            <li><a href="/retraites/" class="text-gray-300 hover:text-white transition-colors">🌿 Retraites bien-être</a></li>
             <li><a href="/guides/qu-est-ce-que-glp1/" class="text-gray-300 hover:text-white transition-colors">Qu'est-ce que le GLP-1 ?</a></li>
             <li><a href="/guides/guide-beaute-perte-de-poids-glp1/" class="text-gray-300 hover:text-white transition-colors">Guide beauté</a></li>
           </ul>

--- a/src/content/effets-secondaires-glp1/peau-relachee-apres-glp1-ozempic-face-solutions.md
+++ b/src/content/effets-secondaires-glp1/peau-relachee-apres-glp1-ozempic-face-solutions.md
@@ -1,0 +1,128 @@
+---
+title: "Peau relâchée et visage creusé après une perte de poids GLP-1 (« Ozempic face ») : les vraies solutions"
+description: "Ozempic face, peau relâchée, visage creusé après Wegovy ou Mounjaro : pourquoi ça arrive, comment le prévenir, et les solutions qui marchent vraiment en France — prix constatés des injections, radiofréquence, ultrasons et chirurgie."
+pubDate: 2026-07-14
+author: "Équipe GLP-1 France"
+category: "Effets secondaires"
+tags: ["ozempic face", "peau relâchée", "visage creusé", "perte de poids rapide", "médecine esthétique", "acide hyaluronique", "lifting"]
+collection: "effets-secondaires-glp1"
+thumbnail: "/images/thumbnails/peau-relachee-apres-glp1-ozempic-face-solutions.svg"
+thumbnailAlt: "Peau relâchée et visage creusé après perte de poids GLP-1 : solutions"
+featured: false
+published: true
+schema: "Article"
+faqSchema:
+  - question: "Qu'est-ce que l'« Ozempic face » ?"
+    answer: "C'est le nom donné à l'aspect creusé et vieilli du visage après une perte de poids rapide sous GLP-1 : joues dégonflées, tempes creuses, peau moins ferme. Ce n'est pas un effet toxique du médicament sur la peau, mais la conséquence de la fonte de la graisse sous-cutanée du visage, décrite dans la littérature dermatologique, identique à celle observée après tout amaigrissement rapide."
+  - question: "Comment prévenir le relâchement de la peau sous Wegovy ou Mounjaro ?"
+    answer: "Quatre leviers : une perte de poids progressive (respecter la titration, ne pas chercher à accélérer), un apport protéique suffisant (1,2 à 1,6 g/kg/jour), du renforcement musculaire 2 à 3 fois par semaine pour limiter la fonte musculaire, et une bonne hydratation. L'arrêt du tabac et la protection solaire aident aussi la peau à se rétracter."
+  - question: "Les crèmes raffermissantes sont-elles efficaces contre la peau relâchée ?"
+    answer: "Très peu. Aucune crème ne recrée le volume graisseux perdu ni ne retend significativement une peau distendue. Les cosmétiques peuvent améliorer l'hydratation et la qualité de surface de la peau, mais pour un relâchement visible, seules la médecine esthétique (injections, radiofréquence, ultrasons) ou la chirurgie ont un effet démontré."
+  - question: "Combien coûtent les traitements esthétiques de l'Ozempic face en France ?"
+    answer: "Prix constatés en 2026 : acide hyaluronique 300 à 450 € la seringue ; inducteurs de collagène type Sculptra 500 à 800 € le flacon (2 à 3 séances, soit 1 200 à 1 800 € au total) ou Radiesse 350 à 450 € la seringue ; radiofréquence microneedling type Morpheus8 350 à 750 € la séance (3 à 4 séances) ; ultrasons focalisés (Ultherapy) 500 à 2 800 € selon la zone. Aucun n'est remboursé."
+  - question: "La chirurgie de la peau en excès peut-elle être remboursée après une perte de poids massive ?"
+    answer: "Parfois, pour le corps : une dermolipectomie abdominale peut être prise en charge si un tablier abdominal recouvre le pubis, après entente préalable de l'Assurance Maladie (réponse sous 15 jours), fréquemment après chirurgie bariatrique — les dépassements d'honoraires restent à charge. Le lifting du visage, lui, reste un acte esthétique jamais remboursé (6 000 à 10 000 € en moyenne)."
+mainKeyword: "ozempic face"
+secondaryKeywords: ["peau relâchée après perte de poids", "visage creusé ozempic", "ozempic face solutions", "relâchement cutané GLP-1", "lifting après perte de poids"]
+---
+
+**Réponse rapide : le visage creusé et la peau relâchée après un traitement GLP-1 — surnommés « Ozempic face » — ne sont pas un effet toxique du médicament, mais la conséquence mécanique d'une perte de poids rapide** : la graisse sous-cutanée du visage fond, et la peau n'a pas le temps de se rétracter. La prévention repose sur une perte progressive, les protéines et le renforcement musculaire. Pour corriger : les crèmes ne suffisent pas ; les options efficaces vont des injections d'acide hyaluronique (300 à 450 € la seringue) aux inducteurs de collagène, à la radiofréquence et aux ultrasons focalisés, jusqu'au lifting dans les cas marqués. Voici ce qui est démontré, ce que ça coûte en France, et qui consulter.
+
+## « Ozempic face » : de quoi parle-t-on exactement ?
+
+L'expression, née aux États-Unis, désigne l'aspect que peut prendre le visage après une perte de poids importante et rapide sous sémaglutide ou tirzépatide : joues « dégonflées », pommettes aplaties, tempes et cernes creusés, sillons plus marqués, peau moins ferme donnant un air fatigué ou vieilli.
+
+Le phénomène est désormais décrit dans la littérature dermatologique : une [publication de 2024 dans *Dermatological Reviews*](https://onlinelibrary.wiley.com/doi/abs/10.1002/der2.70003) détaille la perte de volume facial, l'amincissement du derme et la diminution du collagène et de l'élastine observés lors des amaigrissements rapides sous GLP-1. Point essentiel, souligné aussi par la [Cleveland Clinic](https://health.clevelandclinic.org/ozempic-face) : **le médicament n'attaque pas la peau**. C'est l'ampleur et la vitesse de la perte de poids qui sont en cause — le même visage creusé s'observe après une chirurgie bariatrique ou un régime drastique. Les GLP-1 ont simplement rendu ces pertes de poids massives beaucoup plus fréquentes.
+
+## Pourquoi le visage se creuse et la peau se relâche
+
+### La graisse faciale est un échafaudage
+
+Le galbe du visage repose sur des compartiments graisseux profonds et superficiels (joues, pommettes, tempes, contour des yeux). Lors d'une perte de poids, l'organisme puise dans toutes ses réserves, visage compris. Or ces coussinets soutiennent la peau : quand ils fondent, la peau se retrouve « trop grande », d'où l'affaissement, comme l'explique [Medical News Today](https://www.medicalnewstoday.com/articles/ozempic-face).
+
+### La peau n'a pas le temps de suivre
+
+L'élasticité cutanée permet à la peau de se rétracter — mais lentement, et de moins en moins bien avec l'âge. Une perte de 15 à 20 % du poids corporel en un an, courante sous tirzépatide ([voir les effets secondaires de Mounjaro](/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/)), dépasse souvent les capacités de rétraction, surtout après 45-50 ans, chez les fumeurs et en cas d'exposition solaire cumulée.
+
+### Les facteurs qui aggravent le phénomène
+
+- **La vitesse et l'ampleur de la perte** : plus on perd vite et beaucoup, plus le décalage peau/volume est grand ;
+- **L'âge** : collagène et élastine diminuent naturellement ;
+- **La [fonte musculaire](/collections/regime-glp1/glp1-fonte-musculaire-preserver-muscles/)** : une partie du poids perdu sous GLP-1 est du muscle si l'alimentation et l'exercice ne suivent pas, ce qui accentue l'affaissement ;
+- **Tabac, soleil, carences** en protéines et micronutriments.
+
+À noter : le même mécanisme de « choc » lié à l'amaigrissement rapide explique la chute de cheveux observée sous ces traitements. Le [RCP européen de Mounjaro](https://www.ema.europa.eu/en/documents/product-information/mounjaro-epar-product-information_fr.pdf) classe la chute de cheveux comme effet indésirable **fréquent** chez les patients traités pour la gestion du poids (4,9 % sous tirzépatide contre 1,0 % sous placebo dans les études SURMOUNT-1, -2 et -3 poolées). Notre dossier dédié : [GLP-1 et chute de cheveux](/collections/effets-secondaires-glp1/glp1-chute-de-cheveux-alopecie-causes-solutions/).
+
+## Prévenir vaut mieux que corriger
+
+On ne peut pas choisir où l'on perd sa graisse, mais on peut limiter les dégâts :
+
+1. **Perdre progressivement.** Respectez la titration prévue par votre médecin, sans chercher à accélérer. Une perte étalée laisse à la peau le temps de se rétracter partiellement.
+2. **Protéger le muscle.** Un apport de [protéines suffisant](/collections/regime-glp1/glp1-proteines/) (1,2 à 1,6 g/kg/jour) et du renforcement musculaire 2 à 3 fois par semaine limitent la fonte de la masse maigre — y compris les muscles qui soutiennent le visage.
+3. **S'hydrater et soigner l'hygiène de vie.** Eau en quantité, arrêt du tabac, protection solaire : tout ce qui préserve le collagène aide.
+4. **S'appuyer sur un cadre.** Si vous avez du mal à structurer alimentation et activité physique pendant le traitement, un séjour encadré peut aider à installer les bonnes habitudes — voir notre [guide des retraites bien-être compatibles GLP-1](/retraites/).
+
+Le relâchement ne concerne d'ailleurs pas que le visage : bras, ventre et cuisses sont touchés aussi. Nous y consacrons un article complet : [peau relâchée sur le corps après GLP-1](/collections/effets-secondaires-glp1/glp1-relachement-cutane-peau-corps-perte-poids-solutions/).
+
+## Crèmes et cosmétiques : soyons honnêtes
+
+Aucune crème « raffermissante » ne recrée un volume graisseux perdu ni ne retend une peau réellement distendue. Les cosmétiques (rétinoïdes, vitamine C, acide hyaluronique topique) peuvent améliorer l'hydratation, l'éclat et la qualité de surface de la peau — c'est utile en complément, mais **l'effet sur un relâchement visible est marginal**. Méfiez-vous des produits vendus spécifiquement « anti-Ozempic face » : c'est du marketing surfant sur la tendance. Pour un résultat mesurable, il faut passer aux traitements médicaux.
+
+## Médecine esthétique en France : options et prix constatés (2026)
+
+Toutes ces techniques relèvent d'un médecin (dermatologue, médecin esthétique) et **aucune n'est remboursée** — ce sont des actes esthétiques. Les prix ci-dessous sont des tarifs publics constatés en juillet 2026 ; exigez toujours un devis et vérifiez la qualification du praticien.
+
+### Acide hyaluronique : restaurer le volume, effet immédiat
+
+Le traitement de première intention pour les joues, pommettes, tempes et sillons creusés. Résultat immédiat, durée de 12 à 18 mois. Prix constatés : [300 à 450 € la seringue](https://www.skinclinik.fr/medecine-esthetique/injections-acide-hyaluronique/prix-injection-acide-hyaluronique/), un traitement des sillons nasogéniens revenant par exemple à environ 700 € (2 seringues). Un visage globalement creusé nécessite souvent plusieurs seringues : budgétez en conséquence.
+
+### Inducteurs de collagène (Sculptra, Radiesse) : plus progressif, plus durable
+
+Ces injectables stimulent la production de collagène plutôt que de combler ponctuellement — une logique adaptée aux visages « dégonflés » après perte de poids. Pour le Sculptra (acide poly-L-lactique), comptez [500 à 800 € le flacon, avec un protocole de 2 à 3 séances, soit 1 200 à 1 800 € au total](https://medecine-esthetique-cassis.fr/injection-sculptra-prix/) ; les résultats s'installent en quelques semaines et durent 2 ans et plus. Le Radiesse (hydroxyapatite de calcium) est facturé [350 à 450 € la seringue](https://medecine-esthetique-cassis.fr/inducteurs-tissulaires-prix/).
+
+### Radiofréquence microneedling (type Morpheus8) : retendre modérément
+
+La radiofréquence fractionnée délivrée par micro-aiguilles chauffe le derme pour induire une rétraction et une néosynthèse de collagène. Utile pour un relâchement léger à modéré du bas du visage et du cou. Prix constatés à Paris : [350 à 750 € la séance, avec un protocole de 3 à 4 séances espacées de 4 à 6 semaines](https://esthetique-rivedroite.paris/morpheus-8/) — soit un budget global de l'ordre de 1 000 à 3 000 €.
+
+### Ultrasons focalisés (Ultherapy) : l'« effet lifting » sans chirurgie
+
+Les ultrasons microfocalisés ciblent le plan profond (SMAS) pour retendre l'ovale. Une seule séance le plus souvent, résultat progressif sur 3 à 6 mois. Prix constatés : [de 500 € (zone limitée) à 2 800 € pour le visage complet](https://www.centrelaserclipp.com/techniques/ulthera/) selon les zones traitées. Efficace sur un relâchement modéré ; insuffisant si l'excès de peau est important.
+
+## Chirurgie : quand la perte de poids a été massive
+
+Après une perte de 25, 30 ou 40 kg, l'excès cutané peut dépasser ce que la médecine esthétique peut corriger. C'est le terrain du **chirurgien plasticien**.
+
+- **Lifting cervico-facial** : il retire l'excès de peau et retend les plans profonds du visage et du cou. Prix constatés en France : [6 000 à 10 000 € en moyenne](https://docteur-picovski.com/prix/lifting-visage/). Acte esthétique : **jamais remboursé**.
+- **Dermolipectomie (corps)** : pour le tablier abdominal, une prise en charge par l'Assurance Maladie est possible — situation fréquente après chirurgie bariatrique, et envisageable après une perte massive sous GLP-1. Le critère clé est un [tablier abdominal recouvrant le pubis, constaté par le chirurgien puis validé par le médecin-conseil](https://docteur-picovski.com/faq/prise-en-charge-secu-abdominoplastie/) ; la demande d'[entente préalable est réputée acceptée sans réponse de la CPAM sous 15 jours](https://www.april.fr/complementaire-sante/guide/abdominoplastie). Attention : la prise en charge couvre l'hospitalisation et l'acte de base, mais **les dépassements d'honoraires du chirurgien et de l'anesthésiste restent à votre charge**.
+
+Règle de bon sens partagée par les chirurgiens : opérer sur un **poids stabilisé depuis au moins 6 à 12 mois**, jamais en pleine phase de perte.
+
+## En pratique : qui consulter, dans quel ordre ?
+
+1. **Pendant la perte de poids** : votre médecin prescripteur pour ajuster le rythme, un diététicien pour sécuriser les protéines. Ne faites rien d'esthétique tant que le poids bouge.
+2. **Poids stabilisé, gêne modérée** : consultez un **dermatologue ou un médecin esthétique** — il hiérarchisera entre injections, radiofréquence et ultrasons selon votre peau et votre budget.
+3. **Excès cutané important** : consultez un **chirurgien plasticien** qualifié (vérifiez l'inscription à l'Ordre et la spécialité en chirurgie plastique, reconstructrice et esthétique) et demandez plusieurs devis.
+
+Gardez la mesure : un visage un peu creusé n'est pas une maladie, et beaucoup de patients trouvent que le bénéfice cardiométabolique et fonctionnel de la perte de poids l'emporte largement. Si le regard des autres ou le vôtre pèse, parlez-en aussi — le retentissement psychologique d'une transformation corporelle rapide est réel et se travaille.
+
+## FAQ : Ozempic face et peau relâchée
+
+### Qu'est-ce que l'« Ozempic face » ?
+
+L'aspect creusé et vieilli du visage après une perte de poids rapide sous GLP-1 : joues dégonflées, tempes creuses, peau moins ferme. Ce n'est pas un effet toxique du médicament mais la fonte de la graisse sous-cutanée faciale, décrite dans la [littérature dermatologique](https://onlinelibrary.wiley.com/doi/abs/10.1002/der2.70003), identique à celle de tout amaigrissement rapide.
+
+### Comment prévenir le relâchement de la peau sous Wegovy ou Mounjaro ?
+
+Perte progressive (respecter la titration), protéines suffisantes (1,2 à 1,6 g/kg/jour), renforcement musculaire 2 à 3 fois par semaine pour limiter la [fonte musculaire](/collections/regime-glp1/glp1-fonte-musculaire-preserver-muscles/), hydratation, arrêt du tabac et protection solaire.
+
+### Les crèmes raffermissantes sont-elles efficaces contre la peau relâchée ?
+
+Très peu. Aucune crème ne recrée le volume perdu ni ne retend significativement une peau distendue. Elles améliorent l'hydratation et la qualité de surface, mais pour un relâchement visible, seules la médecine esthétique ou la chirurgie ont un effet démontré.
+
+### Combien coûtent les traitements esthétiques de l'Ozempic face en France ?
+
+Prix constatés 2026 : acide hyaluronique [300 à 450 € la seringue](https://www.skinclinik.fr/medecine-esthetique/injections-acide-hyaluronique/prix-injection-acide-hyaluronique/) ; Sculptra [500 à 800 € le flacon, 1 200 à 1 800 € le protocole complet](https://medecine-esthetique-cassis.fr/injection-sculptra-prix/) ; Morpheus8 [350 à 750 € la séance, 3 à 4 séances](https://esthetique-rivedroite.paris/morpheus-8/) ; Ultherapy [500 à 2 800 € selon la zone](https://www.centrelaserclipp.com/techniques/ulthera/). Aucun n'est remboursé.
+
+### La chirurgie de la peau en excès peut-elle être remboursée après une perte de poids massive ?
+
+Pour le corps, oui dans certains cas : la dermolipectomie abdominale peut être prise en charge si un [tablier abdominal recouvre le pubis](https://docteur-picovski.com/faq/prise-en-charge-secu-abdominoplastie/), après entente préalable de la CPAM — les dépassements d'honoraires restent à charge. Le lifting du visage reste un acte esthétique non remboursé (6 000 à 10 000 € en moyenne).

--- a/src/content/retraites-bien-etre/brides-les-bains-avis-prix-resultats-cure-minceur.md
+++ b/src/content/retraites-bien-etre/brides-les-bains-avis-prix-resultats-cure-minceur.md
@@ -1,0 +1,147 @@
+---
+title: "Brides-les-Bains : avis, prix, résultats — la cure minceur remboursée par la Sécu vaut-elle le coup ?"
+description: "Cure thermale amaigrissement de Brides-les-Bains : prix réel 2026 après remboursement, résultats mesurés par l'étude Maâthermes, avis honnêtes des curistes (le positif et le négatif) et compatibilité avec Wegovy ou Mounjaro."
+pubDate: 2026-07-14
+author: "Équipe GLP-1 France"
+category: "Retraites et séjours"
+tags: ["brides-les-bains", "cure thermale", "perte de poids", "remboursement", "avis", "wegovy"]
+collection: "retraites-bien-etre"
+thumbnail: "/images/thumbnails/brides-les-bains-avis-prix-resultats-cure-minceur.svg"
+thumbnailAlt: "Brides-les-Bains avis, prix et résultats de la cure minceur remboursée"
+featured: false
+published: true
+schema: "Article"
+faqSchema:
+  - question: "Combien coûte réellement une cure à Brides-les-Bains en 2026 ?"
+    answer: "Après remboursement de l'Assurance Maladie (65 % du forfait thermal, 70 % de la surveillance médicale), il reste à votre charge environ 290 € de soins (ticket modérateur + complément tarifaire de 97,73 €), auxquels s'ajoutent l'hébergement (450 à 780 € les 3 semaines en studio) et les options non remboursées comme le programme Idéal (420 €). Budget total réaliste : 1 000 à 1 500 € pour 3 semaines."
+  - question: "La cure de Brides-les-Bains fait-elle vraiment maigrir ?"
+    answer: "L'étude Maâthermes, menée sur 257 personnes en surpoids ou obèses, a mesuré une perte de poids moyenne de 3,86 kg (4,6 % du poids corporel) 14 mois après la cure, contre environ 1,5 kg dans le groupe témoin suivi classiquement. 45 % des curistes avaient perdu plus de 5 % de leur poids initial. C'est un résultat réel mais modeste : la cure est un déclencheur, pas un traitement de l'obésité à elle seule."
+  - question: "Que pensent les curistes de Brides-les-Bains ?"
+    answer: "Sur les plateformes d'avis spécialisées, la station obtient environ 7,9/10. Les curistes saluent l'encadrement diététique, les ateliers et la dynamique de groupe. Les critiques récurrentes portent sur la brièveté des soins thermaux quotidiens (quelques minutes de jets ou massages plus un bain en piscine), l'attente en haute saison et l'absence de suivi structuré après le retour à la maison."
+  - question: "Peut-on faire la cure de Brides-les-Bains sous Wegovy ou Mounjaro ?"
+    answer: "Oui, il n'existe pas de contre-indication générale, et la cure est médicalement encadrée : le médecin thermal vous reçoit en consultation en début de cure et adapte le programme. Signalez impérativement votre traitement GLP-1, car ces médicaments ralentissent la vidange gastrique et peuvent interagir avec la cure de boisson et le programme alimentaire. Les deux remboursements (médicament à 65 % depuis le 15 juin 2026 et cure thermale) sont cumulables."
+  - question: "Comment obtenir la prescription pour une cure remboursée à Brides-les-Bains ?"
+    answer: "Demandez à votre médecin traitant (ou à un spécialiste) de remplir le questionnaire de prise en charge en orientation AD (affections digestives et maladies métaboliques), envoyez-le à votre caisse d'Assurance Maladie et attendez l'accord préalable avant de réserver vos dates. La saison thermale 2026 court du 23 mars au 31 octobre."
+mainKeyword: "brides les bains avis"
+secondaryKeywords: ["cure brides les bains prix", "brides les bains cure minceur", "cure thermale amaigrissement avis", "brides les bains resultats", "cure brides les bains remboursement"]
+---
+
+**Réponse rapide** : oui, la cure de Brides-les-Bains « vaut le coup » — mais à condition de savoir ce qu'on achète. Pour environ **1 000 à 1 500 € de reste à charge** (soins remboursés à 65 %, hébergement non remboursé), vous obtenez 18 jours d'encadrement médical, diététique et sportif dont l'efficacité a été mesurée : **3,86 kg perdus en moyenne, encore 14 mois après la cure** ([étude Maâthermes](https://thermalinfos.fr/etude-maathermes/)). Ce n'est ni un séjour miracle ni un spa de luxe : c'est un déclic médicalisé, avec de vrais points faibles que le site officiel ne vous dira pas — nous, si.
+
+Brides-les-Bains, en Savoie, est la **première station thermale française de l'amaigrissement**, avec environ 12 000 curistes par an ([Location-cure.net](https://www.location-cure.net/station-thermale/brides-les-bains-73570)). Voici les prix vérifiés 2026, les résultats mesurés, les avis honnêtes — et la réponse à la question que de plus en plus de patients se posent : peut-on y aller sous Wegovy ou Mounjaro ?
+
+## La cure conventionnée 18 jours : ce que c'est concrètement
+
+La cure « amaigrissement » de Brides-les-Bains relève de l'orientation **AD (affections digestives et maladies métaboliques)**. C'est une cure **conventionnée de 18 jours de soins**, délivrés du lundi au samedi, jours fériés inclus — soit trois semaines sur place ([Thermes de Brides-les-Bains](https://www.thermes-brideslesbains.fr/cure-thermale-conventionnee)).
+
+Au programme, validé par le médecin thermal en début de séjour :
+
+- **Soins thermaux quotidiens** : cure de boisson (l'eau de Brides est réputée pour ses effets sur le transit), bains, douches au jet, massages sous l'eau ;
+- **Volet diététique** : consultations avec des diététiciens, ateliers de cuisine, conférences nutrition ;
+- **Activité physique adaptée** : programme structuré avec des éducateurs sportifs ;
+- **Suivi médical** : consultations du médecin thermal qui encadre la cure du début à la fin.
+
+L'établissement propose en option le **programme Idéal** (420 €, non remboursé), la formule la plus complète intégrant diététique et activité physique renforcées ([Thermes de Brides-les-Bains](https://reservation.thermes-brideslesbains.fr/fr/produits/cures-conventionnees/cure-thermale-amaigrissement-ad-programme-ideal)).
+
+La **saison thermale 2026** court du **23 mars au 31 octobre** ([Thermes de Brides-les-Bains](https://www.thermes-brideslesbains.fr/)).
+
+## Prix 2026 : ce que rembourse la Sécu, ce qui reste à payer
+
+C'est le point qui fait la réputation de Brides : la cure est **remboursée par l'Assurance Maladie** sur prescription médicale — 65 % du forfait thermal et 70 % de la surveillance médicale ([ameli.fr](https://www.ameli.fr/assure/remboursements/rembourse/cure-thermale)). Mais « remboursée » ne veut pas dire gratuite. Voici le vrai décompte.
+
+| Poste | Prix 2026 | Remboursement | Reste à charge |
+|---|---|---|---|
+| Forfait thermal AD (72 séances) | 542,45 € (tarif de responsabilité) | 65 % soit ~352,59 € | ~189,86 € |
+| Complément tarifaire (non remboursable) | 97,73 € | 0 % | 97,73 € |
+| Surveillance médicale (médecin thermal) | ~80 € | 70 % | ~24 € |
+| Programme Idéal (option) | 420 € | 0 % | 420 € (facultatif) |
+| Hébergement 3 semaines (studio) | 450 à 780 € | 0 %* | 450 à 780 € |
+| **Total réaliste sans option** | — | — | **≈ 800 à 1 100 €** |
+| **Total avec programme Idéal** | — | — | **≈ 1 200 à 1 500 €** |
+
+Sources : [grille tarifaire des Thermes de Brides-les-Bains](https://www.thermes-brideslesbains.fr/cure-thermale-conventionnee/tarif-cure-thermale) (forfait AD à 542,45 € en tarif forfaitaire de responsabilité, 640,18 € en tarif limite de facturation — la différence de **97,73 €** constitue le complément tarifaire à votre charge), [ameli.fr](https://www.ameli.fr/assure/remboursements/rembourse/cure-thermale) pour les taux.
+
+*Sous conditions de ressources (revenus 2025 inférieurs à **14 664,38 €**, majorés de 50 % par ayant droit), l'Assurance Maladie participe aux frais d'hébergement à hauteur de 65 % d'une base forfaitaire de 150,01 €, soit **97,50 €**, et à une partie du transport sur la base du billet SNCF aller-retour en 2e classe ([Aide-sociale.fr](https://www.aide-sociale.fr/cure-thermale-prise-en-charge/)).
+
+Côté logement, les studios pour curistes se louent entre **450 et 780 € les trois semaines** selon la saison et le standing, avec une moyenne autour de 700 € ([Les Curistes](https://www.lescuristes.fr/location-magnifique-studio---classe-2--parfait-pour-votre-cure--3-semaines---780-euros---tout-inclus-brides-les-bains_12427), [Location-cure.net](https://www.location-cure.net/location-brides-les-bains-73570)). Une bonne mutuelle peut par ailleurs couvrir tout ou partie du ticket modérateur : le détail complet des cumuls est dans notre guide [Wegovy remboursé + cure thermale remboursée](/collections/retraites-bien-etre/wegovy-rembourse-cure-thermale-protocole-minceur-moins-cher/).
+
+## Les résultats : ce que dit l'étude Maâthermes (et ce qu'elle ne dit pas)
+
+Brides-les-Bains ne repose pas que sur du marketing : l'efficacité de la cure thermale sur le surpoids a été évaluée par l'étude clinique contrôlée **Maâthermes**, menée sur **257 personnes** en surpoids ou obèses, âgées en moyenne de 51 ans ([Médecine thermale](https://www.medecinethermale.fr/medecins/la-medecine-thermale-aujourdhui/la-recherche-thermale/letude-maathermes.html)).
+
+| Résultat à 14 mois | Groupe cure thermale | Groupe témoin (suivi classique) |
+|---|---|---|
+| Perte de poids moyenne | **3,86 kg (4,6 % du poids)** | ~1,5 kg |
+| Ont perdu plus de 5 % du poids initial | **45 %** | nettement moins |
+
+Source : [Thermalinfos — étude Maâthermes](https://thermalinfos.fr/etude-maathermes/).
+
+Lecture honnête de ces chiffres : la cure fait **deux à trois fois mieux qu'un suivi médical classique**, et l'effet persiste plus d'un an — ce qui est rare dans la perte de poids. Mais 3,86 kg en moyenne reste un résultat **modeste** : pour une personne avec un IMC de 35 ou plus, la cure seule ne constitue pas un traitement de l'obésité. C'est un accélérateur de changement d'habitudes, pas une solution autonome — d'où l'intérêt croissant de la combiner avec un traitement GLP-1 (voir plus bas).
+
+## Avis des curistes : le positif ET le négatif
+
+Le site officiel des Thermes publie une [page d'avis clients](https://www.thermes-brideslesbains.fr/avis-cure-thermale) — forcément flatteuse. Voici une synthèse plus équilibrée, tirée des plateformes indépendantes et des forums.
+
+### La note globale
+
+Sur la plateforme spécialisée Thermes.biz, les curistes certifiés attribuent à Brides-les-Bains une note moyenne de **7,9/10** : propreté 8,6, personnel 7,9, soins 7,8, organisation 7,4 ([Thermes.biz](https://www.thermes.biz/cure/brides-les-bains-73570)). Sur Location-cure.net, **90,3 % des curistes se disent satisfaits des résultats obtenus** ([Location-cure.net](https://www.location-cure.net/station-thermale/brides-les-bains-73570)).
+
+### Ce que les curistes apprécient
+
+- **L'encadrement diététique** : ateliers cuisine, conférences, consultations — la diététicienne et blogueuse Ariane Grumbach décrit une station entièrement organisée autour de la rééducation alimentaire, jusqu'aux menus adaptés des hôtels et restaurants ([arianegrumbach.com](https://www.arianegrumbach.com/de-retour-de-brides-les-bains/)) ;
+- **La dynamique de groupe** : trois semaines entouré de personnes qui partagent le même objectif, ce qui aide à tenir ;
+- **Des résultats tangibles** : des curistes rapportent 2,5 à 5 kg perdus et plusieurs centimètres de tour de taille pendant le séjour ([Les Curistes](https://www.lescuristes.fr/q/quels-sont-vos-retours-concernant-la-cure-thermale-de-brides-les-bains-y_2968)) ;
+- **Le cadre** : village thermal calme au pied des Trois Vallées, tout se fait à pied.
+
+### Ce que les curistes critiquent
+
+- **Des soins thermaux courts** : plusieurs curistes déchantent en découvrant que les soins quotidiens se résument parfois à 5-10 minutes de jets ou massages plus 15 minutes de bain en piscine ([Les Curistes](https://www.lescuristes.fr/q/quels-sont-vos-retours-concernant-la-cure-thermale-de-brides-les-bains-y_2968)). La valeur de la cure est dans l'accompagnement global, pas dans le volume de soins ;
+- **L'attente et l'affluence** en haute saison (12 000 curistes par an dans un petit village) ;
+- **L'après-cure** : c'est la critique la plus sérieuse. Des curistes qui n'ont pas modifié leurs comportements en profondeur se disent « perdus » au retour, sans suivi structuré — et reprennent du poids ;
+- **Le coût réel** : entre hébergement, options et repas, la « cure remboursée » coûte en pratique un vrai budget de vacances.
+
+**Notre verdict** : Brides-les-Bains vaut le coup si vous y allez pour apprendre à manger et bouger autrement, avec trois semaines devant vous et un budget d'environ 1 200 €. Elle décevra ceux qui attendent des soins spa intensifs ou une perte de poids spectaculaire. Pour comparer avec d'autres formules, consultez notre [comparatif des meilleures retraites perte de poids en France](/collections/retraites-bien-etre/meilleures-retraites-perte-de-poids-france-prix/).
+
+## Sous Wegovy ou Mounjaro : la cure est-elle compatible ?
+
+C'est la nouvelle question de la saison 2026. Depuis le **15 juin 2026**, Wegovy (sémaglutide) et Mounjaro (tirzépatide) sont **remboursés à 65 %** par l'Assurance Maladie pour les patients avec un IMC ≥ 35 accompagné d'au moins une comorbidité (ou IMC ≥ 40), après échec d'une prise en charge nutritionnelle de 6 mois, avec une primo-prescription réservée aux spécialistes de l'obésité (CSO, services hospitaliers) ([Vidal](https://www.vidal.fr/actualites/37850-obesite-prise-en-charge-de-wegovy-et-mounjaro-a-partir-du-15-juin-2026-sous-conditions.html)).
+
+Cure et traitement GLP-1 sont-ils compatibles ? **Oui, avec un encadrement médical — qui existe précisément sur place** :
+
+- La cure est supervisée par un **médecin thermal** qui vous reçoit en consultation dès le début du séjour et adapte le protocole de soins ; l'équipe pluridisciplinaire (médecin, diététiciens, éducateurs sportifs) accompagne chaque curiste ([Brides-les-Bains](https://www.brides-les-bains.com/ete/en/courses-of-spa-treatments/)) ;
+- Il n'existe **pas de contre-indication générale** connue entre GLP-1 et cure thermale, mais les GLP-1 ralentissent la vidange gastrique et provoquent fréquemment nausées ou troubles digestifs : la cure de boisson et le programme alimentaire hypocalorique doivent donc être ajustés par le médecin thermal — signalez impérativement votre traitement ;
+- Les **deux remboursements se cumulent** : ce sont des prises en charge distinctes de l'Assurance Maladie. Le montage complet est détaillé dans notre article [Wegovy remboursé + cure thermale : le protocole minceur le moins cher de France](/collections/retraites-bien-etre/wegovy-rembourse-cure-thermale-protocole-minceur-moins-cher/).
+
+Vous ne savez pas si vous remplissez les critères de remboursement du médicament ? Faites notre [test d'éligibilité Wegovy/Mounjaro](/outils/test-eligibilite/) en 2 minutes.
+
+## Comment obtenir la prescription (étapes concrètes)
+
+1. **Consultez votre médecin traitant** (ou un spécialiste) : c'est lui qui remplit le questionnaire de prise en charge en précisant l'orientation **AD** et la station Brides-les-Bains ([ameli.fr](https://www.ameli.fr/assure/remboursements/rembourse/cure-thermale)) ;
+2. **Envoyez le formulaire à votre caisse d'Assurance Maladie**, avec la déclaration de ressources si vous demandez les aides transport/hébergement ;
+3. **Attendez l'accord de prise en charge** avant de réserver quoi que ce soit ;
+4. **Réservez la cure** auprès des Thermes (saison du 23 mars au 31 octobre 2026) puis votre hébergement — les studios les mieux placés partent des mois à l'avance ;
+5. Sur place, la **consultation du médecin thermal** en début de cure fixe votre programme personnalisé.
+
+Pour explorer d'autres formats de séjours encadrés (jeûne, sport, cliniques européennes), parcourez notre [hub des retraites et séjours perte de poids](/retraites/).
+
+## FAQ — Brides-les-Bains : avis, prix, résultats
+
+### Combien coûte réellement une cure à Brides-les-Bains en 2026 ?
+
+Après remboursement (65 % du forfait thermal, 70 % de la surveillance médicale), il reste environ 290 € de soins à votre charge (ticket modérateur + complément tarifaire de 97,73 €), plus l'hébergement (450 à 780 € les 3 semaines en studio) et les options comme le programme Idéal (420 €). Budget total réaliste : 1 000 à 1 500 €.
+
+### La cure de Brides-les-Bains fait-elle vraiment maigrir ?
+
+L'étude Maâthermes (257 participants) a mesuré 3,86 kg perdus en moyenne 14 mois après la cure, contre environ 1,5 kg avec un suivi classique ; 45 % des curistes avaient perdu plus de 5 % de leur poids. Résultat réel, durable, mais modeste : la cure est un déclencheur, pas un traitement de l'obésité à elle seule.
+
+### Que pensent les curistes de Brides-les-Bains ?
+
+Environ 7,9/10 sur les plateformes d'avis certifiés. Points forts : encadrement diététique, ateliers, dynamique de groupe. Critiques récurrentes : soins thermaux quotidiens courts, affluence en haute saison, et surtout absence de suivi structuré après le retour.
+
+### Peut-on faire la cure sous Wegovy ou Mounjaro ?
+
+Oui : pas de contre-indication générale, et le médecin thermal adapte le programme en consultation de début de cure. Signalez votre traitement (les GLP-1 ralentissent la vidange gastrique). Les remboursements du médicament (65 % depuis le 15 juin 2026) et de la cure sont cumulables.
+
+### Comment obtenir la prescription pour une cure remboursée ?
+
+Votre médecin traitant remplit le questionnaire de prise en charge en orientation AD, vous l'envoyez à votre caisse, et vous attendez l'accord préalable avant de réserver. Saison 2026 : du 23 mars au 31 octobre.

--- a/src/content/retraites-bien-etre/combien-coute-retraite-bien-etre-france-prix-2026.md
+++ b/src/content/retraites-bien-etre/combien-coute-retraite-bien-etre-france-prix-2026.md
@@ -1,0 +1,142 @@
+---
+title: "Combien coûte une retraite bien-être en France ? Les vrais prix 2026 (de 62 € à 1 000 € par jour)"
+description: "Cure thermale, jeûne et randonnée, yoga, thalasso, séjour sportif, clinique longevity : les vrais prix 2026 des retraites bien-être en France, vérifiés et sourcés, avec ce qui est remboursable et les astuces pour payer moins."
+pubDate: 2026-07-14
+author: "Équipe GLP-1 France"
+category: "Retraites et séjours"
+tags: ["retraite bien-être", "prix", "cure thermale", "jeûne", "yoga", "thalasso", "budget"]
+collection: "retraites-bien-etre"
+thumbnail: "/images/thumbnails/combien-coute-retraite-bien-etre-france-prix-2026.svg"
+thumbnailAlt: "Combien coûte une retraite bien-être en France, les vrais prix 2026 par catégorie"
+featured: false
+published: true
+schema: "Article"
+faqSchema:
+  - question: "Quel est le prix moyen d'une retraite bien-être en France en 2026 ?"
+    answer: "Comptez de 62 € par jour tout compris pour une cure thermale conventionnée (après remboursement de l'Assurance Maladie) à plus de 1 000 € par jour dans une clinique longevity comme Lanserhof ou SHA. Entre les deux : jeûne et randonnée à partir de 540 € la semaine, retraite yoga de 650 à 1 500 € la semaine, séjour sportif tout compris dès 790 € la semaine, thalasso de 950 à 2 400 € la semaine de cure."
+  - question: "Quelle est la retraite bien-être la moins chère en France ?"
+    answer: "La cure thermale conventionnée de 18 jours, car c'est la seule partiellement remboursée par l'Assurance Maladie (65 % du forfait thermal, 70 % de la surveillance médicale, sur prescription médicale). Reste à charge total réaliste avec hébergement : environ 1 000 à 1 400 € pour 3 semaines, soit à partir d'environ 62 € par jour. Le jeûne et randonnée en chambre partagée (dès 540 € la semaine) est l'alternative courte la plus économique."
+  - question: "Une retraite bien-être est-elle remboursée par la Sécurité sociale ?"
+    answer: "Seule la cure thermale conventionnée, prescrite par un médecin dans une station agréée, est partiellement remboursée. La thalassothérapie n'est plus prise en charge depuis 1998, et les retraites yoga, jeûne, séjours sportifs ou cliniques longevity ne sont jamais remboursés. Sous conditions de ressources (plafond 14 664,38 €), la CPAM ajoute une aide à l'hébergement (97,50 €) et au transport pour la cure thermale."
+  - question: "Pourquoi les prix des retraites bien-être varient-ils autant ?"
+    answer: "Cinq facteurs expliquent l'écart de 1 à 15 : le niveau d'hébergement (chambre partagée vs hôtel 5 étoiles), la présence d'encadrement médical (médecins, bilans, examens), la taille du groupe (retraite collective vs programme individuel), la saison (haute saison estivale plus chère) et la localisation (la Côte d'Azur affiche des prix environ 30 % au-dessus de la moyenne nationale)."
+  - question: "Comment payer sa retraite bien-être moins cher ?"
+    answer: "Partez hors saison (studios curistes à 695 € au printemps contre 780 € l'été à Brides-les-Bains), réservez la cure et l'hébergement séparément plutôt qu'en formule packagée, choisissez la chambre partagée pour le jeûne ou le yoga, profitez des tarifs dégressifs à la semaine, et vérifiez votre éligibilité aux aides CPAM (cure thermale sous conditions de ressources) ainsi qu'aux aides des caisses de retraite."
+mainKeyword: "retraite bien-être prix"
+secondaryKeywords: ["combien coûte une retraite bien-être", "prix retraite spirituelle france", "tarif jeûne et randonnée", "prix thalasso semaine", "cure thermale prix par jour", "retraite yoga prix"]
+---
+
+**Réponse rapide** : en France, une retraite bien-être coûte entre **62 € par jour** (cure thermale conventionnée de 3 semaines, seule formule partiellement remboursée par la Sécu) et **plus de 1 000 € par jour** (cliniques longevity type Lanserhof ou SHA). Entre les deux : le jeûne et randonnée dès **540 € la semaine**, la retraite yoga entre **650 et 1 500 € la semaine**, le séjour sportif tout compris dès **790 € la semaine** et la thalasso entre **950 et 2 400 € la semaine**. Tous ces chiffres sont vérifiés et sourcés ci-dessous — avec ce qui est remboursable, ce qui ne l'est pas, et les astuces pour payer moins.
+
+## Le tableau des vrais prix 2026, catégorie par catégorie
+
+| Type de retraite | Prix constaté 2026 | Prix par jour | Remboursable ? |
+|---|---|---|---|
+| Cure thermale conventionnée (18 jours) | ~1 000-1 400 € de reste à charge, hébergement inclus | **à partir de ~62 €** | Oui, partiellement |
+| Jeûne et randonnée (semaine) | 540 à ~1 500 € | ~77 à 215 € | Non |
+| Retraite yoga (semaine) | 650 à 1 500 € | ~90 à 215 € | Non |
+| Séjour sportif / perte de poids (semaine) | dès 790 € tout compris | ~113 € | Non |
+| Thalasso (semaine de cure) | 950 à 2 400 € | ~135 à 400 € | Non |
+| Clinique luxe / longevity (7 jours) | 7 400 à 7 500 € et plus | **1 000 € et plus** | Non |
+
+Détail et sources pour chaque ligne ci-dessous.
+
+### Cure thermale conventionnée : la moins chère, car remboursée
+
+C'est l'exception française : la cure thermale de 18 jours, prescrite par un médecin dans une station agréée, est **prise en charge par l'Assurance Maladie** — 65 % du forfait thermal, 70 % de la surveillance médicale ([ameli.fr](https://www.ameli.fr/assure/remboursements/rembourse/cure-thermale)).
+
+Exemple chiffré à Brides-les-Bains, première station de l'amaigrissement : forfait thermal AD à 542,45 €, remboursé à 65 %, plus un complément tarifaire de 97,73 € non remboursable ([Thermes de Brides-les-Bains](https://www.thermes-brideslesbains.fr/cure-thermale-conventionnee/tarif-cure-thermale)). Reste à charge sur les soins : environ **290 €**. Ajoutez l'hébergement — studios curistes entre 450 et 780 € les 3 semaines ([Location-cure.net](https://www.location-cure.net/location-brides-les-bains-73570)) — et le budget total tourne autour de **1 000 à 1 400 € pour 21 jours**, soit **à partir d'environ 62 € par jour**, encadrement médical, diététique et sportif compris.
+
+Aucune autre formule ne descend à ce niveau de prix par jour avec un médecin sur place. Notre analyse complète : [Brides-les-Bains — avis, prix, résultats](/collections/retraites-bien-etre/brides-les-bains-avis-prix-resultats-cure-minceur/).
+
+### Jeûne et randonnée : dès 540 € la semaine
+
+Le format popularisé par la méthode Buchinger : une semaine de jeûne (ou monodiète) encadrée, avec randonnées quotidiennes. Les prix constatés en 2026 :
+
+- **À partir de 540 € la semaine** en Provence chez Jeux, Jeûne et Randonnée ([jeux-jeune-rando.com](https://www.jeux-jeune-rando.com/des-tarifs-abordables-pour-nos-sejours-jeune-et-randonnee/)) ;
+- **699 à 799 € le stage** (selon formule jeûne ou jus/monodiète) chez Le Genêt, hébergement en sus à partir de 35 €/nuit en chambre partagée ([le-genet.com](https://www.le-genet.com/tarifs-de-nos-stages-de-jeune)) ;
+- Le haut de gamme du secteur peut atteindre environ 1 500 € la semaine en chambre individuelle avec accompagnement renforcé.
+
+Soit **77 à 215 € par jour**. Pour trouver un séjour, le calendrier officiel de la Fédération Francophone de Jeûne et Randonnée recense les stages agréés ([ffjr.com](https://www.ffjr.com/trouver-un-sejour-de-jeune-et-randonnee/calendrier-des-sejours/)). Attention si vous prenez un traitement GLP-1 : jeûner sous Wegovy ou Mounjaro nécessite un avis médical — nous avons interrogé la question dans notre article dédié, accessible depuis le [hub retraites et séjours](/retraites/).
+
+### Retraite yoga : 650 à 1 500 € la semaine
+
+Les fourchettes réelles constatées en France pour 2026 : **180 à 450 € le week-end** et **650 à 1 200 € la semaine** selon les régions et prestations ([Santé Racine](https://santeracine.fr/decouvrez-les-meilleures-retraites-de-yoga-en-france-pour-2026.php)), certaines plateformes situant plutôt la semaine entre **900 et 1 500 €** avec pension complète ([Pasithéa Retreats](https://www.pasithea-retreats.com/retraite-yoga-france/)).
+
+La région pèse lourd : la Côte d'Azur et l'Île-de-France affichent des prix environ **30 % au-dessus de la moyenne nationale**, quand l'Ardèche ou le Cantal restent accessibles ([Santé Racine](https://santeracine.fr/decouvrez-les-meilleures-retraites-de-yoga-en-france-pour-2026.php)). Chambre individuelle, repas bio et nombre de séances quotidiennes font le reste de l'écart.
+
+### Séjour sportif / perte de poids : dès 790 € la semaine tout compris
+
+Les stages de remise en forme encadrés par des coachs diplômés affichent des tarifs étonnamment contenus grâce à l'hébergement partagé. Exemple vérifié : **790 € la semaine tout compris** (hébergement, pension complète, 2 séances de coaching par jour, bilan initial) chez Coaching Village, avec tarif dégressif à **613 €/semaine** pour un séjour de 3 semaines ([coaching-village.com](https://www.coaching-village.com/pages/sejours-et-tarifs/stage-perte-de-poids.html)) — soit environ **113 € par jour**. D'autres opérateurs (Vercors Fitness Camp, RVR Training) proposent des formats comparables d'une à deux semaines.
+
+Pour un panorama complet des séjours orientés perte de poids, consultez notre [comparatif des meilleures retraites minceur en France](/collections/retraites-bien-etre/meilleures-retraites-perte-de-poids-france-prix/).
+
+### Thalasso : 950 à 2 400 € la semaine de cure
+
+La thalassothérapie utilise l'eau de mer, sans prescription médicale — et **n'est plus remboursée depuis 1998**, car considérée comme une pratique de confort ([SGCA](https://www.sgca.fr/medical-et-sante/thalasso-remboursement.html), [Matmut](https://www.matmut.fr/mutuelle/conseils/differences-thalassotherapie-cure-thermale)).
+
+Référence du secteur, le Sofitel Quiberon Thalassa Sea & Spa : week-end 2 nuits **à partir de 400 €**, cure de 6-7 jours **de 950 à 2 400 € tout compris**, forfait soins seuls « Intermède Marin » à **135 €/jour** (145 € week-ends et vacances scolaires) ([Promo Thalasso](https://www.promothalasso.com/hotel-thalasso/bretagne/quiberon)). Comptez donc **135 à 400 € par jour** selon l'hôtel et la saison.
+
+### Clinique luxe / longevity : 1 000 € par jour et (bien) plus
+
+Le sommet du marché, à la frontière du médical :
+
+- **Lanserhof Sylt** (Allemagne, référence des clients français) : la Cure Classic de 7 jours démarre autour de **7 433 €**, hébergement compris — la cure seule coûte 2 940 € hors chambre, et les examens complémentaires prescrits sur place gonflent la facture ([Healing Holidays](https://www.healingholidays.com/retreats/lanserhof-sylt/lanserhof-sylt-cure-classic/details)) ;
+- **SHA Wellness Clinic** (Espagne) : les programmes de 7 jours débutent vers **7 500 €** chambre d'entrée de gamme incluse, davantage pour les programmes Longevity ([Serenity Ways](https://www.serenityways.com/posts/compare-sha-wellness-clinic-lanserhof-programs-prices)) ;
+- En France, **La Réserve Paris** décline avec Nescens des séjours et journées « better-aging » : à titre d'échelle, le forfait 10 accès au spa s'affiche à **1 200 €** et les soins signatures entre 260 et 340 € l'unité ([La Réserve Paris](https://www.lareserve-paris.com/en/spa/a-day-at-spa-nescens/), [Forbes France](https://www.forbes.fr/luxe/la-reserve-paris-hotel-spa-nescens-un-ecrin-de-bien-etre-ou-defier-le-temps/)) ; sa jumelle La Réserve Ramatuelle propose des séjours Nescens better-aging complets ([La Réserve Ramatuelle](https://www.lareserve-ramatuelle.com/sejours-nescens-better-aging/)).
+
+Soit **plus de 1 000 € par jour** dès l'entrée de gamme. Notre enquête détaillée : [retraites GLP-1 et cliniques de luxe en Europe](/collections/retraites-bien-etre/retraite-glp1-ozempic-cliniques-luxe-europe-prix/).
+
+## Ce qui fait vraiment varier le prix
+
+1. **L'hébergement** — c'est le premier poste. Chambre partagée en jeûne et rando (35 €/nuit) contre suite d'hôtel 5 étoiles : l'écart se chiffre en centaines d'euros par nuit ;
+2. **L'encadrement médical** — un séjour avec médecins, bilans sanguins et imagerie (Lanserhof, SHA) coûte structurellement 5 à 10 fois plus qu'une retraite animée par un coach ou un professeur de yoga ;
+3. **La taille du groupe** — programme individuel sur mesure vs retraite collective de 15 personnes : la mutualisation divise les coûts ;
+4. **La saison** — à Brides-les-Bains, le même studio curiste passe de 695 € les 3 semaines au printemps à 780 € l'été ([Les Curistes](https://www.lescuristes.fr/location-magnifique-studio---classe-2--parfait-pour-votre-cure--3-semaines---780-euros---tout-inclus-brides-les-bains_12427)) ; en thalasso, les forfaits prennent 10 à 15 € par jour les week-ends et vacances scolaires ;
+5. **La localisation** — Côte d'Azur et Île-de-France : environ +30 % sur les retraites yoga par rapport à la moyenne nationale.
+
+## Remboursable ou pas : le récapitulatif
+
+| Formule | Prise en charge Assurance Maladie |
+|---|---|
+| Cure thermale conventionnée (prescription + station agréée) | ✓ 65 % du forfait thermal, 70 % de la surveillance médicale |
+| Aides transport/hébergement en cure thermale | ✓ Sous conditions de ressources uniquement |
+| Thalassothérapie | Non (plus remboursée depuis 1998) |
+| Jeûne et randonnée, yoga, séjour sportif | Non |
+| Cliniques longevity / better-aging | Non |
+
+Pour la cure thermale, l'aide à l'hébergement (65 % d'un forfait de 150,01 €, soit **97,50 €**) et au transport (base billet SNCF aller-retour 2e classe) n'est versée que si vos revenus de l'année précédente ne dépassent pas **14 664,38 €**, majorés de 50 % par ayant droit ([Aide-sociale.fr](https://www.aide-sociale.fr/cure-thermale-prise-en-charge/)). Certaines mutuelles et caisses de retraite ajoutent leurs propres forfaits cure.
+
+À noter, sur le versant médicament : depuis le **15 juin 2026**, Wegovy et Mounjaro sont remboursés à 65 % pour les patients éligibles (IMC ≥ 35 avec comorbidité ou ≥ 40, échec nutritionnel de 6 mois, primo-prescription en CSO/CHU). Cumulé avec la cure thermale conventionnée, cela forme le parcours minceur encadré le moins cher de France — le montage est détaillé dans [Wegovy remboursé + cure thermale remboursée](/collections/retraites-bien-etre/wegovy-rembourse-cure-thermale-protocole-minceur-moins-cher/). Vérifiez vos critères avec notre [test d'éligibilité](/outils/test-eligibilite/).
+
+## 5 astuces pour payer votre retraite moins cher
+
+1. **Partez hors saison** : printemps et automne, les hébergements curistes et les thalassos baissent de 10 à 15 %, et les retraites yoga hors juillet-août sont nettement plus négociables ;
+2. **Dissociez cure et hébergement** : en cure thermale comme en jeûne et rando, réserver le stage d'un côté et un studio ou une chambre partagée de l'autre revient souvent moins cher que la formule packagée en résidence ;
+3. **Choisissez la chambre partagée** : c'est 30 à 50 % d'économie sur les séjours jeûne, yoga et sport — et un moteur de motivation collective en bonus ;
+4. **Jouez les tarifs dégressifs** : 790 €/semaine mais 613 €/semaine sur 3 semaines chez Coaching Village ; même logique de 4e semaine remisée chez les loueurs de Brides-les-Bains ;
+5. **Activez toutes les aides** : prescription médicale pour la cure thermale (remboursement 65/70 %), aides CPAM transport/hébergement sous conditions de ressources, forfaits « cure » de votre mutuelle, et aides des caisses de retraite pour les retraités.
+
+Pour choisir la formule adaptée à votre objectif (perte de poids, détox, remise en forme, accompagnement d'un traitement GLP-1), explorez notre [hub des retraites et séjours bien-être](/retraites/) et notre [comparatif des retraites perte de poids en France](/collections/retraites-bien-etre/meilleures-retraites-perte-de-poids-france-prix/).
+
+## FAQ — Prix des retraites bien-être en France
+
+### Quel est le prix moyen d'une retraite bien-être en France en 2026 ?
+
+De 62 € par jour tout compris (cure thermale conventionnée après remboursement) à plus de 1 000 € par jour (cliniques longevity type Lanserhof ou SHA). Entre les deux : jeûne et randonnée dès 540 €/semaine, yoga 650 à 1 500 €/semaine, séjour sportif dès 790 €/semaine tout compris, thalasso 950 à 2 400 €/semaine.
+
+### Quelle est la retraite bien-être la moins chère ?
+
+La cure thermale conventionnée de 18 jours, seule formule partiellement remboursée (65 % du forfait thermal, 70 % de la surveillance médicale). Reste à charge total avec hébergement : environ 1 000 à 1 400 € pour 3 semaines, soit à partir d'environ 62 €/jour. En format court, le jeûne et randonnée en chambre partagée (dès 540 €/semaine) est le plus économique.
+
+### Une retraite bien-être est-elle remboursée par la Sécurité sociale ?
+
+Seule la cure thermale conventionnée sur prescription médicale l'est. La thalasso n'est plus prise en charge depuis 1998 ; yoga, jeûne, séjours sportifs et cliniques longevity ne sont jamais remboursés. Sous conditions de ressources (plafond 14 664,38 €), la CPAM ajoute une aide hébergement (97,50 €) et transport pour la cure thermale.
+
+### Pourquoi les prix varient-ils autant d'une retraite à l'autre ?
+
+Cinq facteurs : le niveau d'hébergement, la présence d'encadrement médical (médecins et bilans multiplient le prix par 5 à 10), la taille du groupe, la saison, et la localisation (Côte d'Azur environ +30 %).
+
+### Comment payer sa retraite bien-être moins cher ?
+
+Partir hors saison, réserver stage et hébergement séparément, choisir la chambre partagée, profiter des tarifs dégressifs à la semaine, et activer les aides : remboursement de la cure thermale, aides CPAM sous conditions de ressources, forfaits mutuelle et aides des caisses de retraite.

--- a/src/content/retraites-bien-etre/cure-detox-arnaque-ou-efficace-avis-science.md
+++ b/src/content/retraites-bien-etre/cure-detox-arnaque-ou-efficace-avis-science.md
@@ -1,0 +1,134 @@
+---
+title: "Cure détox pour maigrir : arnaque ou efficace ? Ce que dit vraiment la science"
+description: "Cure détox : arnaque marketing ou méthode efficace ? Revue des preuves scientifiques (aucun essai clinique solide), risques réels, prix constatés en France et alternatives sérieuses, y compris sous traitement GLP-1."
+pubDate: 2026-07-14
+author: "Équipe GLP-1 France"
+category: "Retraites et séjours"
+tags: ["cure détox", "détox", "jus détox", "jeûne", "perte de poids", "arnaque santé", "science"]
+collection: "retraites-bien-etre"
+thumbnail: "/images/thumbnails/cure-detox-arnaque-ou-efficace-avis-science.svg"
+thumbnailAlt: "Cure détox arnaque ou efficace : analyse scientifique"
+featured: false
+published: true
+schema: "Article"
+faqSchema:
+  - question: "Les cures détox sont-elles efficaces pour éliminer les toxines ?"
+    answer: "Non. Une revue critique publiée en 2015 dans le Journal of Human Nutrition and Dietetics n'a trouvé aucun essai clinique randomisé démontrant l'efficacité des cures détox commerciales. Le foie et les reins assurent déjà l'élimination des déchets de l'organisme en continu, sans aide extérieure."
+  - question: "Pourquoi perd-on du poids pendant une cure détox ?"
+    answer: "Parce qu'une cure à base de jus, tisanes ou bouillons est avant tout une restriction calorique sévère : on perd de l'eau, du glycogène et un peu de graisse et de muscle. Ce n'est pas un effet « détoxifiant ». Selon l'ANSES, 80 % des personnes reprennent le poids perdu dans l'année qui suit un régime restrictif."
+  - question: "Combien coûte une cure détox en France ?"
+    answer: "Les prix constatés en 2026 vont d'environ 500 à 900 € la semaine pour la plupart des séjours jeûne/détox tout compris, avec des extrêmes de 400 à plus de 1 200 €. Exemples de tarifs publics : 770 à 960 € les 7 jours chez Jeûne et Randonnées (Vosges), 840 à 1 150 € la semaine chez Osez Jeûner. Aucun de ces séjours n'est remboursé."
+  - question: "Peut-on faire une cure détox sous Wegovy ou Mounjaro ?"
+    answer: "C'est déconseillé sans avis médical. Sous GLP-1, l'appétit est déjà fortement réduit : une restriction supplémentaire type jus ou jeûne augmente le risque de fonte musculaire, de carences et de calculs biliaires. La priorité sous traitement est l'inverse d'une détox : protéines suffisantes (1,2 à 1,6 g/kg/jour), hydratation et activité physique."
+  - question: "Une retraite bien-être peut-elle quand même être utile ?"
+    answer: "Oui, mais pas pour ses « toxines ». Un séjour encadré peut aider à couper avec l'alcool et les aliments ultra-transformés, à se remettre en mouvement et à réapprendre à cuisiner. Ce sont le cadre et l'accompagnement qui agissent, pas les jus. Privilégiez les séjours avec encadrement médical ou diététique réel."
+mainKeyword: "cure détox efficace"
+secondaryKeywords: ["cure détox avis", "détox arnaque", "cure détox prix", "jus détox maigrir", "détox foie science"]
+---
+
+**Réponse rapide : non, les cures détox ne « détoxifient » rien.** Aucun essai clinique randomisé n'a jamais démontré qu'une cure de jus, de tisanes ou de compléments élimine des « toxines » — c'est la conclusion d'une [revue critique de la littérature publiée dans le *Journal of Human Nutrition and Dietetics*](https://onlinelibrary.wiley.com/doi/10.1111/jhn.12286). Votre foie et vos reins font déjà ce travail 24 h/24, gratuitement. Si vous perdez du poids pendant une cure, c'est simplement parce que vous mangez beaucoup moins — et [selon l'ANSES](https://www.anses.fr/fr/content/lillusion-perdue-des-regimes-amaigrissants), 80 % des personnes reprennent le poids perdu dans l'année. Pour autant, tout n'est pas à jeter : le **cadre** d'un séjour bien conçu (rupture avec l'alcool, repas structurés, activité physique, sommeil) peut réellement aider. On fait le tri entre science et marketing.
+
+## « Détox » : ce que dit vraiment la science
+
+### Votre corps se détoxifie déjà tout seul
+
+Le terme « détoxification » a un sens médical précis : c'est ce que font en continu le **foie** (transformation des substances indésirables — alcool, médicaments, déchets du métabolisme), les **reins** (filtration et élimination urinaire), auxquels s'ajoutent les poumons, l'intestin et la peau. Chez une personne dont ces organes fonctionnent normalement, il n'existe **aucune accumulation de « toxines »** qu'un jus de céleri viendrait déloger. Comme le [rappellent des médecins interrogés par Radio France](https://www.ici.fr/infos/sante-sciences/pas-de-produit-miracle-mais-un-gros-business-des-medecins-fustigent-les-cures-detox-apres-les-fetes-1412477) : « pas de produit miracle, mais un gros business ».
+
+Détail révélateur : les vendeurs de cures détox ne précisent presque jamais **quelles toxines** leurs produits sont censés éliminer, ni comment le mesurer. C'est le signe d'une allégation invérifiable — donc marketing.
+
+### Ce que montre la littérature scientifique
+
+La référence sur le sujet reste la revue critique de Klein et Kiat (2015), publiée dans le [*Journal of Human Nutrition and Dietetics*](https://onlinelibrary.wiley.com/doi/10.1111/jhn.12286). Les auteurs ont passé au crible les régimes détox commerciaux les plus populaires (jus, jeûnes courts, compléments, laxatifs). Leurs conclusions :
+
+- **Aucun essai clinique randomisé** n'a évalué l'efficacité de ces cures chez l'humain ;
+- les rares études existantes souffrent de **méthodologies défaillantes et d'effectifs minuscules** ;
+- compte tenu du coût pour les consommateurs et des risques potentiels, les auteurs recommandent aux professionnels de santé de **déconseiller** ces cures.
+
+Dix ans plus tard, aucune étude solide n'est venue renverser ce constat.
+
+### Côté réglementation : des promesses qui ne passent pas le filtre
+
+En Europe, toute allégation de santé sur un aliment ou un complément doit être **scientifiquement validée avant autorisation**, dans le cadre du [règlement (CE) n° 1924/2006](https://eur-lex.europa.eu/legal-content/FR/TXT/?uri=LEGISSUM:l21306). Les promesses vagues de « détoxification » ou de « purification » de l'organisme relèvent précisément du type d'allégations contre lesquelles [la DGCCRF met en garde les consommateurs](https://www.economie.gouv.fr/dgccrf/les-fiches-pratiques/allegations-nutritionnelles-et-de-sante-ne-vous-faites-pas-avoir) : séduisantes, invérifiables, et sans dossier scientifique derrière.
+
+## Pourquoi on se sent (parfois) mieux après une cure
+
+Si les cures détox n'éliminent aucune toxine, pourquoi tant de témoignages enthousiastes ? Parce qu'une cure agit — mais pas par le mécanisme vendu.
+
+### Ce qui marche vraiment dans une « cure »
+
+- **La restriction calorique** : une semaine de jus et bouillons, c'est souvent moins de 800 kcal/jour. La balance descend — eau, glycogène, un peu de graisse. Rien de « détox » là-dedans.
+- **L'arrêt de l'alcool et des ultra-transformés** : c'est probablement le vrai bénéfice. Une semaine sans alcool, sans sucres ajoutés et sans excès améliore le sommeil, la digestion et l'énergie.
+- **Le cadre et le repos** : coupure avec le travail, marche quotidienne, horaires réguliers, sommeil rattrapé. Un séjour à la campagne fait du bien — avec ou sans jus de betterave.
+- **L'effet de rupture psychologique** : marquer un « avant/après » aide certaines personnes à enclencher un changement. C'est réel, mais ça n'a rien à voir avec le foie.
+
+Autrement dit : **vous payez les toxines, mais ce sont les légumes, la marche et le sommeil qui travaillent.**
+
+## Les risques réels des cures détox
+
+Une cure détox n'est pas seulement inefficace sur les « toxines » : elle peut faire du mal, surtout dans ses versions longues ou très restrictives.
+
+- **Carences et fonte musculaire** : l'ANSES, dans son [rapport sur les pratiques alimentaires d'amaigrissement](https://www.anses.fr/fr/content/lillusion-perdue-des-regimes-amaigrissants), documente les déficits en vitamines et minéraux des régimes restrictifs et la **perte de masse maigre** (muscle) qu'ils entraînent — perte qui réduit la dépense énergétique de repos et prépare la reprise de poids.
+- **Effet yoyo quasi garanti** : toujours selon l'ANSES, la reprise de poids concerne **80 % des personnes à un an**, et davantage encore avec le temps. Une semaine de jus ne change aucune habitude durable.
+- **Populations à risque** : diabète (risque d'hypoglycémie sous traitement), troubles du comportement alimentaire (une cure très restrictive peut les réactiver), grossesse, insuffisance rénale, personnes âgées. Dans tous ces cas, un avis médical est indispensable avant toute restriction sévère.
+- **Interactions et faux sentiment de sécurité** : certaines plantes « détox » et compléments peuvent interférer avec des traitements en cours. Et croire qu'une cure « nettoie » les excès entretient le cycle excès/purge, le contraire d'une relation saine à l'alimentation.
+
+## Combien coûte une cure détox en France ? (prix constatés 2026)
+
+Le marché est florissant, et les prix — pour un bénéfice « détox » nul sur le plan scientifique — sont loin d'être anecdotiques. Tarifs publics relevés en juillet 2026 :
+
+| Formule | Prix constaté | Source |
+|---|---|---|
+| Séjour jeûne/détox 7 jours (Vosges) | 770 à 960 € selon chambre | [Jeûne et Randonnées](https://www.jeunedetox.fr/dates-et-tarifs/) |
+| Semaine jeûne/détox (Osez Jeûner) | 840 € (ch. double) à 1 150 € (indiv.), option jus +30 € | [Osez Jeûner](https://www.osezjeuner.com/sejour/semaine-de-jeune-detox) |
+| Stage jeûne et randonnée (moyenne marché) | 500 à 900 € la semaine, extrêmes 400 à 1 200 € | [Les Crocodiles Jaunes](https://www.lescrocodilesjaunes.fr/combien-coute-un-stage-de-jeune/) |
+
+À ce niveau de prix, comparez avec ce qui est réellement encadré médicalement : notre [comparatif des meilleures retraites perte de poids en France](/collections/retraites-bien-etre/meilleures-retraites-perte-de-poids-france-prix/) montre qu'une cure thermale conventionnée de 18 jours, remboursée à 65 %, revient à environ 100 à 150 € de reste à charge sur les soins — avec un vrai suivi médical.
+
+**Aucune cure détox n'est remboursée** par l'Assurance Maladie, et aucune ne dispose d'un encadrement médical obligatoire.
+
+## Détox et GLP-1 : inutile, et souvent contre-productif
+
+Si vous êtes sous Wegovy ou Mounjaro — [remboursés à 65 % depuis le 15 juin 2026](https://www.vidal.fr/actualites/37850-obesite-prise-en-charge-de-wegovy-et-mounjaro-a-partir-du-15-juin-2026-sous-conditions.html) sous conditions d'IMC et de prescription spécialisée — la question de la détox ne se pose même pas : il n'y a **rien à « détoxifier »**. Ces traitements ne laissent aucun résidu que des jus élimineraient, et votre perte de poids est déjà enclenchée par le médicament.
+
+Pire : une cure restrictive superposée à un GLP-1 cumule les problèmes. L'appétit étant déjà fortement freiné, réduire encore les apports augmente le risque de [fonte musculaire](/collections/regime-glp1/glp1-fonte-musculaire-preserver-muscles/), de carences et de calculs biliaires. Sous traitement, les priorités sont exactement inverses à celles d'une détox :
+
+- **Protéines** : viser 1,2 à 1,6 g/kg/jour pour protéger le muscle ;
+- **Hydratation** : les nausées et la satiété précoce font boire moins qu'il ne faudrait ;
+- **Activité physique**, notamment du renforcement musculaire.
+
+Quant aux stages de jeûne sous GLP-1, notre analyse détaillée — [peut-on jeûner sous Wegovy ou Mounjaro ?](/collections/retraites-bien-etre/jeune-sous-wegovy-mounjaro-avis-medecins/) — conclut qu'ils sont déconseillés sans avis médical. Et si votre objectif est de combiner traitement et séjour structuré, la [cure thermale conventionnée compatible GLP-1](/collections/retraites-bien-etre/wegovy-rembourse-cure-thermale-protocole-minceur-moins-cher/) est une option autrement plus sérieuse.
+
+## Quand une « retraite » garde du sens (mais pas pour vos toxines)
+
+Faut-il pour autant renoncer à tout séjour bien-être ? Non — à condition de payer pour ce qui agit vraiment :
+
+1. **La rupture** : s'extraire de son environnement (placards, apéros, écrans) est un levier comportemental documenté ;
+2. **Le cadre** : repas structurés, activité quotidienne, sommeil régulier ;
+3. **L'accompagnement humain** : diététicien, éducateur sportif, médecin — pas un « coach détox » autoproclamé ;
+4. **L'apprentissage** : ateliers cuisine, éducation nutritionnelle, gestion du stress — ce qu'on ramène à la maison.
+
+Un bon séjour se juge à ce qu'il change **trois mois après le retour**, pas au nombre de jus verts servis. Pour choisir un séjour avec un encadrement réel plutôt qu'un discours pseudo-scientifique, consultez notre [guide des retraites bien-être et perte de poids](/retraites/) et notre [classement des retraites avec prix vérifiés](/collections/retraites-bien-etre/meilleures-retraites-perte-de-poids-france-prix/).
+
+**Signaux d'alarme** avant de réserver : promesses de « nettoyage » d'organes, vente forcée de compléments sur place, absence de tout professionnel de santé, témoignages spectaculaires sans aucune donnée, interdiction de poser des questions sur les qualifications de l'équipe.
+
+## FAQ : cure détox, ce qu'il faut retenir
+
+### Les cures détox sont-elles efficaces pour éliminer les toxines ?
+
+Non. La [revue critique de Klein et Kiat (2015)](https://onlinelibrary.wiley.com/doi/10.1111/jhn.12286) n'a identifié aucun essai clinique randomisé démontrant l'efficacité des cures détox commerciales. Le foie et les reins assurent déjà l'élimination des déchets en continu, sans aide extérieure.
+
+### Pourquoi perd-on du poids pendant une cure détox ?
+
+Parce qu'une cure à base de jus ou bouillons est une restriction calorique sévère : on perd de l'eau, du glycogène, un peu de graisse et de muscle. Ce n'est pas un effet « détoxifiant » — et [selon l'ANSES](https://www.anses.fr/fr/content/lillusion-perdue-des-regimes-amaigrissants), 80 % des personnes reprennent le poids perdu dans l'année.
+
+### Combien coûte une cure détox en France ?
+
+Le plus souvent 500 à 900 € la semaine tout compris, avec des extrêmes de 400 à plus de 1 200 €. Exemples publics 2026 : 770 à 960 € les 7 jours chez [Jeûne et Randonnées](https://www.jeunedetox.fr/dates-et-tarifs/), 840 à 1 150 € chez [Osez Jeûner](https://www.osezjeuner.com/sejour/semaine-de-jeune-detox). Jamais remboursées.
+
+### Peut-on faire une cure détox sous Wegovy ou Mounjaro ?
+
+C'est déconseillé sans avis médical : l'appétit est déjà très réduit sous GLP-1, et une restriction supplémentaire augmente les risques de fonte musculaire, de carences et de calculs biliaires. Sous traitement, misez au contraire sur les protéines (1,2 à 1,6 g/kg/jour), l'hydratation et le renforcement musculaire.
+
+### Une retraite bien-être peut-elle quand même être utile ?
+
+Oui, pour son cadre : rupture avec l'alcool et les ultra-transformés, activité physique quotidienne, sommeil, accompagnement par de vrais professionnels. Ce sont ces leviers qui agissent — pas les « toxines ». Voyez notre [comparatif des retraites sérieuses en France](/collections/retraites-bien-etre/meilleures-retraites-perte-de-poids-france-prix/).

--- a/src/pages/outils/test-eligibilite.astro
+++ b/src/pages/outils/test-eligibilite.astro
@@ -1,0 +1,254 @@
+---
+import StaticLayout from '../../layouts/StaticLayout.astro';
+---
+
+<StaticLayout
+  title="Test d'Éligibilité Remboursement Wegovy & Mounjaro 2026 (2 min)"
+  description="Êtes-vous éligible au remboursement à 65% de Wegovy ou Mounjaro ? Testez en 2 minutes avec les critères officiels 2026 : IMC, comorbidités, parcours nutritionnel."
+  keywords="test éligibilité wegovy, remboursement mounjaro conditions, suis-je éligible glp1, imc remboursement obésité"
+>
+  <div class="min-h-screen py-12" style="background: linear-gradient(160deg, #f0fdf4 0%, #ffffff 60%);">
+    <div class="container mx-auto px-4 max-w-2xl">
+
+      <div class="text-center mb-10">
+        <h1 class="text-3xl md:text-4xl font-bold mb-4" style="color: #1a3c34;">
+          Suis-je éligible au remboursement Wegovy / Mounjaro ?
+        </h1>
+        <p class="text-lg text-gray-600">
+          Depuis le 15 juin 2026, Wegovy et Mounjaro sont remboursés à <strong>65 %</strong> par l'Assurance Maladie, sous conditions.
+          Vérifiez votre situation en 3 questions — critères officiels (arrêtés du 23 mai 2026).
+        </p>
+      </div>
+
+      <div class="bg-white rounded-2xl shadow-xl p-6 md:p-8" id="testCard">
+
+        <!-- Étape 1 : IMC -->
+        <div class="test-step" id="step1">
+          <p class="text-sm font-semibold mb-4" style="color:#16a34a;">Étape 1/3 — Votre IMC</p>
+          <div class="grid grid-cols-2 gap-4 mb-2">
+            <div>
+              <label for="taille" class="block text-sm font-medium text-gray-700 mb-1">Taille (cm)</label>
+              <input type="number" id="taille" min="120" max="230" placeholder="ex : 170"
+                class="w-full border border-gray-300 rounded-lg px-4 py-3 text-lg focus:outline-none" style="accent-color:#16a34a;" />
+            </div>
+            <div>
+              <label for="poids" class="block text-sm font-medium text-gray-700 mb-1">Poids (kg)</label>
+              <input type="number" id="poids" min="35" max="350" placeholder="ex : 105"
+                class="w-full border border-gray-300 rounded-lg px-4 py-3 text-lg focus:outline-none" />
+            </div>
+          </div>
+          <p id="imcLive" class="text-sm text-gray-500 mb-4 min-h-5"></p>
+          <button id="btnStep1" class="w-full text-white font-semibold py-3 rounded-lg text-lg" style="background:#16a34a;">Continuer →</button>
+        </div>
+
+        <!-- Étape 2 : comorbidités -->
+        <div class="test-step hidden" id="step2">
+          <p class="text-sm font-semibold mb-1" style="color:#16a34a;">Étape 2/3 — Vos comorbidités</p>
+          <p class="text-gray-600 mb-4">Avez-vous l'un de ces problèmes de santé diagnostiqués ? (plusieurs choix possibles)</p>
+          <div class="space-y-2 mb-5" id="comorbList">
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="checkbox" value="Diabète de type 2" class="comorb w-5 h-5" style="accent-color:#16a34a;"/> Diabète de type 2</label>
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="checkbox" value="Hypertension artérielle" class="comorb w-5 h-5" style="accent-color:#16a34a;"/> Hypertension artérielle</label>
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="checkbox" value="Apnée du sommeil" class="comorb w-5 h-5" style="accent-color:#16a34a;"/> Apnée du sommeil (SAHOS)</label>
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="checkbox" value="Dyslipidémie" class="comorb w-5 h-5" style="accent-color:#16a34a;"/> Cholestérol / triglycérides élevés</label>
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="checkbox" value="Stéatose hépatique" class="comorb w-5 h-5" style="accent-color:#16a34a;"/> Foie gras (stéatose / NASH)</label>
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="checkbox" value="Maladie cardiovasculaire" class="comorb w-5 h-5" style="accent-color:#16a34a;"/> Maladie cardiovasculaire</label>
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="checkbox" value="aucune" id="comorbNone" class="w-5 h-5" style="accent-color:#16a34a;"/> Aucune de ces situations</label>
+          </div>
+          <button id="btnStep2" class="w-full text-white font-semibold py-3 rounded-lg text-lg" style="background:#16a34a;">Continuer →</button>
+        </div>
+
+        <!-- Étape 3 : suivi nutritionnel -->
+        <div class="test-step hidden" id="step3">
+          <p class="text-sm font-semibold mb-1" style="color:#16a34a;">Étape 3/3 — Parcours nutritionnel</p>
+          <p class="text-gray-600 mb-4">Avez-vous déjà suivi une prise en charge nutritionnelle encadrée (médecin, diététicien) pendant au moins 6 mois ?</p>
+          <div class="space-y-2 mb-5">
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="radio" name="nutri" value="oui" class="w-5 h-5" style="accent-color:#16a34a;"/> Oui, sans perte de poids suffisante</label>
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="radio" name="nutri" value="encours" class="w-5 h-5" style="accent-color:#16a34a;"/> C'est en cours</label>
+            <label class="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50"><input type="radio" name="nutri" value="non" class="w-5 h-5" style="accent-color:#16a34a;"/> Non, pas encore</label>
+          </div>
+          <button id="btnStep3" class="w-full text-white font-semibold py-3 rounded-lg text-lg" style="background:#16a34a;">Voir mon résultat →</button>
+        </div>
+
+        <!-- Résultat -->
+        <div class="test-step hidden" id="resultStep">
+          <div id="verdictBox" class="rounded-xl p-5 mb-5"></div>
+          <div id="nextSteps" class="text-gray-700 space-y-3 mb-6"></div>
+
+          <!-- Capture email -->
+          <div class="rounded-xl p-5 mb-5" style="background:#f0fdf4; border: 1px solid #bbf7d0;">
+            <p class="font-semibold mb-1" style="color:#1a3c34;">📩 Recevez votre plan d'action par email</p>
+            <p class="text-sm text-gray-600 mb-3">Votre résultat détaillé + les étapes concrètes (documents, où consulter, questions à poser au médecin).</p>
+            <form id="captureForm" class="flex flex-col sm:flex-row gap-2">
+              <input type="email" id="captureEmail" required placeholder="votre@email.fr"
+                class="flex-1 border border-gray-300 rounded-lg px-4 py-3 focus:outline-none" />
+              <button type="submit" class="text-white font-semibold px-6 py-3 rounded-lg" style="background:#16a34a;">Recevoir</button>
+            </form>
+            <p id="captureMsg" class="text-sm mt-2 min-h-5"></p>
+          </div>
+
+          <!-- Upsell Dossier -->
+          <div id="dossierUpsell" class="hidden rounded-xl p-5 text-white" style="background:#1a3c34;">
+            <p class="font-bold text-lg mb-1">Votre Dossier GLP-1 personnalisé — 4,99 €</p>
+            <p class="text-sm opacity-90 mb-3">Verdict d'éligibilité détaillé, centres CSO/CHU près de chez vous, checklist pour le rendez-vous médecin et estimation du reste à charge — prêt à imprimer.</p>
+            <a href="/dossier-glp1/" class="inline-block font-semibold px-6 py-3 rounded-lg" style="background:#16a34a; color:white;">Préparer mon dossier →</a>
+          </div>
+
+          <button id="btnRestart" class="w-full mt-4 text-sm text-gray-500 underline">Refaire le test</button>
+        </div>
+      </div>
+
+      <div class="mt-8 text-sm text-gray-500 leading-relaxed">
+        <p><strong>Critères officiels du remboursement à 65 %</strong> (arrêtés du 23 mai 2026, en vigueur depuis le 15 juin 2026) :
+        IMC ≥ 40, ou IMC ≥ 35 avec au moins une comorbidité liée au poids, après échec d'une prise en charge nutritionnelle
+        d'au moins 6 mois (perte &lt; 5 %). La première prescription remboursée doit être faite par un spécialiste de l'obésité
+        (CSO, CHU, endocrinologue en lien avec un CSO) ; le renouvellement peut ensuite se faire chez votre médecin traitant.
+        Ce test est informatif : seule l'évaluation d'un médecin fait foi.</p>
+        <p class="mt-2">Pour aller plus loin : <a href="/collections/glp1-cout/remboursement-mounjaro-wegovy-15-juin-2026/" style="color:#16a34a;">les conditions détaillées du remboursement</a> ·
+        <a href="/collections/glp1-cout/prix-wegovy-france/" style="color:#16a34a;">prix Wegovy</a> ·
+        <a href="/collections/glp1-cout/prix-mounjaro-france/" style="color:#16a34a;">prix Mounjaro</a> ·
+        <a href="/outils/carte-prix-pharmacies/" style="color:#16a34a;">carte des prix en pharmacie</a></p>
+      </div>
+    </div>
+  </div>
+
+  <script is:inline src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
+  <script is:inline>
+    (function () {
+      var supabaseUrl = 'https://ywekaivgjzsmdocchvum.supabase.co';
+      var supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inl3ZWthaXZnanpzbWRvY2NodnVtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUzNjQ0MDcsImV4cCI6MjA3MDk0MDQwN30.f2Mo-77InzZHnK1o7bMNs1ZC3DyX7EkPl964ksQTafY';
+      var sb = window.supabase.createClient(supabaseUrl, supabaseKey);
+
+      var state = { imc: null, taille: null, poids: null, comorbidites: [], nutri: null, verdict: null };
+
+      function show(id) {
+        document.querySelectorAll('.test-step').forEach(function (el) { el.classList.add('hidden'); });
+        document.getElementById(id).classList.remove('hidden');
+        document.getElementById('testCard').scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+
+      function computeImc() {
+        var t = parseFloat(document.getElementById('taille').value);
+        var p = parseFloat(document.getElementById('poids').value);
+        if (t >= 120 && t <= 230 && p >= 35 && p <= 350) {
+          var imc = p / Math.pow(t / 100, 2);
+          return { imc: imc, taille: t, poids: p };
+        }
+        return null;
+      }
+
+      ['taille', 'poids'].forEach(function (id) {
+        document.getElementById(id).addEventListener('input', function () {
+          var r = computeImc();
+          document.getElementById('imcLive').textContent = r ? 'Votre IMC : ' + r.imc.toFixed(1) : '';
+        });
+      });
+
+      document.getElementById('btnStep1').addEventListener('click', function () {
+        var r = computeImc();
+        if (!r) { document.getElementById('imcLive').textContent = 'Merci d\'indiquer une taille et un poids valides.'; return; }
+        state.imc = r.imc; state.taille = r.taille; state.poids = r.poids;
+        show('step2');
+      });
+
+      document.getElementById('comorbNone').addEventListener('change', function () {
+        if (this.checked) document.querySelectorAll('.comorb').forEach(function (c) { c.checked = false; });
+      });
+      document.querySelectorAll('.comorb').forEach(function (c) {
+        c.addEventListener('change', function () { if (this.checked) document.getElementById('comorbNone').checked = false; });
+      });
+
+      document.getElementById('btnStep2').addEventListener('click', function () {
+        state.comorbidites = Array.prototype.map.call(document.querySelectorAll('.comorb:checked'), function (c) { return c.value; });
+        show('step3');
+      });
+
+      document.getElementById('btnStep3').addEventListener('click', function () {
+        var sel = document.querySelector('input[name="nutri"]:checked');
+        if (!sel) return;
+        state.nutri = sel.value;
+        renderVerdict();
+        show('resultStep');
+      });
+
+      function renderVerdict() {
+        var imc = state.imc, hasComorb = state.comorbidites.length > 0;
+        var box = document.getElementById('verdictBox');
+        var steps = document.getElementById('nextSteps');
+        var upsell = document.getElementById('dossierUpsell');
+        var html = '', stepsHtml = '', eligible = false;
+
+        if (imc >= 40 || (imc >= 35 && hasComorb)) {
+          if (state.nutri === 'oui') {
+            eligible = true;
+            state.verdict = 'eligible';
+            html = '<p class="text-xl font-bold" style="color:#15803d;">✓ Vous semblez éligible au remboursement à 65 %</p>' +
+              '<p class="mt-1 text-gray-700">IMC ' + imc.toFixed(1) + (imc >= 40 ? ' (≥ 40)' : ' (≥ 35) avec comorbidité') + ' et parcours nutritionnel déjà tenté : vous cochez les critères officiels.</p>';
+            stepsHtml = '<p><strong>Vos prochaines étapes :</strong></p><ol class="list-decimal ml-5 space-y-1">' +
+              '<li>Prendre rendez-vous dans un <strong>CSO ou CHU</strong> (ou avec un endocrinologue en lien avec un CSO) pour la première prescription remboursée — annuaire : annuaire-sante.ameli.fr</li>' +
+              '<li>Apporter les justificatifs de votre suivi nutritionnel (comptes rendus, courbes de poids)</li>' +
+              '<li>Le renouvellement pourra ensuite se faire chez votre médecin traitant</li></ol>';
+            box.style.background = '#f0fdf4'; box.style.border = '1px solid #86efac';
+          } else {
+            state.verdict = 'eligible_apres_suivi';
+            html = '<p class="text-xl font-bold" style="color:#b45309;">⏳ Presque : il manque le parcours nutritionnel</p>' +
+              '<p class="mt-1 text-gray-700">Avec un IMC de ' + imc.toFixed(1) + (hasComorb ? ' et une comorbidité' : '') + ', vous remplissez le critère de poids. Mais le remboursement exige d\'abord <strong>6 mois de prise en charge nutritionnelle encadrée</strong> (avec une perte &lt; 5 %).</p>';
+            stepsHtml = '<p><strong>Vos prochaines étapes :</strong></p><ol class="list-decimal ml-5 space-y-1">' +
+              '<li>Parlez-en à votre médecin traitant pour démarrer (ou documenter) un suivi nutritionnel</li>' +
+              '<li>Dans 6 mois, si la perte de poids reste insuffisante, direction CSO/CHU pour la prescription remboursée</li></ol>';
+            box.style.background = '#fffbeb'; box.style.border = '1px solid #fcd34d';
+            eligible = true;
+          }
+        } else if (imc >= 35) {
+          state.verdict = 'non_eligible_comorbidite';
+          html = '<p class="text-xl font-bold" style="color:#b45309;">Pas éligible en l\'état — il manque une comorbidité confirmée</p>' +
+            '<p class="mt-1 text-gray-700">Avec un IMC de ' + imc.toFixed(1) + ', le remboursement nécessite au moins une comorbidité liée au poids (diabète, hypertension, apnée du sommeil…). Certaines passent inaperçues : parlez-en à votre médecin (un dépistage d\'apnée du sommeil, par exemple, change la donne).</p>';
+          stepsHtml = '<p>Un bilan chez votre médecin traitant peut révéler une comorbidité non diagnostiquée — c\'est l\'étape n°1.</p>';
+          box.style.background = '#fffbeb'; box.style.border = '1px solid #fcd34d';
+        } else if (imc >= 30) {
+          state.verdict = 'non_eligible_imc30';
+          html = '<p class="text-xl font-bold" style="color:#b91c1c;">Non éligible au remboursement (IMC ' + imc.toFixed(1) + ')</p>' +
+            '<p class="mt-1 text-gray-700">Le remboursement à 65 % exige un IMC ≥ 35 avec comorbidité, ou ≥ 40. Avec un IMC entre 30 et 35, un traitement reste <strong>médicalement possible sur prescription</strong> (non remboursé, à votre charge : Wegovy 146,91–195,10 €/mois).</p>';
+          stepsHtml = '<p>Parlez-en à votre médecin : lui seul peut évaluer l\'intérêt d\'un traitement dans votre situation, remboursé ou non.</p>';
+          box.style.background = '#fef2f2'; box.style.border = '1px solid #fecaca';
+        } else {
+          state.verdict = 'non_eligible';
+          html = '<p class="text-xl font-bold" style="color:#b91c1c;">Non éligible (IMC ' + imc.toFixed(1) + ')</p>' +
+            '<p class="mt-1 text-gray-700">Les traitements GLP-1 de l\'obésité ciblent un IMC ≥ 30. Votre médecin peut vous conseiller d\'autres approches adaptées à votre objectif.</p>';
+          stepsHtml = '';
+          box.style.background = '#fef2f2'; box.style.border = '1px solid #fecaca';
+        }
+
+        box.innerHTML = html;
+        steps.innerHTML = stepsHtml;
+        if (eligible) upsell.classList.remove('hidden'); else upsell.classList.add('hidden');
+      }
+
+      document.getElementById('captureForm').addEventListener('submit', function (e) {
+        e.preventDefault();
+        var email = document.getElementById('captureEmail').value.trim();
+        var msg = document.getElementById('captureMsg');
+        if (!email) return;
+        sb.from('contacts').insert({
+          email: email,
+          contact_type: 'eligibility_test',
+          subject: 'Test éligibilité remboursement',
+          message: 'IMC ' + state.imc.toFixed(1) + ' (' + state.poids + ' kg / ' + state.taille + ' cm) — verdict: ' + state.verdict +
+            ' — comorbidités: ' + (state.comorbidites.join(', ') || 'aucune') + ' — suivi nutritionnel: ' + state.nutri,
+          newsletter: true,
+          created_at: new Date().toISOString()
+        }).then(function (r) {
+          if (r.error) { msg.textContent = 'Une erreur est survenue, réessayez.'; msg.style.color = '#b91c1c'; }
+          else { msg.textContent = '✓ C\'est noté ! Vous recevrez votre plan d\'action très vite.'; msg.style.color = '#15803d'; document.getElementById('captureEmail').value = ''; }
+        });
+      });
+
+      document.getElementById('btnRestart').addEventListener('click', function () {
+        state = { imc: null, taille: null, poids: null, comorbidites: [], nutri: null, verdict: null };
+        document.getElementById('taille').value = ''; document.getElementById('poids').value = '';
+        document.querySelectorAll('.comorb, #comorbNone').forEach(function (c) { c.checked = false; });
+        document.querySelectorAll('input[name="nutri"]').forEach(function (c) { c.checked = false; });
+        show('step1');
+      });
+    })();
+  </script>
+</StaticLayout>

--- a/src/pages/outils/test-eligibilite.astro
+++ b/src/pages/outils/test-eligibilite.astro
@@ -90,7 +90,7 @@ import StaticLayout from '../../layouts/StaticLayout.astro';
           <div id="dossierUpsell" class="hidden rounded-xl p-5 text-white" style="background:#1a3c34;">
             <p class="font-bold text-lg mb-1">Passez à l'action : votre Dossier GLP-1 personnalisé — 4,99 €</p>
             <p class="text-sm opacity-90 mb-3">Ce que le test gratuit ne vous donne pas : <strong>les centres CSO/CHU près de chez vous</strong>, la checklist personnalisée pour le rendez-vous (documents à apporter, questions à poser), et <strong>votre reste à charge chiffré</strong> selon votre dosage et votre mutuelle — le tout dans un document prêt à imprimer pour votre médecin.</p>
-            <a href="/dossier-glp1/" class="inline-block font-semibold px-6 py-3 rounded-lg" style="background:#16a34a; color:white;">Préparer mon dossier →</a>
+            <a href="/dossier-glp1/?src=test-eligibilite" class="inline-block font-semibold px-6 py-3 rounded-lg" style="background:#16a34a; color:white;">Préparer mon dossier →</a>
           </div>
 
           <button id="btnRestart" class="w-full mt-4 text-sm text-gray-500 underline">Refaire le test</button>

--- a/src/pages/outils/test-eligibilite.astro
+++ b/src/pages/outils/test-eligibilite.astro
@@ -76,8 +76,8 @@ import StaticLayout from '../../layouts/StaticLayout.astro';
 
           <!-- Capture email -->
           <div class="rounded-xl p-5 mb-5" style="background:#f0fdf4; border: 1px solid #bbf7d0;">
-            <p class="font-semibold mb-1" style="color:#1a3c34;">📩 Recevez votre plan d'action par email</p>
-            <p class="text-sm text-gray-600 mb-3">Votre résultat détaillé + les étapes concrètes (documents, où consulter, questions à poser au médecin).</p>
+            <p class="font-semibold mb-1" style="color:#1a3c34;">📩 Recevez votre résultat par email</p>
+            <p class="text-sm text-gray-600 mb-3">Votre verdict + les 3 grandes étapes du parcours remboursement, pour le garder sous la main.</p>
             <form id="captureForm" class="flex flex-col sm:flex-row gap-2">
               <input type="email" id="captureEmail" required placeholder="votre@email.fr"
                 class="flex-1 border border-gray-300 rounded-lg px-4 py-3 focus:outline-none" />
@@ -88,8 +88,8 @@ import StaticLayout from '../../layouts/StaticLayout.astro';
 
           <!-- Upsell Dossier -->
           <div id="dossierUpsell" class="hidden rounded-xl p-5 text-white" style="background:#1a3c34;">
-            <p class="font-bold text-lg mb-1">Votre Dossier GLP-1 personnalisé — 4,99 €</p>
-            <p class="text-sm opacity-90 mb-3">Verdict d'éligibilité détaillé, centres CSO/CHU près de chez vous, checklist pour le rendez-vous médecin et estimation du reste à charge — prêt à imprimer.</p>
+            <p class="font-bold text-lg mb-1">Passez à l'action : votre Dossier GLP-1 personnalisé — 4,99 €</p>
+            <p class="text-sm opacity-90 mb-3">Ce que le test gratuit ne vous donne pas : <strong>les centres CSO/CHU près de chez vous</strong>, la checklist personnalisée pour le rendez-vous (documents à apporter, questions à poser), et <strong>votre reste à charge chiffré</strong> selon votre dosage et votre mutuelle — le tout dans un document prêt à imprimer pour votre médecin.</p>
             <a href="/dossier-glp1/" class="inline-block font-semibold px-6 py-3 rounded-lg" style="background:#16a34a; color:white;">Préparer mon dossier →</a>
           </div>
 


### PR DESCRIPTION
## Contenu

**Nouveau funnel d'entrée : `/outils/test-eligibilite/`**
- Test 3 étapes client-side (IMC → comorbidités → parcours nutritionnel) avec les critères officiels du remboursement 65 % (arrêtés du 23/05/2026)
- Capture email → table `contacts` (`contact_type: 'eligibility_test'`)
- Upsell Dossier 4,99 € pour les profils éligibles, avec différenciation explicite gratuit/payant (anti-cannibalisation) et attribution `?src=test-eligibilite`
- Lié depuis le footer (+ lien `/retraites/` pour le jus interne)

**4 articles phase 2** (tous chiffres vérifiés et sourcés) :
- Brides-les-Bains : avis indépendant, prix 2026, résultats Maâthermes
- Combien coûte une retraite bien-être : 6 catégories, €/jour, remboursable vs non
- Cure détox : lecture sceptique et sourcée (Klein & Kiat 2015, ANSES) + section GLP-1
- Peau relâchée / "Ozempic face" : dermato sourcée + prix médecine esthétique France (effets-secondaires-glp1)

**CLAUDE.md** : verticale retraites documentée, mandat élargi de la routine quotidienne (check de tous les projets, amélioration, opportunités, détection des pages non indexées avec liste GSC quotidienne), préférence franc-parler.

## Vérification

- Build complet : 22 606 pages OK
- 0 occurrence Zepbound, YAML validé programmatiquement, thumbnails SVG uniques
- Aucun lien d'affiliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvjaXvZhzVz3Y8TCnXPjVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvjaXvZhzVz3Y8TCnXPjVm)_