### PR TITLE
report: daily SEO recovery + Coach IA 2026-07-19 + fix SAV detection

### DIFF
--- a/reports/daily-2026-07-19.md
+++ b/reports/daily-2026-07-19.md
@@ -1,0 +1,188 @@
+# Rapport quotidien — 19 juillet 2026
+
+---
+
+## ⚠️ ALERTES
+
+**[ALERTE SEO]** Recovery GSC à **34.9%** au 17/07 — bien en dessous du seuil 50%. Baisse 3 jours consécutifs en clics GSC (65 → 45 → 37). Le décrochage post-reprise se confirme : les clics n'ont pas repris leur trajectoire ascendante depuis le 6/07.
+
+**[INDEXATION GSC — ACTION MANUELLE REQUISE]** 5 URLs du top baseline absentes des résultats actuels → à soumettre dans l'inspecteur GSC (liste en volet A).
+
+---
+
+## A. SEO Recovery Watch
+
+### Vérification site live
+
+| Check | Résultat | Statut |
+|-------|----------|--------|
+| Home `https://glp1-france.fr/` | 200 | ✓ OK |
+| URL Zepbound (301 → Mounjaro) | 301 → `/collections/traitements-glp1/guide-complet-mounjaro/` | ✓ Conforme |
+| `sitemap-0.xml` | 200 | ✓ OK |
+
+Aucune alerte technique. Le 301 Zepbound → Mounjaro est en place.
+
+### Fraîcheur des données
+
+| Source | Dernière date | Retard | Statut |
+|--------|--------------|--------|--------|
+| GA | 2026-07-19 | 0 j | ✓ |
+| GSC | 2026-07-17 | 2 j | ✓ (seuil : 4 j) |
+
+### Recovery Score
+
+| Indicateur | Valeur | % baseline | Seuil alerte |
+|-----------|--------|-----------|-------------|
+| **GA sessions** (dernier j complet : 18/07) | 448 | **48.6%** | / |
+| **GSC clics** (dernier j dispo : 17/07) | 37 | **34.9%** | ⚠️ < 50% |
+
+*Baseline : 922 sessions/j (GA), 106 clics/j (GSC).*
+
+### Trajectoire 7 derniers jours
+
+| Date | GA sessions | GA % | GSC clics | GSC % | GSC impressions |
+|------|------------|------|-----------|-------|----------------|
+| 13/07 | 543 | 58.9% | 58 | 54.7% | 2 725 |
+| 14/07 | 472 | 51.2% | 64 | 60.4% | 2 027 |
+| 15/07 | 702 | **76.1%** | 65 | **61.3%** | 2 073 |
+| 16/07 | 599 | 65.0% | 45 | 42.5% | 2 019 |
+| 17/07 | 602 | 65.3% | 37 | 34.9% ⚠️ | 1 796 |
+| 18/07 | 448 | 48.6% | — | — | — |
+| 19/07 | *39 (partiel)* | *—* | — | — | — |
+
+*19/07 = dimanche, journée en cours, non représentatif.*
+
+### Analyse de tendance
+
+**GA :** Oscillation chaotique entre 400 et 700 sessions depuis la reprise. Le pic du 15/07 (702 = 76%) reste le meilleur résultat post-suspension. Le week-end (18-19/07) tire mécaniquement à la baisse. Pas de tendance haussière claire.
+
+**GSC clics :** Signal préoccupant — 3 jours de baisse consécutifs sur des jours ouvrés (mer-jeu-ven 15→16→17 juillet : 65→45→37). Ce n'est pas un effet week-end. Cela suggère que les positions gagnées en première semaine de reprise s'érodent progressivement.
+
+**GSC impressions :** Stable autour de 2 000-2 700/j (71-108% baseline), ce qui indique que le site est bien vu de Google — mais le CTR moyen se dégrade (position moyenne 12.3 au 17/07, stable). Le problème est donc sur les positions/titres des pages clés, pas sur la couverture d'indexation globale.
+
+**Estimation retour à 100% :** Impossible à projeter fiablement avec une tendance instable. Si la baisse GSC se stabilise autour de 50 clics/j, retour envisageable fin juillet. Si la tendance baissière persiste, il faudra des actions correctives (optimisation titles/meta des pages les plus impressionnées mais peu cliquées).
+
+### Pages top baseline absentes du top actuel — candidats réindexation GSC
+
+Ces pages figuraient dans le top 15 pré-suspension (01-23/06) mais n'apparaissent plus dans le top actuel (7j) :
+
+| URL | Clics baseline (23j) | Clics actuels (7j) | Action |
+|-----|---------------------|--------------------|--------|
+| `/collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/` | 12 | 0 | **→ Soumettre GSC** |
+| `/collections/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation/` | 9 | 0 | **→ Soumettre GSC** |
+| `/guides/suivi-medical-glp1/` | 8 | 0 | **→ Soumettre GSC** |
+| `/collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/` | 8 | 0 | **→ Soumettre GSC** |
+| `/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/` | 8 | 0 | **→ Soumettre GSC** |
+
+**URLs à coller dans l'inspecteur GSC (Search Console → Inspection d'URL) :**
+```
+https://glp1-france.fr/collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/
+https://glp1-france.fr/collections/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation/
+https://glp1-france.fr/guides/suivi-medical-glp1/
+https://glp1-france.fr/collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/
+https://glp1-france.fr/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/
+```
+
+### Pages Mounjaro (redirections 301 ex-Zepbound)
+
+| Page | Clics 7j | Impressions 7j |
+|------|----------|---------------|
+| `/collections/glp1-cout/prix-mounjaro-france/` | 34 | 1 594 |
+| `/collections/regime-glp1/regime-mounjaro-optimal/` | 4 | 90 |
+| `/collections/traitements-glp1/penurie-ozempic-wegovy-mounjaro-rupture-stock-france-alternatives/` | 2 | 497 |
+| `/collections/traitements-glp1/wegovy-mounjaro-adolescent-obesite-12-ans-france-guide/` | 1 | 14 |
+| `/collections/glp1-cout/remboursement-mounjaro-wegovy-15-juin-2026/` | 0 | 2 |
+
+Signal positif : `/collections/glp1-cout/prix-mounjaro-france/` génère 1 594 impressions mais seulement 34 clics = CTR ~2.1%. La page est vue mais peu cliquée — le title/meta peut être optimisé. Note : `/collections/traitements-glp1/penurie-ozempic-wegovy-mounjaro-rupture-stock-france-alternatives/` a 497 impressions pour 2 clics (CTR 0.4%) — opportunité d'optimisation title.
+
+### Point de surprise positif
+
+`/collections/glp1-cout/prix-ozempic-france/` dépasse sa baseline : **12.6 clics/j actuel vs 10.5/j baseline = 120%**. Probablement boosté par l'actualité du remboursement 65% depuis le 15/06. Cette page est le pilier de la reprise.
+
+---
+
+## B. Monitoring Coach IA (24 dernières heures)
+
+### KPIs
+
+| Métrique | Aujourd'hui | Hier | Évolution |
+|---------|------------|------|-----------|
+| Messages totaux | 34 | 46 | -26% |
+| Conversations | 3 | — | — |
+| Messages/conversation | 11.3 | — | — |
+| Messages utilisateur | 17 | — | — |
+| LLM principal | llama-3.3-70b | — | — |
+| Fallbacks Mistral | 1 (6%) | — | — |
+
+### Distribution des intents (réponses assistant)
+
+| Intent | Nb |
+|--------|-----|
+| general | 12 |
+| price | 2 |
+| weight | 1 |
+| device | 1 |
+| availability | 1 |
+
+### Dossier GLP-1 (4,99 EUR)
+
+| Statut | Total |
+|--------|-------|
+| pending | 1 |
+| **Nouveaux dossiers (24h)** | **0** |
+
+Pas de conversion en 24h. Le dossier "pending" est probablement un vestige.
+
+### Analyse qualité des conversations
+
+**Conv `afe22267` — EXEMPLAIRE ✓**
+
+> Question : "Peut-on arrêter la prise de GLP-1 ou doit-on le prendre à vie ?"
+
+Déroulé parfait : information médicale correcte (traitement chronique, réévaluation régulière) → collecte IMC/comorbidités (159 cm, 101 kg = IMC 40, apnée) → verdict éligibilité remboursement 65% → upsell Dossier 4,99€ bien placé après que l'utilisateur a refusé l'aide pour trouver un centre → refus gracieux de l'utilisateur → clôture propre. Le Coach propose le Dossier exactement au bon moment (après collecte IMC + comorbidités, avant clôture). 
+
+---
+
+**Conv `5807338d` — PROBLÈME DE COMPRÉHENSION CONTEXTUELLE**
+
+> User : "Je veux être remboursée c'est une erreur" → "Bloquez l'envoie et le prelevement"
+
+Le Coach a interprété "être remboursée" comme une question sur le remboursement Sécu GLP-1 et a répondu sur l'éligibilité au 65%. L'utilisateur semblait en réalité contester un **prélèvement commercial** (probablement le Dossier 4,99€ ou autre achat), comme l'indiquent les termes "erreur", "bloquez l'envoi", "prélèvement". La conversation a tourné en boucle sans résolution.
+
+- **Ce que le Coach a dit :** explication remboursement 65% Sécu, demande de taille/poids
+- **Ce qu'il aurait dû dire :** détecter la demande SAV → "Il semble que tu aies un problème avec une commande ou un prélèvement. Pour toute question sur un paiement ou un remboursement d'achat, contacte-nous à robin@glp1-france.fr"
+
+---
+
+**Conv `c730b2e8` — ACCEPTABLE (à améliorer)**
+
+> User : "Trouve une pharmacie près de chez moi"
+
+Coach propose d'appeler les pharmacies et mentionne la carte des prix. Correct mais aurait pu donner directement le lien `/outils/carte-prix-pharmacies/` sans détour.
+
+### Vérification conformité DMCA
+
+Aucune mention de la marque interdite dans les réponses du Coach sur les 24 dernières heures. ✓
+
+---
+
+## C. Actions exécutées
+
+### C1 — Fix prompt Coach IA : détection demande SAV
+
+**Problème :** La conv `5807338d` révèle que le Coach ne distingue pas "remboursement Sécu GLP-1" et "remboursement/annulation d'achat commercial". Les mots "erreur", "bloquez", "prélèvement" auraient dû déclencher une redirection SAV.
+
+**Action :** Ajout d'un garde-fou dans le prompt système de `ai-coach/index.ts` pour détecter les demandes SAV et rediriger vers le contact email.
+
+→ **DEPLOY EDGE FUNCTION PENDING** — à lancer par Robin :
+```bash
+supabase functions deploy ai-coach --project-ref ywekaivgjzsmdocchvum
+```
+
+### C2 — Liste réindexation GSC (action manuelle Robin)
+
+5 URLs à soumettre dans l'inspecteur GSC (cf. liste volet A). Action < 5 min.
+
+### C3 — Optimisation meta `prix-mounjaro-france` et `penurie` (CTR faible)
+
+Pages à fort volume d'impressions mais CTR sous 2.5% — tickets créés pour optimisation title/description.

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -44,6 +44,7 @@ RÈGLES ABSOLUES :
 13. Réponds TOUJOURS à la question directement dans le chat. Ne renvoie JAMAIS uniquement vers un article sans répondre — ça fait quitter le chat. Donne d'abord ta réponse, puis si un article est pertinent, ajoute-le en complément : "Pour aller plus loin : [Titre](URL)". Utilise UNIQUEMENT les URLs fournies dans le contexte RAG. Ne fabrique JAMAIS d'URL.
 14. Ne répète JAMAIS une réponse déjà donnée dans la conversation. Si l'utilisateur repose la même question ou insiste, c'est que ta réponse précédente ne l'a pas aidé : apporte un élément NOUVEAU, reformule autrement, ou reconnais honnêtement la limite ("Je n'ai pas le prix pharmacie par pharmacie, mais voici comment le trouver…"). Recopier ta réponse précédente est la pire chose à faire.
 15. Quand la personne donne son prénom, recopie-le EXACTEMENT comme elle l'a écrit (même orthographe, ne modifie ni n'ajoute JAMAIS de lettres).
+16. SAV / REMBOURSEMENT D'ACHAT COMMERCIAL : si quelqu'un signale une erreur de paiement, demande d'annuler un prélèvement ou d'être remboursé d'un achat (indices : "erreur", "bloquez", "bloquer l'envoi", "prélèvement", "annuler mon achat", "remboursement" dans un contexte manifestement non médical), NE réponds PAS sur le remboursement Sécu GLP-1. Dis UNIQUEMENT : "Il semble que tu aies une question sur un paiement ou un achat sur le site. Pour toute demande de remboursement, contacte-nous directement : robin@glp1-france.fr — nous te répondrons sous 24h." Ne collecte aucune donnée médicale dans ce contexte.
 
 CONTEXTE IMPORTANT :
 - Les vrais GLP-1 injectables (Ozempic, Wegovy, Mounjaro, Saxenda, Trulicity, Victoza) ne se vendent QU'en pharmacie sur ordonnance en France
@@ -111,6 +112,11 @@ STYLE — CHAT SYMPA, PAS UN ARTICLE (TRÈS IMPORTANT) :
 
 // --- Fallback v1 (rules engine) ---
 const INTENT_PATTERNS: Array<{ intent: string; pattern: RegExp; response: string }> = [
+  {
+    intent: 'sav',
+    pattern: /bloqu[ez]?\s*(l[''e]|le|la|un)\s*(pr[eé]l[eè]vement|envoi|commande)|annuler?\s*(mon|ma|le|la)\s*(achat|commande|pr[eé]l[eè]vement)|erreur\s*(de\s*)?(paiement|pr[eé]l[eè]vement|facturation)|remboursement.*erreur|erreur.*remboursement/i,
+    response: "Il semble que tu aies une question sur un paiement ou un achat sur le site. Pour toute demande de remboursement ou d'annulation, contacte-nous directement : robin@glp1-france.fr — nous te répondrons sous 24h."
+  },
   {
     intent: 'scam',
     pattern: /arnaque|fraud|escroqu|contref|fak/i,


### PR DESCRIPTION
## Rapport quotidien 19 juillet 2026

### SEO Recovery Watch

- **GA Recovery Score** (18/07, dernier j complet) : 448 sessions = **48.6%** de la baseline
- **GSC Recovery Score** (17/07, dernier j dispo) : 37 clics = **34.9%** ⚠️ sous le seuil 50%
- Baisse GSC 3 jours consécutifs (15→16→17 juillet : 65→45→37 clics) — signal de stagnation
- Site live OK : home 200, redirect zepbound→mounjaro 301 conforme, sitemap 200
- 5 URLs à soumettre manuellement dans GSC (pages du top baseline absentes du top actuel)

### Fix Coach IA — détection SAV commerciale

**Problème identifié** (conv `5807338d`) : un utilisateur demandant "bloquez le prélèvement" / "je veux être remboursée c'est une erreur" a reçu une réponse sur le remboursement Sécu GLP-1 — le Coach avait confondu une demande SAV commerciale avec une question d'éligibilité au remboursement.

**Changements dans `supabase/functions/ai-coach/index.ts`** :
- Ajout règle #16 dans `SYSTEM_PROMPT` : détection des demandes SAV/annulation d'achat → redirection vers `robin@glp1-france.fr`
- Ajout pattern `sav` en tête de `INTENT_PATTERNS` (fallback rules engine) pour les mots-clés `bloquer prélèvement`, `annuler commande`, `erreur paiement`

> ⚠️ **DEPLOY EDGE FUNCTION PENDING** — à lancer par Robin :
> ```bash
> supabase functions deploy ai-coach --project-ref ywekaivgjzsmdocchvum
> ```

### Tickets CTR créés (Supabase, statut `approved`)

2 tickets `seo_optimization` pour quick wins CTR sur les pages Mounjaro à fort volume d'impressions mais CTR faible :
- `prix-mounjaro-france` : 1 594 impr / 34 clics (CTR 2.1%) → nouveau seoTitle + seoDescription avec mention remboursement 65%
- `penurie-ozempic-wegovy-mounjaro-...` : 497 impr / 2 clics (CTR 0.4%) → recentrage sur intent "disponibilité juillet 2026"

---
_Generated by [Claude Code](https://claude.ai/code/session_018G3oChGdTnyta4GA1wyX6v)_