### PR TITLE
SEO programmatique pharmacies — palier 1 (+995 pages) + prix officiels réglementés sur toute la verticale

### DIFF
--- a/src/content/regime-glp1/regime-mounjaro-optimal.md
+++ b/src/content/regime-glp1/regime-mounjaro-optimal.md
@@ -3,7 +3,6 @@ title: "Régime Mounjaro Optimal 2026 : Menus & Aliments"
 description: "Régime Mounjaro optimal pour tirzépatide : aliments à privilégier (30-35% protéines), menus types par phase et 7 conseils pour maximiser la perte de poids."
 pubDate: 2025-09-07
 date: 2026-05-29
-updatedAt: '2026-05-29'
 author: "Dr. Sophie Dubois"
 category: "Nutrition"
 tags: ["glp1", "traitements", "nutrition"]

--- a/src/lib/pharmacyCityData.ts
+++ b/src/lib/pharmacyCityData.ts
@@ -1,0 +1,71 @@
+// Données villes partagées par les pages prix locales (/pharmacies/[ville]/prix-*).
+// Top N villes par nombre de pharmacies + CSO du département (primo-prescription).
+// Doit rester synchronisé avec priceCitySlugs dans src/pages/pharmacies/[ville].astro.
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const PRICE_CITIES_LIMIT = 200;
+
+export interface PriceCityPath {
+  params: { ville: string };
+  props: {
+    city: string;
+    department: string;
+    pharmacies: { name: string; postal: string }[];
+    csos: { name: string; city: string; postal_code: string; phone: string | null; parent_hospital: string | null }[];
+  };
+}
+
+export function getPriceCityPaths(limit: number = PRICE_CITIES_LIMIT): PriceCityPath[] {
+  const dataPath = path.resolve(process.cwd(), 'public/data/pharmacies.json');
+  const csoPath = path.resolve(process.cwd(), 'public/data/cso.json');
+  let pharmacies: { schema: string[]; rows: any[][] } = { schema: [], rows: [] };
+  let csos: any[] = [];
+  try { pharmacies = JSON.parse(fs.readFileSync(dataPath, 'utf-8')); } catch {}
+  try { csos = JSON.parse(fs.readFileSync(csoPath, 'utf-8')); } catch {}
+
+  const iName = pharmacies.schema.indexOf('name');
+  const iCity = pharmacies.schema.indexOf('city');
+  const iSlug = pharmacies.schema.indexOf('city_slug');
+  const iCP = pharmacies.schema.indexOf('postal_code');
+  const iDept = pharmacies.schema.indexOf('department');
+
+  const byCity: Record<string, { slug: string; city: string; department: string; pharmacies: { name: string; postal: string }[] }> = {};
+  for (const row of pharmacies.rows) {
+    const slug = row[iSlug];
+    if (!slug) continue;
+    if (!byCity[slug]) byCity[slug] = { slug, city: row[iCity], department: String(row[iDept]), pharmacies: [] };
+    byCity[slug].pharmacies.push({ name: row[iName], postal: row[iCP] });
+  }
+
+  const csosByDept: Record<string, any[]> = {};
+  for (const c of csos) {
+    const d = String(c.department);
+    if (!csosByDept[d]) csosByDept[d] = [];
+    csosByDept[d].push(c);
+  }
+
+  return Object.values(byCity)
+    .sort((a, b) => b.pharmacies.length - a.pharmacies.length)
+    .slice(0, limit)
+    .map((c) => ({
+      params: { ville: c.slug },
+      props: {
+        city: c.city,
+        department: c.department,
+        pharmacies: c.pharmacies.sort((a, b) => String(a.postal).localeCompare(String(b.postal))),
+        csos: (csosByDept[c.department] || []).slice(0, 4).map((x) => ({
+          name: x.name,
+          city: x.city,
+          postal_code: x.postal_code,
+          phone: x.phone ?? null,
+          parent_hospital: x.parent_hospital ?? null,
+        })),
+      },
+    }));
+}
+
+// "PARIS" → "Paris", "AIX EN PROVENCE" → "Aix En Provence"
+export function titleCaseCity(s: string): string {
+  return (s || '').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/src/lib/pharmacyPricing.ts
+++ b/src/lib/pharmacyPricing.ts
@@ -1,6 +1,7 @@
-// Estimation des prix GLP-1 par pharmacie — logique partagée entre la map (client)
-// et les pages statiques générées au build (server-side).
-// Même algorithme : hash déterministe (FINESS + drug + dose) × variance département.
+// Prix officiels GLP-1 — partagés entre la map (client) et les pages statiques (build).
+// Depuis le 15/06/2026 (arrêtés JO du 28/05/2026), les prix d'Ozempic, Wegovy et Mounjaro
+// sont RÉGLEMENTÉS : identiques dans toutes les pharmacies françaises. Aucune estimation.
+// Sources : Base de données publique des médicaments (BDPM), Vidal, Légifrance.
 
 export const DRUG_REF: Record<string, {
   name: string;
@@ -10,72 +11,48 @@ export const DRUG_REF: Record<string, {
 }> = {
   ozempic: {
     name: 'Ozempic',
-    note: 'Remboursé 65% en bithérapie metformine / 30% en trithérapie insuline (DT2) · prix CEPS identique France entière',
+    note: 'Remboursé 30% (diabète type 2) · 100% en ALD · prix officiel identique France entière',
     fixed: true,
     doses: [
-      { dose: '0,25 mg', price: 80.18 },
-      { dose: '0,5 mg', price: 80.18 },
-      { dose: '1 mg', price: 80.18 },
-      { dose: '2 mg', price: 80.18 },
+      { dose: '0,25 mg', price: 77.60 },
+      { dose: '0,5 mg', price: 77.60 },
+      { dose: '1 mg', price: 77.60 },
     ],
   },
   wegovy: {
     name: 'Wegovy',
-    note: 'Prix libéré · non remboursé · estimation par pharmacie',
+    note: 'Remboursé 65% depuis le 15/06/2026 (obésité, sous conditions) · prix réglementé identique partout',
+    fixed: true,
     doses: [
-      { dose: '0,25 mg', price: 135 },
-      { dose: '0,5 mg', price: 135 },
-      { dose: '1 mg', price: 170 },
-      { dose: '1,7 mg', price: 230 },
-      { dose: '2,4 mg', price: 270 },
+      { dose: '0,25 mg', price: 146.91 },
+      { dose: '0,5 mg', price: 146.91 },
+      { dose: '1 mg', price: 146.91 },
+      { dose: '1,7 mg', price: 169.31 },
+      { dose: '2,4 mg', price: 195.10 },
     ],
   },
   mounjaro: {
     name: 'Mounjaro',
-    note: 'Prix libéré · non remboursé · estimation par pharmacie',
+    note: 'Remboursé 65% depuis le 15/06/2026 (obésité, sous conditions) · prix réglementé identique partout',
+    fixed: true,
     doses: [
-      { dose: '2,5 mg', price: 220 },
-      { dose: '5 mg', price: 260 },
-      { dose: '7,5 mg', price: 320 },
-      { dose: '10 mg', price: 375 },
-      { dose: '12,5 mg', price: 420 },
-      { dose: '15 mg', price: 470 },
+      { dose: '2,5 mg', price: 176.10 },
+      { dose: '5 mg', price: 237.68 },
+      { dose: '7,5 mg', price: 335.95 },
+      { dose: '10 mg', price: 335.95 },
+      { dose: '12,5 mg', price: 433.80 },
+      { dose: '15 mg', price: 433.80 },
     ],
   },
   saxenda: {
     name: 'Saxenda',
-    note: 'Prix libéré · non remboursé · pack 5 stylos',
-    doses: [
-      { dose: '6 mg/ml', price: 280 },
-    ],
+    note: 'Prix libre · non remboursé · demandez le tarif à la pharmacie',
+    doses: [],
   },
 };
 
-const PREMIUM_DEPTS = new Set(['75', '92', '78', '06', '69', '13', '74', '77', '93', '94', '91', '95']);
-const RURAL_DEPTS = new Set(['23', '15', '48', '19', '46', '55', '39', '52', '58', '43', '04']);
-
-function pharmaSeed(finess: string, drug: string, dose: string): number {
-  const s = String(finess) + '|' + drug + '|' + dose;
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
-  return Math.abs(h);
-}
-
-export function estimatePrice(
-  basePrice: number,
-  finess: string,
-  department: string,
-  drug: string,
-  dose: string,
-): number {
-  const seed = pharmaSeed(finess, drug, dose);
-  let factor = 0.92 + ((seed % 161) / 1000);
-  if (PREMIUM_DEPTS.has(department)) factor += 0.05 + ((seed % 101) / 1000);
-  else if (RURAL_DEPTS.has(department)) factor -= 0.06 + ((seed % 41) / 1000);
-  return Math.round(basePrice * factor * 100) / 100;
-}
-
-export function computePharmacyPrices(finess: string, department: string) {
+export function computePharmacyPrices(_finess: string, _department: string) {
+  // Les prix étant réglementés, ils ne dépendent plus de la pharmacie ni du département.
   const result: Record<string, { name: string; note: string; fixed: boolean; rows: { dose: string; price: number }[] }> = {};
   for (const slug of Object.keys(DRUG_REF)) {
     const ref = DRUG_REF[slug];
@@ -83,10 +60,7 @@ export function computePharmacyPrices(finess: string, department: string) {
       name: ref.name,
       note: ref.note,
       fixed: ref.fixed === true,
-      rows: ref.doses.map((d) => ({
-        dose: d.dose,
-        price: ref.fixed ? d.price : estimatePrice(d.price, finess, department, slug, d.dose),
-      })),
+      rows: ref.doses.map((d) => ({ dose: d.dose, price: d.price })),
     };
   }
   return result;
@@ -96,7 +70,7 @@ export function slugifyName(name: string): string {
   return (name || '')
     .toLowerCase()
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[̀-ͯ]/g, '')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 }

--- a/src/pages/outils/carte-prix-pharmacies.astro
+++ b/src/pages/outils/carte-prix-pharmacies.astro
@@ -175,8 +175,8 @@ const updatedFr = stats.updated_at
     <!-- Disclaimer -->
     <section class="map-disclaimer">
       <p>
-        <strong>Source&nbsp;:</strong> Référentiel FINESS (data.gouv.fr / Atlasanté — mis à jour bimensuel) · Prix officiels Ozempic = CEPS (80,18&nbsp;€/stylo, remboursé 65&nbsp;% en bithérapie metformine / 30&nbsp;% en trithérapie insuline pour le diabète de type 2) · Prix Wegovy / Mounjaro / Saxenda = <strong>prix libéré</strong>, varie selon pharmacie et n'est pas remboursé.
-        Les prix soumis par la communauté sont modérés avant affichage. Cette page est informative et ne remplace pas un avis médical.
+        <strong>Source&nbsp;:</strong> Référentiel FINESS (data.gouv.fr / Atlasanté — mis à jour bimensuel) · Prix Ozempic (77,60&nbsp;€, remboursé 30&nbsp;% diabète type 2, 100&nbsp;% en ALD), Wegovy (146,91–195,10&nbsp;€) et Mounjaro (176,10–433,80&nbsp;€) <strong>réglementés</strong> depuis le 15 juin 2026 (remboursés 65&nbsp;% dans l'obésité sous conditions) — identiques dans toutes les pharmacies · Saxenda = prix libre, non remboursé.
+        Cette page est informative et ne remplace pas un avis médical.
       </p>
     </section>
   </div>
@@ -193,9 +193,7 @@ const updatedFr = stats.updated_at
       <div class="drawer-body" id="drawer-body"></div>
       <div class="drawer-footer">
         <div class="drawer-legend">
-          <span class="pop-src-off">Officiel</span> prix CEPS légal ·
-          <span class="pop-src-usr">Communauté</span> prix user ·
-          <span class="pop-src-est">Estimation</span> moyenne marché
+          <span class="pop-src-off">Officiel</span> prix réglementé, identique dans toutes les pharmacies
         </div>
         <button type="button" class="drawer-cta" id="drawer-submit-btn">Vous avez vu un prix ici ? Partagez-le</button>
       </div>
@@ -287,72 +285,48 @@ const updatedFr = stats.updated_at
       saxenda: 'Saxenda',
     };
 
-    // Prix médians marché FR — servent de base pour la synthèse par pharmacie.
-    // Ozempic = CEPS officiel (80,18€ identique partout, pas de variance).
-    // Wegovy / Mounjaro / Saxenda = médiane fourchette marché FR avril 2026, variée par pharmacie.
+    // Prix officiels réglementés depuis le 15/06/2026 (arrêtés JO du 28/05/2026) —
+    // identiques dans toutes les pharmacies françaises. Sources : BDPM, Vidal, Légifrance.
+    // Saxenda reste en prix libre : aucun prix affiché (zéro estimation).
     const DRUG_REF = {
       ozempic: {
-        note: 'Remboursé 30% (diabète type 2) · prix CEPS identique France entière',
+        note: 'Remboursé 30% (diabète type 2) · 100% en ALD · prix officiel identique France entière',
         fixed: true,
         doses: [
-          { dose: '0,25 mg', price: 80.18 },
-          { dose: '0,5 mg', price: 80.18 },
-          { dose: '1 mg', price: 80.18 },
-          { dose: '2 mg', price: 80.18 },
+          { dose: '0,25 mg', price: 77.60 },
+          { dose: '0,5 mg', price: 77.60 },
+          { dose: '1 mg', price: 77.60 },
         ],
       },
       wegovy: {
-        note: 'Prix libéré · non remboursé · estimation par pharmacie',
+        note: 'Remboursé 65% depuis le 15/06/2026 (obésité, sous conditions) · prix réglementé identique partout',
+        fixed: true,
         doses: [
-          { dose: '0,25 mg', price: 135 },
-          { dose: '0,5 mg', price: 135 },
-          { dose: '1 mg', price: 170 },
-          { dose: '1,7 mg', price: 230 },
-          { dose: '2,4 mg', price: 270 },
+          { dose: '0,25 mg', price: 146.91 },
+          { dose: '0,5 mg', price: 146.91 },
+          { dose: '1 mg', price: 146.91 },
+          { dose: '1,7 mg', price: 169.31 },
+          { dose: '2,4 mg', price: 195.10 },
         ],
       },
       mounjaro: {
-        note: 'Prix libéré · non remboursé · estimation par pharmacie',
+        note: 'Remboursé 65% depuis le 15/06/2026 (obésité, sous conditions) · prix réglementé identique partout',
+        fixed: true,
         doses: [
-          { dose: '2,5 mg', price: 220 },
-          { dose: '5 mg', price: 260 },
-          { dose: '7,5 mg', price: 320 },
-          { dose: '10 mg', price: 375 },
-          { dose: '12,5 mg', price: 420 },
-          { dose: '15 mg', price: 470 },
+          { dose: '2,5 mg', price: 176.10 },
+          { dose: '5 mg', price: 237.68 },
+          { dose: '7,5 mg', price: 335.95 },
+          { dose: '10 mg', price: 335.95 },
+          { dose: '12,5 mg', price: 433.80 },
+          { dose: '15 mg', price: 433.80 },
         ],
       },
       saxenda: {
-        note: 'Prix libéré · non remboursé · estimation par pharmacie',
-        doses: [
-          { dose: '6 mg/ml', price: 280 },
-        ],
+        note: 'Prix libre · non remboursé · demandez le tarif à la pharmacie',
+        fixed: true,
+        doses: [],
       },
     };
-
-    // Départements "premium" (tarifs généralement plus élevés en France)
-    const PREMIUM_DEPTS = new Set(['75', '92', '78', '06', '69', '13', '74', '77', '93', '94', '91', '95']);
-    // Départements "ruraux" (tarifs souvent plus bas)
-    const RURAL_DEPTS = new Set(['23', '15', '48', '19', '46', '55', '39', '52', '58', '43', '04']);
-
-    // Hash déterministe simple (djb2 variant) — sert de graine pour la variance par pharmacie
-    function pharmaSeed(finess, drug, dose) {
-      const s = String(finess) + '|' + drug + '|' + dose;
-      let h = 5381;
-      for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff;
-      return Math.abs(h);
-    }
-
-    // Variance basée sur le profil tarifaire de la pharmacie (département + hash finess)
-    function estimatePrice(basePrice, finess, department, drug, dose) {
-      // Variance de base ±8% depuis le hash
-      const seed = pharmaSeed(finess, drug, dose);
-      let factor = 0.92 + ((seed % 161) / 1000); // 0.920 → 1.080
-      // Ajustement département
-      if (PREMIUM_DEPTS.has(department)) factor += 0.05 + ((seed % 101) / 1000); // +5 à +15%
-      else if (RURAL_DEPTS.has(department)) factor -= 0.06 + ((seed % 41) / 1000); // -6 à -10%
-      return Math.round(basePrice * factor * 100) / 100;
-    }
 
     let currentDrug = 'all';
     let currentLayer = 'pharmacies';
@@ -731,33 +705,14 @@ const updatedFr = stats.updated_at
         const highlight = d === currentDrug ? ' pop-drug-active' : '';
 
         const rows = ref.doses.map((ds) => {
-          const key = d + '|' + ds.dose;
-          const sub = submitted[key];
-          let priceHtml, srcPill, rowClass = '';
-          if (sub) {
-            priceHtml = Number(sub.p).toFixed(2);
-            srcPill = sub.s === 'user'
-              ? '<span class="pop-dose-src pop-src-usr">Communauté</span>'
-              : sub.s === 'scraped'
-                ? '<span class="pop-dose-src pop-src-scr">Vérifié</span>'
-                : '<span class="pop-dose-src pop-src-off">Officiel</span>';
-          } else if (ref.fixed) {
-            priceHtml = ds.price.toFixed(2);
-            srcPill = '<span class="pop-dose-src pop-src-off">Officiel</span>';
-          } else {
-            priceHtml = estimatePrice(ds.price, finess, dept, d, ds.dose).toFixed(2);
-            srcPill = '<span class="pop-dose-src pop-src-est">Estimation</span>';
-            rowClass = ' pop-dose-est';
-          }
-          return `<div class="pop-dose-row${rowClass}"><span class="pop-dose">${escapeHtml(ds.dose)}</span><strong>${priceHtml}&nbsp;€</strong>${srcPill}</div>`;
+          // Prix réglementés depuis le 15/06/2026 : le prix officiel prime toujours
+          // sur les anciennes soumissions communautaires (potentiellement obsolètes).
+          const priceHtml = ds.price.toFixed(2);
+          const srcPill = '<span class="pop-dose-src pop-src-off">Officiel</span>';
+          return `<div class="pop-dose-row"><span class="pop-dose">${escapeHtml(ds.dose)}</span><strong>${priceHtml}&nbsp;€</strong>${srcPill}</div>`;
         }).join('');
 
-        const hasReal = ref.doses.some((ds) => submitted[d + '|' + ds.dose]);
-        const globalBadge = ref.fixed
-          ? '<span class="pop-src-off">Officiel CEPS</span>'
-          : hasReal
-            ? '<span class="pop-src-usr">Données communauté</span>'
-            : '<span class="pop-src-est">Estimation</span>';
+        const globalBadge = '<span class="pop-src-off">Prix officiel</span>';
 
         return `
           <div class="pop-drug${highlight}">

--- a/src/pages/pharmacies/[ville].astro
+++ b/src/pages/pharmacies/[ville].astro
@@ -45,10 +45,13 @@ export async function getStaticPaths() {
     c.centerLng = c.pharmacies.reduce((a, p) => a + Number(p.lng), 0) / c.pharmacies.length;
   }
 
-  // Top 100 villes seulement (budget build time)
-  const topCities = Object.values(byCity)
-    .sort((a, b) => b.pharmacies.length - a.pharmacies.length)
-    .slice(0, 100);
+  // Top 500 villes (palier 2 du rollout programmatique — était 100)
+  const allCitiesSorted = Object.values(byCity)
+    .sort((a, b) => b.pharmacies.length - a.pharmacies.length);
+  const topCities = allCitiesSorted.slice(0, 500);
+  // Villes disposant de pages prix dédiées (/pharmacies/[ville]/prix-*) — doit rester
+  // synchronisé avec PRICE_CITIES_LIMIT dans prix-mounjaro/wegovy/ozempic.astro
+  const priceCitySlugs = new Set(allCitiesSorted.slice(0, 200).map((c) => c.slug));
 
   // Calcule les "villes proches" pour chaque ville : même département d'abord, puis top global
   const sameDeptByCity = {};
@@ -94,11 +97,12 @@ export async function getStaticPaths() {
       sameDept: sameDeptByCity[c.slug] || [],
       topGlobal: topGlobalForOthers.filter((o) => o.slug !== c.slug).slice(0, 10),
       zipcodes: zipcodesByCity[c.slug] || [],
+      hasPricePages: priceCitySlugs.has(c.slug),
     },
   }));
 }
 
-const { city, sameDept = [], topGlobal = [], zipcodes = [] } = Astro.props;
+const { city, sameDept = [], topGlobal = [], zipcodes = [], hasPricePages = false } = Astro.props;
 const ville = city.slug;
 
 // Pharmacies sérialisées pour la mini-map (limitées à 1000 pour la perf)
@@ -130,12 +134,12 @@ const DEPT_NAMES = {
 };
 const villeCap = titleCase(city.city);
 
-// Stats par drug : prix moyen, min, max, pharmacies qui ont un prix
+// Prix officiels (BDPM / arrêtés JO du 28/05/2026, en vigueur 15/06/2026) — identiques dans toute la France
 const DRUGS = [
-  { slug: 'ozempic', name: 'Ozempic', note: 'remboursé 65% bithérapie metformine / 30% trithérapie insuline (DT2) — prix CEPS 80,18 €' },
-  { slug: 'wegovy', name: 'Wegovy', note: 'prix libéré, non remboursé' },
-  { slug: 'mounjaro', name: 'Mounjaro', note: 'prix libéré, non remboursé (avis HAS favorable nov. 2025, négociation CEPS en cours)' },
-  { slug: 'saxenda', name: 'Saxenda', note: 'prix libéré, non remboursé' },
+  { slug: 'ozempic', name: 'Ozempic', official: '77,60 €', officialMeta: 'TTC par stylo · identique France entière', note: 'remboursé 30% (diabète type 2) · 100% en ALD' },
+  { slug: 'wegovy', name: 'Wegovy', official: '146,91 – 195,10 €', officialMeta: 'selon dosage · prix réglementé identique partout', note: 'remboursé 65% depuis le 15/06/2026 (obésité, sous conditions)' },
+  { slug: 'mounjaro', name: 'Mounjaro', official: '176,10 – 433,80 €', officialMeta: 'selon dosage · prix réglementé identique partout', note: 'remboursé 65% depuis le 15/06/2026 (obésité, sous conditions)' },
+  { slug: 'saxenda', name: 'Saxenda', official: null, note: 'prix libre, non remboursé' },
 ];
 
 const drugStats = DRUGS.map((d) => {
@@ -163,31 +167,31 @@ const drugStats = DRUGS.map((d) => {
 
 const hasUserPrices = drugStats.some((d) => d.count > 0 && d.slug !== 'ozempic');
 
-// Top 10 pharmacies par prix Ozempic (80,18€ uniforme CEPS, donc tri alphabétique)
+// Prix réglementés identiques partout, donc tri alphabétique
 const topPharmacies = [...city.pharmacies]
   .sort((a, b) => a.name.localeCompare(b.name))
   .slice(0, 20);
 
 const title = `Pharmacies GLP-1 à ${villeCap} — Prix Ozempic, Wegovy, Mounjaro 2026`;
-const description = `${city.pharmacies.length} pharmacies référencées à ${villeCap} (${city.department}). Prix Ozempic officiel CEPS 80,18 € (remboursé 65% DT2 bithérapie), prix Wegovy et Mounjaro variables. Carte interactive + contributions communautaires.`;
+const description = `${city.pharmacies.length} pharmacies référencées à ${villeCap} (${city.department}). Prix officiels 2026 : Ozempic 77,60 €, Wegovy 146,91–195,10 €, Mounjaro 176,10–433,80 € (réglementés, remboursables sous conditions). Carte interactive.`;
 
 // FAQ schema
 const faq = [
   {
     q: `Combien de pharmacies vendent Ozempic, Wegovy ou Mounjaro à ${villeCap} ?`,
-    a: `Nous avons référencé ${city.pharmacies.length} pharmacies d'officine à ${villeCap}. Toutes peuvent potentiellement délivrer Ozempic (remboursé pour diabète type 2) sur ordonnance. Wegovy et Mounjaro sont également disponibles sur ordonnance mais leur prix varie selon l'officine.`,
+    a: `Nous avons référencé ${city.pharmacies.length} pharmacies d'officine à ${villeCap}. Toutes peuvent délivrer Ozempic, Wegovy ou Mounjaro sur ordonnance, et commander sous 24-48 h auprès de leur grossiste si le produit n'est pas en stock. Les prix sont réglementés et identiques dans toutes les officines.`,
   },
   {
     q: `Quel est le prix d'Ozempic à ${villeCap} ?`,
-    a: `Ozempic est vendu au prix public CEPS de **80,18 € par stylo**, identique dans toutes les pharmacies de France, y compris à ${villeCap}. En 2026, il est remboursé à **65 %** par l'Assurance Maladie en bithérapie avec metformine (et 30 % en trithérapie avec insuline) pour les patients atteints de diabète de type 2 — 100 % en ALD. Détails : [Prix Ozempic France](/collections/glp1-cout/prix-ozempic-france/).`,
+    a: `Ozempic est vendu **77,60 € TTC par stylo**, prix identique dans toutes les pharmacies de France, y compris à ${villeCap}. Il est remboursé à **30 %** par l'Assurance Maladie pour le diabète de type 2 (et à **100 %** pour les patients en ALD). Détails : [Prix Ozempic France](/collections/glp1-cout/prix-ozempic-france/).`,
   },
   {
     q: `Wegovy et Mounjaro sont-ils remboursés à ${villeCap} ?`,
-    a: `Non. Wegovy et Mounjaro ne sont pas remboursés par l'Assurance Maladie en France (avril 2026). Leur prix est libéré, ce qui signifie que chaque pharmacie fixe son propre tarif. Les prix observés varient généralement entre 169 et 360 € pour Wegovy et entre 230 et 440 € pour Mounjaro selon le dosage.`,
+    a: `Oui, depuis le **15 juin 2026**, Wegovy et Mounjaro sont remboursés à **65 %** par l'Assurance Maladie dans l'obésité, sous conditions : IMC ≥ 40, ou IMC ≥ 35 avec comorbidité, après 6 mois de prise en charge nutritionnelle, avec primo-prescription par un spécialiste de l'obésité (CSO/CHU). Leurs prix sont réglementés et identiques partout : Wegovy 146,91 à 195,10 € et Mounjaro 176,10 à 433,80 € selon le dosage.`,
   },
   {
     q: `Comment obtenir une ordonnance pour ces traitements ?`,
-    a: `Tous les traitements GLP-1 nécessitent une prescription médicale. Pour Ozempic et Wegovy, la restriction aux endocrinologues a été levée en juin 2025 : tout médecin peut désormais prescrire. Pour une téléconsultation rapide, vous pouvez passer par des plateformes comme Charles ou Annette.`,
+    a: `Tous les traitements GLP-1 nécessitent une prescription médicale. Pour Ozempic (diabète de type 2), tout médecin peut prescrire. Pour Wegovy et Mounjaro remboursés dans l'obésité, la première prescription doit venir d'un spécialiste (CSO, CHU) — le renouvellement peut ensuite être fait par votre médecin traitant. Vérifiez d'abord vos critères avec notre [test d'éligibilité](/outils/test-eligibilite/).`,
   },
 ];
 ---
@@ -343,27 +347,25 @@ const faq = [
                 <h3>{d.name}</h3>
                 <span class="drug-note">{d.note}</span>
               </div>
-              {d.count > 0 ? (
+              {d.official ? (
                 <div class="drug-stats">
-                  {d.slug === 'ozempic' ? (
-                    <div class="drug-price-row">
-                      <div class="price-label">Prix officiel</div>
-                      <div class="price-big">80,18 €</div>
-                      <div class="price-meta">par stylo · identique France entière</div>
-                    </div>
-                  ) : (
-                    <>
-                      <div class="drug-price-row">
-                        <div class="price-label">Prix le plus bas</div>
-                        <div class="price-big">{d.min.toFixed(2)} €</div>
-                      </div>
-                      <div class="drug-price-row">
-                        <div class="price-label">Prix moyen</div>
-                        <div class="price-mid">{d.avg.toFixed(2)} €</div>
-                        <div class="price-meta">{d.count} prix soumis</div>
-                      </div>
-                    </>
-                  )}
+                  <div class="drug-price-row">
+                    <div class="price-label">Prix officiel</div>
+                    <div class="price-big">{d.official}</div>
+                    <div class="price-meta">{d.officialMeta}</div>
+                  </div>
+                </div>
+              ) : d.count > 0 ? (
+                <div class="drug-stats">
+                  <div class="drug-price-row">
+                    <div class="price-label">Prix le plus bas</div>
+                    <div class="price-big">{d.min.toFixed(2)} €</div>
+                  </div>
+                  <div class="drug-price-row">
+                    <div class="price-label">Prix moyen</div>
+                    <div class="price-mid">{d.avg.toFixed(2)} €</div>
+                    <div class="price-meta">{d.count} prix soumis</div>
+                  </div>
                 </div>
               ) : (
                 <div class="drug-empty">
@@ -376,7 +378,7 @@ const faq = [
         </div>
 
         <p class="prices-note">
-          Les prix Wegovy, Mounjaro et Saxenda sont <strong>libérés</strong> (non remboursés) : chaque pharmacie fixe son tarif. Les valeurs ci-dessus proviennent des soumissions communautaires vérifiées. Pour une information temps réel, <a href="/outils/carte-prix-pharmacies/">consultez la carte</a>.
+          Depuis le <strong>15 juin 2026</strong>, les prix d'Ozempic, Wegovy et Mounjaro sont <strong>réglementés</strong> : identiques dans toutes les pharmacies, inutile de comparer. Seul Saxenda reste en prix libre. La vraie question est la <strong>disponibilité en stock</strong> — appelez avant de vous déplacer, ou <a href="/outils/carte-prix-pharmacies/">consultez la carte</a>.
         </p>
       </div>
     </section>
@@ -467,6 +469,13 @@ const faq = [
           <div class="interlinks-col">
             <h2>Ressources GLP-1</h2>
             <ul class="interlinks-list interlinks-simple">
+              {hasPricePages && (
+                <>
+                  <li><a href={`/pharmacies/${ville}/prix-mounjaro/`}>Prix Mounjaro à {villeCap}</a></li>
+                  <li><a href={`/pharmacies/${ville}/prix-wegovy/`}>Prix Wegovy à {villeCap}</a></li>
+                  <li><a href={`/pharmacies/${ville}/prix-ozempic/`}>Prix Ozempic à {villeCap}</a></li>
+                </>
+              )}
               <li><a href="/outils/carte-prix-pharmacies/">🗺️ Carte des prix pharmacies</a></li>
               <li><a href="/pharmacies/">Annuaire pharmacies par ville</a></li>
               <li><a href="/collections/glp1-cout/prix-ozempic-france/">Prix Ozempic</a></li>
@@ -484,8 +493,8 @@ const faq = [
     <!-- Disclaimer -->
     <section class="ville-disclaimer">
       <p>
-        <strong>Avertissement médical :</strong> cette page est informative et ne remplace pas un avis médical. Tous les traitements GLP-1 nécessitent une prescription médicale. Les prix indiqués (hors Ozempic) sont des contributions communautaires, vérifiez le tarif directement auprès de la pharmacie.
-        Sources : référentiel FINESS (Atlasanté / data.gouv.fr), CEPS.
+        <strong>Avertissement médical :</strong> cette page est informative et ne remplace pas un avis médical. Tous les traitements GLP-1 nécessitent une prescription médicale. Les prix d'Ozempic, Wegovy et Mounjaro sont réglementés (arrêtés JO du 28 mai 2026, en vigueur au 15 juin 2026) et identiques dans toutes les pharmacies ; Saxenda reste en prix libre.
+        Sources : référentiel FINESS (Atlasanté / data.gouv.fr), Base de données publique des médicaments, Légifrance.
       </p>
     </section>
   </div>

--- a/src/pages/pharmacies/[ville]/[pharmacie].astro
+++ b/src/pages/pharmacies/[ville]/[pharmacie].astro
@@ -169,7 +169,7 @@ const isRuralDept = RURAL_DEPTS.has(String(pharmacy.department));
 const deptZone = isPremiumDept ? 'urbaine premium' : isRuralDept ? 'rurale' : 'standard';
 
 const title = `${nameCap} ${cityCap} — Prix Ozempic, Wegovy, Mounjaro`;
-const description = `Prix GLP-1 à ${nameCap} (${pharmacy.postal} ${cityCap}). Ozempic 80,18 € CEPS officiel (remboursé 65% DT2 bithérapie), estimations Wegovy/Mounjaro/Saxenda par dosage. Mis à jour ${updateMonth}.`;
+const description = `Prix GLP-1 à ${nameCap} (${pharmacy.postal} ${cityCap}). Prix officiels 2026 : Ozempic 77,60 €, Wegovy 146,91–195,10 €, Mounjaro 176,10–433,80 € (réglementés, identiques partout). Mis à jour ${updateMonth}.`;
 
 // Position pour la map — bbox étroit autour de la pharmacie
 const bbox = [
@@ -185,11 +185,11 @@ const faq = [
   },
   {
     q: `Quel est le prix d'Ozempic à ${nameCap} ?`,
-    a: `Ozempic est commercialisé au prix CEPS officiel de **80,18 €** par stylo en France entière, identique dans toutes les pharmacies (le CEPS — Comité Économique des Produits de Santé — fixe le prix public). En 2026, Ozempic est remboursé à **65 %** par la Sécurité sociale en bithérapie avec metformine pour le diabète de type 2 (30 % en trithérapie avec insuline). Le reste à charge dépend de votre mutuelle.`,
+    a: `Ozempic est commercialisé au prix officiel de **77,60 € TTC** par stylo en France entière, identique dans toutes les pharmacies. En 2026, Ozempic est remboursé à **30 %** par la Sécurité sociale pour le diabète de type 2, et à **100 %** pour les patients en ALD. Le reste à charge éventuel dépend de votre mutuelle.`,
   },
   {
-    q: `Pourquoi les prix Wegovy et Mounjaro varient-ils d'une pharmacie à l'autre ?`,
-    a: `Wegovy, Mounjaro et Saxenda sont commercialisés en "prix libéré" : chaque pharmacie fixe librement son tarif (contrairement à Ozempic dont le prix est encadré par le CEPS). Les prix affichés sur cette page sont des estimations calculées à partir de la moyenne marché française + variance liée à la zone (${deptZone}). Pour le prix exact, demandez un devis à la pharmacie.`,
+    q: `Les prix de Wegovy et Mounjaro varient-ils d'une pharmacie à l'autre ?`,
+    a: `Non, plus depuis le **15 juin 2026** : les prix de Wegovy (146,91 à 195,10 € selon dosage) et de Mounjaro (176,10 à 433,80 € selon dosage) sont **réglementés par arrêté** et identiques dans toutes les pharmacies françaises, y compris à ${nameCap}. Les deux sont remboursés à 65 % dans l'obésité, sous conditions. Seul Saxenda reste en prix libre — demandez le tarif à la pharmacie.`,
   },
   {
     q: `Combien y a-t-il de pharmacies dispensant les GLP-1 à ${cityCap} ?`,
@@ -201,11 +201,11 @@ const faq = [
   },
   {
     q: `Quelles alternatives si ${nameCap} est en rupture de stock ?`,
-    a: `${zipCount > 1 ? `Le code postal ${pharmacy.postal} compte ${zipCount} pharmacies ; commencez par celles-ci. ` : ''}Vous pouvez aussi appeler les pharmacies voisines de ${cityCap} (liste plus bas), demander à votre médecin un médicament équivalent (par exemple Trulicity à la place d'Ozempic, même classe thérapeutique des agonistes GLP-1, remboursé 65 % bithérapie metformine), ou consulter notre [carte interactive des prix GLP-1 en pharmacie](/outils/carte-prix-pharmacies/) pour identifier les pharmacies les plus proches qui ont déclaré du stock.`,
+    a: `${zipCount > 1 ? `Le code postal ${pharmacy.postal} compte ${zipCount} pharmacies ; commencez par celles-ci. ` : ''}Vous pouvez aussi appeler les pharmacies voisines de ${cityCap} (liste plus bas), demander à votre médecin un médicament équivalent (par exemple Trulicity à la place d'Ozempic, même classe thérapeutique des agonistes GLP-1), ou consulter notre [carte interactive des prix GLP-1 en pharmacie](/outils/carte-prix-pharmacies/) pour identifier les pharmacies les plus proches qui ont déclaré du stock.`,
   },
   {
     q: `Quel est le coût final d'un traitement GLP-1 si j'ai une mutuelle ?`,
-    a: `Pour Ozempic / Trulicity / Victoza (DT2, remboursés Sécu 65 %), votre reste à charge avant mutuelle est ~28 € sur Ozempic 0,5 mg. Une mutuelle "responsable" couvre généralement les 35 % restants. Pour Wegovy, Mounjaro et Saxenda (non remboursés Sécu), certaines mutuelles haut-de-gamme (à partir de ~80 €/mois) prennent en charge 50 à 100 €/mois — vérifiez votre contrat. Détails complets : [Wegovy remboursement mutuelle](/collections/glp1-cout/wegovy-remboursement-mutuelle/) et [Remboursement GLP-1 2026](/collections/glp1-cout/remboursement-glp1-2026/).`,
+    a: `Pour Ozempic (diabète type 2, remboursé 30 % — 100 % en ALD), le reste à charge avant mutuelle est d'environ 54 € par stylo hors ALD. Pour Wegovy et Mounjaro (remboursés 65 % dans l'obésité depuis le 15/06/2026, sous conditions), le reste à charge est de 35 % du prix réglementé — soit environ 51 à 68 € pour Wegovy et 62 à 152 € pour Mounjaro selon le dosage — souvent couvert par une mutuelle "responsable". Détails complets : [Wegovy remboursement mutuelle](/collections/glp1-cout/wegovy-remboursement-mutuelle/) et [Remboursement GLP-1 2026](/collections/glp1-cout/remboursement-glp1-2026/).`,
   },
 ];
 ---
@@ -321,10 +321,7 @@ const faq = [
         </div>
         <p class="context-text">
           {nameCap} est implantée à <strong>{cityCap}</strong> ({pharmacy.postal}), dans le département <strong>{deptLabel}</strong>.
-          {isPremiumDept && ' Cette zone fait partie des départements où les prix libérés (Wegovy, Mounjaro, Saxenda) tendent à se positionner légèrement au-dessus de la moyenne nationale en raison du coût immobilier et du pouvoir d\'achat local.'}
-          {isRuralDept && ' Cette zone rurale présente généralement des prix libérés (Wegovy, Mounjaro, Saxenda) légèrement inférieurs à la moyenne nationale.'}
-          {!isPremiumDept && !isRuralDept && ' Cette zone se situe dans la moyenne nationale pour les prix des traitements en prix libéré (Wegovy, Mounjaro, Saxenda).'}
-          Les estimations affichées plus bas tiennent compte de cette variance régionale.
+          Depuis le 15 juin 2026, les prix d'Ozempic, Wegovy et Mounjaro sont réglementés : ils sont identiques dans cette officine comme dans toutes les pharmacies de France. La disponibilité en stock, elle, varie — appelez avant de vous déplacer.
         </p>
         <p class="context-text">
           Pour comprendre le marché GLP-1 en France et choisir le traitement adapté, consultez nos guides détaillés :
@@ -339,29 +336,31 @@ const faq = [
     <section class="pharma-prices">
       <div class="pharma-section-inner">
         <h2>Prix des traitements GLP-1 à {nameCap}</h2>
-        <p class="prices-intro">Tableau complet des prix par traitement et dosage. <strong>Ozempic</strong> = prix CEPS légal de <strong>80,18 €/stylo</strong>, identique France entière, remboursé 65 % en bithérapie metformine pour le DT2. <strong>Wegovy, Mounjaro, Saxenda</strong> = prix libéré, estimation basée sur la moyenne marché française + variance géographique de la zone {deptZone} (département {pharmacy.department}). Données mises à jour {updateMonth}.</p>
+        <p class="prices-intro">Tableau complet des prix officiels par traitement et dosage. Depuis le <strong>15 juin 2026</strong>, les prix d'<strong>Ozempic, Wegovy et Mounjaro</strong> sont <strong>réglementés</strong> : identiques à {nameCap} comme dans toutes les pharmacies de France. Seul Saxenda reste en prix libre. Données mises à jour {updateMonth}.</p>
 
         <div class="drug-sections">
           {Object.entries(prices).map(([slug, d]) => (
             <div class="drug-section">
               <div class="drug-section-head">
                 <h3>{d.name}</h3>
-                <span class={`src-badge ${d.fixed ? 'src-off' : 'src-est'}`}>{d.fixed ? 'Officiel CEPS' : 'Estimation'}</span>
+                <span class={`src-badge ${d.fixed ? 'src-off' : 'src-est'}`}>{d.fixed ? 'Prix officiel' : 'Prix libre'}</span>
               </div>
               <p class="drug-note">{d.note}</p>
-              <table class="price-table">
-                <thead>
-                  <tr><th>Dosage</th><th>Prix</th></tr>
-                </thead>
-                <tbody>
-                  {d.rows.map((r) => (
-                    <tr>
-                      <td>{r.dose}</td>
-                      <td><strong>{r.price.toFixed(2)} €</strong></td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              {d.rows.length > 0 && (
+                <table class="price-table">
+                  <thead>
+                    <tr><th>Dosage</th><th>Prix</th></tr>
+                  </thead>
+                  <tbody>
+                    {d.rows.map((r) => (
+                      <tr>
+                        <td>{r.dose}</td>
+                        <td><strong>{r.price.toFixed(2)} €</strong></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
             </div>
           ))}
         </div>
@@ -374,7 +373,7 @@ const faq = [
         <div class="pharma-section-inner">
           <h2>Autres pharmacies à {cityCap}</h2>
           <p class="neighbours-intro">
-            Si {nameCap} est en rupture de stock ou si vous cherchez une seconde estimation tarifaire, voici {neighbours.length} pharmacie{neighbours.length > 1 ? 's' : ''} voisine{neighbours.length > 1 ? 's' : ''} à {cityCap} qui peuvent également dispenser vos traitements GLP-1. Le prix Ozempic (CEPS) est identique partout ; les estimations Wegovy / Mounjaro / Saxenda peuvent légèrement varier selon le FINESS de l'officine.
+            Si {nameCap} est en rupture de stock, voici {neighbours.length} pharmacie{neighbours.length > 1 ? 's' : ''} voisine{neighbours.length > 1 ? 's' : ''} à {cityCap} qui peuvent également dispenser vos traitements GLP-1. Les prix étant réglementés et identiques partout, la seule question est la disponibilité — appelez avant de vous déplacer.
           </p>
           <div class="neighbours-grid">
             {neighbours.map((n) => (
@@ -400,8 +399,8 @@ const faq = [
         <h2>Sources et méthodologie</h2>
         <ul class="trust-list">
           <li><strong>Identité de la pharmacie</strong> : référentiel <a href="https://finess.esante.gouv.fr/" target="_blank" rel="noopener noreferrer">FINESS officiel</a> (Agence du numérique en santé / data.gouv.fr).</li>
-          <li><strong>Prix Ozempic</strong> : <a href="https://solidarites-sante.gouv.fr/ministere/acteurs/instances-rattachees/comite-economique-des-produits-de-sante-ceps/" target="_blank" rel="noopener noreferrer">CEPS (Comité Économique des Produits de Santé)</a> — 80,18 €/stylo, identique France entière, encadré par décret.</li>
-          <li><strong>Estimations Wegovy / Mounjaro / Saxenda</strong> : moyenne nationale du prix libéré observée sur le marché français, ajustée par variance géographique (zone urbaine premium / standard / rurale) et identifiant FINESS de l'officine. Méthodologie reproductible — voir le code source : <code>src/lib/pharmacyPricing.ts</code>.</li>
+          <li><strong>Prix Ozempic, Wegovy, Mounjaro</strong> : prix réglementés publiés à la <a href="https://base-donnees-publique.medicaments.gouv.fr/" target="_blank" rel="noopener noreferrer">Base de données publique des médicaments</a> (arrêtés JO du 28 mai 2026, en vigueur au 15 juin 2026) — identiques dans toutes les pharmacies françaises.</li>
+          <li><strong>Saxenda</strong> : prix libre, non remboursé — tarif à demander directement à l'officine.</li>
           <li><strong>Données remboursement</strong> : <a href="https://www.has-sante.fr/" target="_blank" rel="noopener noreferrer">HAS</a> et <a href="https://www.ameli.fr/" target="_blank" rel="noopener noreferrer">Assurance Maladie</a>, à jour {updateMonth}.</li>
         </ul>
         <p class="trust-disclaimer">
@@ -439,7 +438,7 @@ const faq = [
     </section>
 
     <section class="pharma-disclaimer">
-      <p><strong>Avertissement médical :</strong> cette page est informative et ne remplace pas un avis médical. Les prix Wegovy, Mounjaro et Saxenda sont des estimations basées sur la moyenne marché FR + variance géographique (zone {deptZone}), vérifiez le tarif exact auprès de {nameCap}. Sources : référentiel FINESS (data.gouv.fr / Atlasanté), CEPS, HAS, Ameli — mises à jour {updateMonth}.</p>
+      <p><strong>Avertissement médical :</strong> cette page est informative et ne remplace pas un avis médical. Les prix d'Ozempic, Wegovy et Mounjaro sont réglementés et identiques dans toutes les pharmacies (arrêtés en vigueur au 15 juin 2026) ; le prix de Saxenda est libre, demandez-le à {nameCap}. Sources : référentiel FINESS (data.gouv.fr / Atlasanté), Base de données publique des médicaments, Légifrance, HAS, Ameli — mises à jour {updateMonth}.</p>
     </section>
   </div>
 

--- a/src/pages/pharmacies/[ville]/prix-ozempic.astro
+++ b/src/pages/pharmacies/[ville]/prix-ozempic.astro
@@ -1,0 +1,130 @@
+---
+import StaticLayout from '../../../layouts/StaticLayout.astro';
+import { getPriceCityPaths, titleCaseCity } from '../../../lib/pharmacyCityData';
+
+// SEO local (top 200 villes) — cible "ozempic [ville]", "prix ozempic [ville]", "pharmacie ozempic [ville]".
+// Ozempic = diabète type 2 uniquement : angle différent des pages Wegovy/Mounjaro (obésité).
+
+export async function getStaticPaths() {
+  return getPriceCityPaths();
+}
+
+const { city: rawCity, department, pharmacies, csos } = Astro.props;
+const city = titleCaseCity(rawCity);
+const nb = pharmacies.length;
+const shown = pharmacies.slice(0, 25);
+
+const faq = [
+  { q: `Quel est le prix d'Ozempic à ${city} ?`, a: `Ozempic coûte 77,60 € TTC par stylo, prix officiel identique dans toutes les pharmacies de ${city} comme partout en France (dosages 0,25, 0,5 et 1 mg). Il est remboursé à 30 % par l'Assurance Maladie pour le diabète de type 2, et à 100 % pour les patients en ALD.` },
+  { q: `Ozempic est-il remboursé pour maigrir à ${city} ?`, a: `Non. Ozempic n'est remboursé que pour le diabète de type 2. Pour la perte de poids, ce sont Wegovy et Mounjaro qui sont remboursés à 65 % depuis le 15 juin 2026, sous conditions (IMC ≥ 40, ou ≥ 35 avec comorbidité, après 6 mois de prise en charge nutritionnelle). Faites notre test d'éligibilité pour vérifier vos critères.` },
+  { q: `Comment savoir si une pharmacie de ${city} a Ozempic en stock ?`, a: `Appelez avant de vous déplacer avec votre ordonnance. La pharmacie peut aussi commander auprès de son grossiste, généralement sous 24 à 48 h. La pénurie d'Ozempic est terminée : l'ANSM a levé toutes les restrictions en juin 2025 et ne signale aucune tension en 2026.` },
+  { q: `Quel est le reste à charge sur Ozempic à ${city} ?`, a: `Hors ALD, le reste à charge est d'environ 54 € par stylo (remboursement 30 % sur 77,60 €), souvent réduit par la mutuelle. Les patients diabétiques en ALD (affection longue durée) sont pris en charge à 100 % : aucun reste à charge.` },
+];
+
+const faqJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faq.map((f) => ({ '@type': 'Question', name: f.q, acceptedAnswer: { '@type': 'Answer', text: f.a } })),
+});
+---
+
+<StaticLayout
+  title={`Prix Ozempic à ${city} 2026 : 77,60 € (officiel) — Pharmacies et Disponibilité`}
+  description={`Prix d'Ozempic à ${city} : 77,60 € TTC le stylo, identique dans les ${nb} pharmacies de la ville. Remboursé 30 % (diabète type 2), 100 % en ALD. Où le trouver et vérifier la disponibilité.`}
+  keywords={`ozempic ${city.toLowerCase()}, prix ozempic ${city.toLowerCase()}, pharmacie ozempic ${city.toLowerCase()}`}
+>
+  <script type="application/ld+json" set:html={faqJsonLd} />
+  <div class="min-h-screen py-10" style="background: linear-gradient(160deg, #f0fdf4 0%, #ffffff 50%);">
+    <div class="container mx-auto px-4 max-w-3xl">
+
+      <h1 class="text-3xl md:text-4xl font-bold mb-4" style="color:#1a3c34;">Prix Ozempic à {city} : 77,60 € dans toutes les pharmacies</h1>
+
+      <p class="text-lg text-gray-700 mb-6">
+        Le prix d'Ozempic (sémaglutide) est <strong>officiel et identique</strong> dans les {nb} pharmacies
+        de {city} comme partout en France : <strong>77,60 € TTC par stylo</strong>, quel que soit le dosage
+        (0,25, 0,5 ou 1 mg). Inutile de comparer les officines — la seule chose à vérifier, c'est la
+        <strong>disponibilité en stock</strong>.
+      </p>
+
+      <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Prix et remboursement 2026</h2>
+      <div class="overflow-x-auto mb-2">
+        <table class="w-full bg-white rounded-xl shadow border border-gray-100 text-left">
+          <thead><tr style="background:#1a3c34; color:white;"><th class="p-3">Situation</th><th class="p-3">Prix du stylo</th><th class="p-3">Reste à charge</th></tr></thead>
+          <tbody>
+            <tr class="border-t border-gray-100">
+              <td class="p-3 font-medium">Diabète type 2 (remboursé 30 %)</td>
+              <td class="p-3">77,60 €</td>
+              <td class="p-3 text-gray-600">~54,32 € avant mutuelle</td>
+            </tr>
+            <tr class="border-t border-gray-100">
+              <td class="p-3 font-medium">Diabète type 2 en ALD (100 %)</td>
+              <td class="p-3">77,60 €</td>
+              <td class="p-3 text-gray-600">0 €</td>
+            </tr>
+            <tr class="border-t border-gray-100">
+              <td class="p-3 font-medium">Hors indication (non remboursé)</td>
+              <td class="p-3">77,60 €</td>
+              <td class="p-3 text-gray-600">77,60 €</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="text-sm text-gray-500 mb-6">Ozempic est indiqué et remboursé uniquement pour le diabète de type 2. Pour la perte de poids,
+        voir <a href={`/pharmacies/${Astro.params.ville}/prix-wegovy/`} style="color:#16a34a; font-weight:600;">Wegovy</a> et
+        <a href={`/pharmacies/${Astro.params.ville}/prix-mounjaro/`} style="color:#16a34a; font-weight:600;">Mounjaro</a>, remboursés à 65 % depuis le 15 juin 2026 —
+        <a href="/outils/test-eligibilite/" style="color:#16a34a; font-weight:600;">testez votre éligibilité en 2 minutes →</a></p>
+
+      <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Trouver Ozempic en stock à {city}</h2>
+      <p class="text-gray-700 mb-4">
+        La pénurie est terminée : l'ANSM a levé toutes les restrictions en juin 2025 et aucun GLP-1 ne figure sur la
+        liste des tensions d'approvisionnement en 2026. Toutes les pharmacies peuvent délivrer Ozempic sur ordonnance,
+        et commander sous 24-48 h si besoin. Quelques adresses parmi les {nb} pharmacies de {city} :
+      </p>
+      <div class="bg-white rounded-xl shadow border border-gray-100 p-4 mb-3">
+        <ul class="grid md:grid-cols-2 gap-x-6 gap-y-1 text-sm text-gray-700">
+          {shown.map((p) => <li>• {p.name} <span class="text-gray-400">({p.postal})</span></li>)}
+        </ul>
+      </div>
+      <p class="mb-8"><a href={`/pharmacies/${Astro.params.ville}/`} style="color:#16a34a; font-weight:600;">Voir les {nb} pharmacies de {city} sur la carte →</a></p>
+
+      {csos.length > 0 && (
+        <>
+          <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Suivi spécialisé dans le département {department}</h2>
+          <p class="text-gray-700 mb-4">
+            Ozempic peut être prescrit par tout médecin (généraliste ou spécialiste) pour le diabète de type 2.
+            Pour un accompagnement spécialisé — diabète complexe ou obésité associée — voici
+            {csos.length > 1 ? ' les centres hospitaliers spécialisés' : ' le centre hospitalier spécialisé'} du département :
+          </p>
+          <div class="bg-white rounded-xl shadow border border-gray-100 p-4 mb-8">
+            <ul class="space-y-2 text-sm text-gray-700">
+              {csos.map((c) => (
+                <li>
+                  <strong>{c.name}</strong>{c.parent_hospital ? ` — ${c.parent_hospital}` : ''}<br />
+                  <span class="text-gray-500">{c.postal_code} {c.city}{c.phone ? ` · ${c.phone}` : ''}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
+
+      <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Questions fréquentes</h2>
+      <div class="space-y-4 mb-8">
+        {faq.map((f) => (
+          <details class="bg-white rounded-lg border border-gray-100 p-4">
+            <summary class="font-semibold cursor-pointer" style="color:#1a3c34;">{f.q}</summary>
+            <p class="mt-2 text-gray-700">{f.a}</p>
+          </details>
+        ))}
+      </div>
+
+      <div class="text-sm text-gray-500">
+        Pour aller plus loin : <a href="/collections/glp1-cout/prix-ozempic-france/" style="color:#16a34a;">prix Ozempic en France (guide complet)</a> ·
+        <a href="/collections/glp1-cout/remboursement-glp1-2026/" style="color:#16a34a;">remboursement GLP-1 2026</a> ·
+        <a href={`/pharmacies/${Astro.params.ville}/prix-wegovy/`} style="color:#16a34a;">prix Wegovy à {city}</a> ·
+        <a href={`/pharmacies/${Astro.params.ville}/prix-mounjaro/`} style="color:#16a34a;">prix Mounjaro à {city}</a> ·
+        <a href="/outils/carte-prix-pharmacies/" style="color:#16a34a;">carte des pharmacies</a>
+      </div>
+    </div>
+  </div>
+</StaticLayout>

--- a/src/pages/pharmacies/[ville]/prix-wegovy.astro
+++ b/src/pages/pharmacies/[ville]/prix-wegovy.astro
@@ -2,8 +2,8 @@
 import StaticLayout from '../../../layouts/StaticLayout.astro';
 import { getPriceCityPaths, titleCaseCity } from '../../../lib/pharmacyCityData';
 
-// SEO local (top 200 villes) — cible "mounjaro [ville]", "pharmacie mounjaro [ville]".
-// Prix réglementés depuis le 15/06/2026 : la page mise sur l'annuaire + la dispo + le parcours CSO.
+// SEO local (top 200 villes) — cible "wegovy [ville]", "prix wegovy [ville]", "pharmacie wegovy [ville]".
+// Prix réglementés depuis le 15/06/2026 : annuaire + disponibilité + parcours CSO.
 
 export async function getStaticPaths() {
   return getPriceCityPaths();
@@ -15,17 +15,16 @@ const nb = pharmacies.length;
 const shown = pharmacies.slice(0, 25);
 
 const DOSES = [
-  { dose: '2,5 mg (initiation)', prix: '176,10 €' },
-  { dose: '5 mg', prix: '237,68 €' },
-  { dose: '7,5 – 10 mg', prix: '335,95 €' },
-  { dose: '12,5 – 15 mg', prix: '433,80 €' },
+  { dose: '0,25 – 1 mg (initiation et titration)', prix: '146,91 €' },
+  { dose: '1,7 mg', prix: '169,31 €' },
+  { dose: '2,4 mg (dose d’entretien)', prix: '195,10 €' },
 ];
 
 const faq = [
-  { q: `Quel est le prix de Mounjaro à ${city} ?`, a: `Le prix de Mounjaro est réglementé et identique dans toutes les pharmacies de ${city} comme partout en France depuis le 15 juin 2026 : de 176,10 € (2,5 mg) à 433,80 € (15 mg) par mois selon le dosage. Il est remboursé à 65 % par l'Assurance Maladie sous conditions.` },
-  { q: `Quelle pharmacie de ${city} vend Mounjaro le moins cher ?`, a: `Aucune : depuis l'inscription au remboursement (15 juin 2026), le prix est fixé par l'État et identique dans toutes les pharmacies. Inutile de comparer les prix — la vraie question est la disponibilité en stock.` },
-  { q: `Comment savoir si une pharmacie de ${city} a Mounjaro en stock ?`, a: `Appelez avant de vous déplacer avec votre ordonnance. La pharmacie peut aussi commander auprès de son grossiste, généralement sous 24 à 48 h. Aucune tension d'approvisionnement n'est signalée par l'ANSM en 2026.` },
-  { q: `Mounjaro est-il remboursé à ${city} ?`, a: `Oui, comme partout en France : 65 % par l'Assurance Maladie si IMC ≥ 35 avec comorbidité ou IMC ≥ 40, après 6 mois de prise en charge nutritionnelle, avec une première prescription par un spécialiste de l'obésité (CSO, CHU). Votre mutuelle peut couvrir les 35 % restants.` },
+  { q: `Quel est le prix de Wegovy à ${city} ?`, a: `Le prix de Wegovy est réglementé et identique dans toutes les pharmacies de ${city} comme partout en France depuis le 15 juin 2026 : de 146,91 € (dosages d'initiation 0,25 à 1 mg) à 195,10 € (2,4 mg, dose d'entretien) par mois. Il est remboursé à 65 % par l'Assurance Maladie sous conditions.` },
+  { q: `Quelle pharmacie de ${city} vend Wegovy le moins cher ?`, a: `Aucune : depuis l'inscription au remboursement (15 juin 2026), le prix est fixé par l'État et identique dans toutes les pharmacies. Inutile de comparer les prix — la vraie question est la disponibilité en stock.` },
+  { q: `Comment savoir si une pharmacie de ${city} a Wegovy en stock ?`, a: `Appelez avant de vous déplacer avec votre ordonnance. La pharmacie peut aussi commander auprès de son grossiste, généralement sous 24 à 48 h. Aucune tension d'approvisionnement n'est signalée par l'ANSM en 2026.` },
+  { q: `Wegovy est-il remboursé à ${city} ?`, a: `Oui, comme partout en France : 65 % par l'Assurance Maladie si IMC ≥ 35 avec comorbidité ou IMC ≥ 40, après 6 mois de prise en charge nutritionnelle, avec une première prescription par un spécialiste de l'obésité (CSO, CHU). Votre mutuelle peut couvrir les 35 % restants.` },
 ];
 
 const faqJsonLd = JSON.stringify({
@@ -36,18 +35,18 @@ const faqJsonLd = JSON.stringify({
 ---
 
 <StaticLayout
-  title={`Prix Mounjaro à ${city} 2026 : 176,10 € (réglementé) — Pharmacies et Disponibilité`}
-  description={`Prix de Mounjaro à ${city} : 176,10 à 433,80 €/mois, identique dans les ${nb} pharmacies de la ville (prix réglementé). Remboursé 65 %. Où le trouver et vérifier la disponibilité.`}
-  keywords={`mounjaro ${city.toLowerCase()}, prix mounjaro ${city.toLowerCase()}, pharmacie mounjaro ${city.toLowerCase()}`}
+  title={`Prix Wegovy à ${city} 2026 : 146,91 € (réglementé) — Pharmacies et Disponibilité`}
+  description={`Prix de Wegovy à ${city} : 146,91 à 195,10 €/mois, identique dans les ${nb} pharmacies de la ville (prix réglementé). Remboursé 65 %. Où le trouver et vérifier la disponibilité.`}
+  keywords={`wegovy ${city.toLowerCase()}, prix wegovy ${city.toLowerCase()}, pharmacie wegovy ${city.toLowerCase()}`}
 >
   <script type="application/ld+json" set:html={faqJsonLd} />
   <div class="min-h-screen py-10" style="background: linear-gradient(160deg, #f0fdf4 0%, #ffffff 50%);">
     <div class="container mx-auto px-4 max-w-3xl">
 
-      <h1 class="text-3xl md:text-4xl font-bold mb-4" style="color:#1a3c34;">Prix Mounjaro à {city} : le même dans toutes les pharmacies (et c'est une bonne nouvelle)</h1>
+      <h1 class="text-3xl md:text-4xl font-bold mb-4" style="color:#1a3c34;">Prix Wegovy à {city} : le même dans toutes les pharmacies (et c'est une bonne nouvelle)</h1>
 
       <p class="text-lg text-gray-700 mb-6">
-        Vous cherchez la pharmacie la moins chère de {city} pour Mounjaro (tirzépatide) ? Depuis le
+        Vous cherchez la pharmacie la moins chère de {city} pour Wegovy (sémaglutide) ? Depuis le
         <strong>15 juin 2026</strong>, la question ne se pose plus : le prix est <strong>réglementé par l'État</strong> et
         identique dans les {nb} pharmacies de la ville. Fini les écarts de prix — la seule chose à vérifier, c'est la
         <strong>disponibilité en stock</strong>.
@@ -71,9 +70,9 @@ const faqJsonLd = JSON.stringify({
       <p class="text-sm text-gray-500 mb-6">* Si éligible au remboursement (IMC ≥ 35 avec comorbidité ou ≥ 40) ; votre mutuelle peut couvrir ce reste à charge.
         <a href="/outils/test-eligibilite/" style="color:#16a34a; font-weight:600;">Vérifiez votre éligibilité en 2 minutes →</a></p>
 
-      <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Trouver Mounjaro en stock à {city}</h2>
+      <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Trouver Wegovy en stock à {city}</h2>
       <p class="text-gray-700 mb-4">
-        Toutes les pharmacies peuvent délivrer Mounjaro sur ordonnance, et commander sous 24-48 h si besoin.
+        Toutes les pharmacies peuvent délivrer Wegovy sur ordonnance, et commander sous 24-48 h si besoin.
         L'ANSM ne signale aucune tension d'approvisionnement en 2026. Appelez avant de vous déplacer. Quelques adresses parmi les {nb} pharmacies de {city} :
       </p>
       <div class="bg-white rounded-xl shadow border border-gray-100 p-4 mb-3">
@@ -87,7 +86,7 @@ const faqJsonLd = JSON.stringify({
         <>
           <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Où obtenir la première prescription (département {department})</h2>
           <p class="text-gray-700 mb-4">
-            Pour être remboursé, Mounjaro doit d'abord être prescrit par un <strong>spécialiste de l'obésité</strong> —
+            Pour être remboursé, Wegovy doit d'abord être prescrit par un <strong>spécialiste de l'obésité</strong> —
             en pratique un Centre Spécialisé Obésité (CSO) ou un service hospitalier. Le renouvellement peut ensuite être
             fait par votre médecin traitant. Voici {csos.length > 1 ? 'les centres' : 'le centre'} du département :
           </p>
@@ -115,9 +114,9 @@ const faqJsonLd = JSON.stringify({
       </div>
 
       <div class="text-sm text-gray-500">
-        Pour aller plus loin : <a href="/collections/glp1-cout/prix-mounjaro-france/" style="color:#16a34a;">prix Mounjaro en France (guide complet)</a> ·
+        Pour aller plus loin : <a href="/collections/glp1-cout/prix-wegovy-france/" style="color:#16a34a;">prix Wegovy en France (guide complet)</a> ·
         <a href="/collections/glp1-cout/remboursement-mounjaro-wegovy-15-juin-2026/" style="color:#16a34a;">conditions du remboursement</a> ·
-        <a href={`/pharmacies/${Astro.params.ville}/prix-wegovy/`} style="color:#16a34a;">prix Wegovy à {city}</a> ·
+        <a href={`/pharmacies/${Astro.params.ville}/prix-mounjaro/`} style="color:#16a34a;">prix Mounjaro à {city}</a> ·
         <a href={`/pharmacies/${Astro.params.ville}/prix-ozempic/`} style="color:#16a34a;">prix Ozempic à {city}</a> ·
         <a href="/outils/carte-prix-pharmacies/" style="color:#16a34a;">carte des pharmacies</a>
       </div>

--- a/src/pages/pharmacies/cp/[zipcode].astro
+++ b/src/pages/pharmacies/cp/[zipcode].astro
@@ -35,14 +35,14 @@ export async function getStaticPaths() {
     });
   }
 
-  // Top 100 villes (même seuil que [ville].astro)
+  // Top 500 villes (même seuil que [ville].astro)
   const cityCounts = new Map<string, number>();
   for (const row of pharmacies.rows) {
     const slug = row[iSlug];
     if (slug) cityCounts.set(slug, (cityCounts.get(slug) || 0) + 1);
   }
   const validCitySlugs = new Set(
-    [...cityCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 100).map(([s]) => s)
+    [...cityCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 500).map(([s]) => s)
   );
 
   // Génère une page par zipcode ayant >=3 pharmacies (évite les pages 1-row sans valeur)
@@ -72,7 +72,7 @@ function titleCase(s) { return (s || '').toLowerCase().replace(/\b\w/g, (c) => c
 const cityCap = titleCase(city);
 
 const title = `Pharmacies GLP-1 ${zip} (${cityCap}) — Prix Ozempic, Wegovy, Mounjaro`;
-const description = `${pharmas.length} pharmacies au code postal ${zip} à ${cityCap}. Prix Ozempic officiel 80,18 €, prix Wegovy / Mounjaro / Saxenda estimés par pharmacie.`;
+const description = `${pharmas.length} pharmacies au code postal ${zip} à ${cityCap}. Prix officiels 2026 : Ozempic 77,60 €, Wegovy 146,91–195,10 €, Mounjaro 176,10–433,80 € (réglementés, identiques partout).`;
 
 // Autres codes postaux de la même ville
 import fs2 from 'node:fs';
@@ -121,7 +121,7 @@ const mapPharmas = pharmas.slice(0, 500).map((p) => ({ id: p.id, name: p.name, l
           <strong>{zip}</strong>
         </nav>
         <h1>Pharmacies code postal {zip} — {cityCap}</h1>
-        <p class="zip-hero-sub"><strong>{pharmas.length} pharmacies</strong> référencées dans le secteur {zip} ({cityCap}, {dept}). Prix Ozempic officiel CEPS, estimations Wegovy/Mounjaro/Saxenda.</p>
+        <p class="zip-hero-sub"><strong>{pharmas.length} pharmacies</strong> référencées dans le secteur {zip} ({cityCap}, {dept}). Prix Ozempic, Wegovy et Mounjaro réglementés, identiques dans toutes les officines.</p>
         <div class="zip-ctas">
           <a href="/outils/carte-prix-pharmacies/" class="btn-primary">Carte interactive complète →</a>
           {hasCityPage && <a href={`/pharmacies/${citySlug}/`} class="btn-secondary">Retour à {cityCap}</a>}
@@ -209,7 +209,7 @@ const mapPharmas = pharmas.slice(0, 500).map((p) => ({ id: p.id, name: p.name, l
     )}
 
     <section class="zip-disclaimer">
-      <p>Source : référentiel FINESS (data.gouv.fr / Atlasanté). Cette page est informative ; consultez la pharmacie pour confirmer les prix des traitements en prix libéré (Wegovy, Mounjaro, Saxenda).</p>
+      <p>Source : référentiel FINESS (data.gouv.fr / Atlasanté). Cette page est informative. Les prix d'Ozempic, Wegovy et Mounjaro sont réglementés et identiques dans toutes les pharmacies (arrêtés en vigueur au 15 juin 2026) ; seul Saxenda reste en prix libre.</p>
     </section>
   </div>
 

--- a/src/pages/pharmacies/dept/[dept].astro
+++ b/src/pages/pharmacies/dept/[dept].astro
@@ -189,19 +189,16 @@ const isPremiumDept = PREMIUM_DEPTS.has(deptCode);
 const isRuralDept = RURAL_DEPTS.has(deptCode);
 const deptZone = isPremiumDept ? 'urbaine premium' : isRuralDept ? 'rurale' : 'standard';
 
-// Estimations prix moyens régionaux Wegovy / Mounjaro selon zone (méthodologie partagée avec pages pharmacie)
-// Référence : moyenne marché FR + variance géographique
-const WEGOVY_AVG_FR = 269;   // moyenne nationale dosages 1.0/1.7 mg
-const MOUNJARO_AVG_FR = 322; // moyenne nationale dosages 5/7.5 mg
-const variance = isPremiumDept ? 1.06 : isRuralDept ? 0.95 : 1.00;
-const wegovyAvg = WEGOVY_AVG_FR * variance;
-const mounjaroAvg = MOUNJARO_AVG_FR * variance;
+// Prix officiels réglementés (BDPM / arrêtés JO du 28/05/2026, en vigueur 15/06/2026) — identiques partout
+const OZEMPIC_PRICE = '77,60 €';
+const WEGOVY_RANGE = '146,91 – 195,10 €';
+const MOUNJARO_RANGE = '176,10 – 433,80 €';
 
 const updateDate = new Date();
 const updateMonth = updateDate.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
 
 const title = `Pharmacies GLP-1 ${deptLabel} (${deptCode}) — Prix Ozempic Wegovy Mounjaro 2026`;
-const description = `${totalPharmas.toLocaleString('fr-FR')} pharmacies du département ${deptLabel} (${deptCode}) — chef-lieu ${prefecture}. Prix Ozempic CEPS 80,18 € (remboursé 65 % DT2 bithérapie), Wegovy ~${wegovyAvg.toFixed(0)} € et Mounjaro ~${mounjaroAvg.toFixed(0)} € (estimations zone ${deptZone}). Carte + ${totalCities} villes.`;
+const description = `${totalPharmas.toLocaleString('fr-FR')} pharmacies du département ${deptLabel} (${deptCode}) — chef-lieu ${prefecture}. Prix officiels 2026 : Ozempic 77,60 €, Wegovy 146,91–195,10 €, Mounjaro 176,10–433,80 € (réglementés, identiques partout). Carte + ${totalCities} villes.`;
 
 // FAQ — questions départementales spécifiques (pas de duplicate avec pages villes)
 const faq = [
@@ -210,12 +207,12 @@ const faq = [
     a: `Notre référentiel FINESS officiel recense **${totalPharmas.toLocaleString('fr-FR')} pharmacies d'officine** dans le département ${deptLabel} (${deptCode}), réparties dans **${totalCities.toLocaleString('fr-FR')} communes** et ${totalZipcodes} codes postaux différents. Toutes peuvent dispenser les traitements GLP-1 (Ozempic, Wegovy, Mounjaro, Trulicity, Victoza, Saxenda) sur ordonnance médicale.`,
   },
   {
-    q: `Quel est le prix moyen de Wegovy et Mounjaro en ${deptLabel} ?`,
-    a: `En zone ${deptZone} (département ${deptCode}), nos estimations basées sur la moyenne marché française placent le prix moyen Wegovy autour de **${wegovyAvg.toFixed(2)} €** par boîte et le prix moyen Mounjaro autour de **${mounjaroAvg.toFixed(2)} €** par boîte. Ces traitements étant en prix libéré (non remboursés), chaque pharmacie fixe son tarif. Pour Ozempic, le prix CEPS de **80,18 €** est identique partout en France, y compris dans tout le ${deptLabel}.`,
+    q: `Quel est le prix de Wegovy et Mounjaro en ${deptLabel} ?`,
+    a: `Depuis le 15 juin 2026, les prix sont **réglementés et identiques dans toutes les pharmacies** du ${deptLabel} comme partout en France : Wegovy de **146,91 à 195,10 €** et Mounjaro de **176,10 à 433,80 €** par mois selon le dosage. Les deux sont remboursés à **65 %** par l'Assurance Maladie dans l'obésité, sous conditions. Ozempic est à **77,60 €** partout.`,
   },
   {
     q: `Ozempic est-il remboursé par la Sécurité sociale en ${deptLabel} ?`,
-    a: `Oui — le remboursement Ozempic dépend de l'indication, pas de la géographie. En 2026, Ozempic est remboursé à **65 %** par l'Assurance Maladie en bithérapie avec metformine (et 30 % en trithérapie avec insuline) pour les patients atteints de diabète de type 2 — 100 % en ALD (Affection Longue Durée). Wegovy, Mounjaro et Saxenda ne sont pas remboursés en France. Détails : [Remboursement GLP-1 2026](/collections/glp1-cout/remboursement-glp1-2026/).`,
+    a: `Oui — le remboursement Ozempic dépend de l'indication, pas de la géographie. En 2026, Ozempic est remboursé à **30 %** par l'Assurance Maladie pour le diabète de type 2 — et à **100 %** en ALD (Affection Longue Durée). Wegovy et Mounjaro sont quant à eux remboursés à **65 %** dans l'obésité depuis le 15 juin 2026, sous conditions (IMC, primo-prescription spécialiste). Détails : [Remboursement GLP-1 2026](/collections/glp1-cout/remboursement-glp1-2026/).`,
   },
   {
     q: `Quelle est la ville avec le plus de pharmacies en ${deptLabel} ?`,
@@ -227,7 +224,7 @@ const faq = [
   },
   {
     q: `Les prix varient-ils entre ${prefecture} et le reste du ${deptLabel} ?`,
-    a: `Pour **Ozempic**, non — le prix CEPS de 80,18 € est identique dans toutes les pharmacies françaises (encadré par décret). Pour **Wegovy, Mounjaro et Saxenda** (prix libéré), de légères variations peuvent exister entre la préfecture et les zones moins denses du département. Notre méthodologie applique un coefficient de variance ${isPremiumDept ? '+6 %' : isRuralDept ? '−5 %' : 'neutre'} pour la zone ${deptZone} — voir la page d'une pharmacie spécifique pour l'estimation détaillée.`,
+    a: `Non. Depuis le 15 juin 2026, les prix d'Ozempic (77,60 €), de Wegovy (146,91 – 195,10 €) et de Mounjaro (176,10 – 433,80 €) sont **réglementés par arrêté** : ils sont identiques dans toutes les pharmacies françaises, à ${prefecture} comme dans les plus petites communes du ${deptLabel}. Seul Saxenda reste en prix libre et peut varier d'une officine à l'autre.`,
   },
 ];
 
@@ -279,7 +276,7 @@ const wikiUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(deptLabel.re
         <h1>Pharmacies GLP-1 en {deptLabel}</h1>
         <p class="dept-sub">
           <strong>{totalPharmas.toLocaleString('fr-FR')} pharmacies</strong> référencées dans {totalCities.toLocaleString('fr-FR')} communes ·
-          Chef-lieu : <strong>{prefecture}</strong> · Prix Ozempic officiel CEPS, estimations Wegovy/Mounjaro
+          Chef-lieu : <strong>{prefecture}</strong> · Prix Ozempic, Wegovy et Mounjaro réglementés, identiques partout
         </p>
         <div class="dept-stats-row">
           <div class="dept-stat">
@@ -295,8 +292,8 @@ const wikiUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(deptLabel.re
             <div class="dept-stat-lbl">codes postaux</div>
           </div>
           <div class="dept-stat">
-            <div class="dept-stat-num">80,18 €</div>
-            <div class="dept-stat-lbl">prix Ozempic CEPS</div>
+            <div class="dept-stat-num">77,60 €</div>
+            <div class="dept-stat-lbl">prix Ozempic officiel</div>
           </div>
         </div>
         <div class="dept-ctas">
@@ -429,13 +426,12 @@ const wikiUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(deptLabel.re
       </div>
     </section>
 
-    <!-- Prix moyens régionaux -->
+    <!-- Prix officiels -->
     <section class="dept-prices">
       <div class="dept-section-inner">
-        <h2>Prix moyens des traitements GLP-1 en {deptLabel}</h2>
+        <h2>Prix des traitements GLP-1 en {deptLabel}</h2>
         <p class="prices-intro">
-          Le département {deptLabel} appartient à la zone <strong>{deptZone}</strong> (coefficient de variance {isPremiumDept ? '+6 %' : isRuralDept ? '−5 %' : 'neutre'} par rapport à la moyenne nationale).
-          Pour Ozempic, le prix officiel CEPS est identique partout en France. Pour Wegovy et Mounjaro (prix libéré), nos estimations tiennent compte du contexte régional.
+          Depuis le <strong>15 juin 2026</strong>, les prix d'Ozempic, Wegovy et Mounjaro sont <strong>réglementés par arrêté</strong> : ils sont identiques dans toutes les pharmacies du {deptLabel} comme partout en France. Inutile de comparer les officines — la seule question est la disponibilité en stock.
           Données mises à jour {updateMonth}.
         </p>
 
@@ -443,42 +439,42 @@ const wikiUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(deptLabel.re
           <div class="drug-card">
             <div class="drug-head">
               <h3>Ozempic</h3>
-              <span class="src-badge src-off">Officiel CEPS</span>
+              <span class="src-badge src-off">Prix officiel</span>
             </div>
             <div class="drug-price-row">
               <div class="price-label">Prix officiel</div>
-              <div class="price-big">80,18 €</div>
-              <div class="price-meta">par stylo · identique France entière</div>
+              <div class="price-big">{OZEMPIC_PRICE}</div>
+              <div class="price-meta">TTC par stylo · identique France entière</div>
             </div>
-            <p class="drug-note">Remboursé 65 % bithérapie metformine / 30 % trithérapie insuline (DT2). 100 % en ALD.</p>
+            <p class="drug-note">Remboursé 30 % (diabète type 2) · 100 % en ALD.</p>
             <a href="/collections/glp1-cout/prix-ozempic-france/" class="link-small">Détails prix Ozempic →</a>
           </div>
 
           <div class="drug-card">
             <div class="drug-head">
               <h3>Wegovy</h3>
-              <span class="src-badge src-est">Estimation</span>
+              <span class="src-badge src-off">Prix officiel</span>
             </div>
             <div class="drug-price-row">
-              <div class="price-label">Prix moyen estimé</div>
-              <div class="price-big">{wegovyAvg.toFixed(2)} €</div>
-              <div class="price-meta">zone {deptZone} · variance {isPremiumDept ? '+6 %' : isRuralDept ? '−5 %' : '0 %'}</div>
+              <div class="price-label">Prix réglementé</div>
+              <div class="price-big">{WEGOVY_RANGE}</div>
+              <div class="price-meta">selon dosage · identique France entière</div>
             </div>
-            <p class="drug-note">Prix libéré (non remboursé). Chaque pharmacie fixe son tarif. Fourchette nationale : 169 – 360 €.</p>
+            <p class="drug-note">Remboursé 65 % depuis le 15/06/2026 (obésité, sous conditions IMC + primo-prescription spécialiste).</p>
             <a href="/collections/glp1-cout/prix-wegovy-france/" class="link-small">Détails prix Wegovy →</a>
           </div>
 
           <div class="drug-card">
             <div class="drug-head">
               <h3>Mounjaro</h3>
-              <span class="src-badge src-est">Estimation</span>
+              <span class="src-badge src-off">Prix officiel</span>
             </div>
             <div class="drug-price-row">
-              <div class="price-label">Prix moyen estimé</div>
-              <div class="price-big">{mounjaroAvg.toFixed(2)} €</div>
-              <div class="price-meta">zone {deptZone} · variance {isPremiumDept ? '+6 %' : isRuralDept ? '−5 %' : '0 %'}</div>
+              <div class="price-label">Prix réglementé</div>
+              <div class="price-big">{MOUNJARO_RANGE}</div>
+              <div class="price-meta">selon dosage · identique France entière</div>
             </div>
-            <p class="drug-note">Prix libéré (non remboursé). Avis HAS favorable nov. 2025, négociation CEPS en cours. Fourchette nationale : 230 – 440 €.</p>
+            <p class="drug-note">Remboursé 65 % depuis le 15/06/2026 (obésité, sous conditions IMC + primo-prescription spécialiste).</p>
             <a href="/collections/glp1-cout/prix-mounjaro-france/" class="link-small">Détails prix Mounjaro →</a>
           </div>
         </div>
@@ -608,10 +604,10 @@ const wikiUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(deptLabel.re
     <section class="dept-disclaimer">
       <p>
         <strong>Avertissement médical :</strong> cette page est informative et ne remplace pas un avis médical.
-        Tous les traitements GLP-1 nécessitent une ordonnance. Le prix Ozempic est officiel et identique en France entière.
-        Les prix moyens Wegovy et Mounjaro sont des <strong>estimations</strong> calculées par moyenne nationale + variance régionale (zone {deptZone}) ;
-        vérifiez le tarif exact directement auprès de chaque pharmacie. Sources : référentiel FINESS (data.gouv.fr / Atlasanté),
-        CEPS, HAS, Ameli — mises à jour {updateMonth}.
+        Tous les traitements GLP-1 nécessitent une ordonnance. Les prix d'Ozempic, Wegovy et Mounjaro sont réglementés
+        (arrêtés JO du 28 mai 2026, en vigueur au 15 juin 2026) et identiques dans toutes les pharmacies françaises ;
+        seul Saxenda reste en prix libre. Sources : référentiel FINESS (data.gouv.fr / Atlasanté),
+        Base de données publique des médicaments, Légifrance, HAS, Ameli — mises à jour {updateMonth}.
       </p>
     </section>
   </div>

--- a/src/pages/pharmacies/index.astro
+++ b/src/pages/pharmacies/index.astro
@@ -90,8 +90,8 @@ const totalPharmacies = pharmacies.rows.length;
           </div>
           <div class="info-card">
             <div class="info-icon">💰</div>
-            <h3>Prix Ozempic officiel</h3>
-            <p>Tarif CEPS de 80,18&nbsp;€/stylo appliqué partout en France (remboursé à 65&nbsp;% en bithérapie metformine, 30&nbsp;% en trithérapie insuline pour le diabète de type 2). Pour Wegovy, Mounjaro et Saxenda, le prix est libéré — il varie selon la pharmacie.</p>
+            <h3>Prix officiels réglementés</h3>
+            <p>Depuis le 15 juin 2026, les prix sont identiques dans toutes les pharmacies : Ozempic 77,60&nbsp;€ (remboursé 30&nbsp;% diabète type 2, 100&nbsp;% en ALD), Wegovy 146,91–195,10&nbsp;€ et Mounjaro 176,10–433,80&nbsp;€ (remboursés 65&nbsp;% dans l'obésité, sous conditions). Seul Saxenda reste en prix libre.</p>
           </div>
           <div class="info-card">
             <div class="info-icon">👥</div>


### PR DESCRIPTION
## Résumé

Scale-up programmatique des pages pharmacies (mission validée par Robin) — **palier 1 : +995 pages** (23 612 au total, build vert en 272 s), avec au préalable une correction critique des données prix sur toute la verticale.

### 🔴 Fix critique 1 : main ne buildait plus
`regime-mounjaro-optimal.md` avait une clé `updatedAt` dupliquée (introduite par le batch CTR de la PR #60) → `astro build` échouait → **le deploy FTP d'aujourd'hui a silencieusement échoué**. Corrigé (scan complet : aucun autre fichier touché).

### 🔴 Fix critique 2 : prix inventés sur ~20 000 pages live
La verticale pharmacies affichait des **prix "estimés" générés par hash FINESS ± coefficients départementaux** (pure invention, YMYL) et des faits périmés (Ozempic 80,18 € remboursé 65 % ; "Wegovy/Mounjaro non remboursés prix libéré"). Remplacé partout par les **prix officiels réglementés** (BDPM / arrêtés JO 28/05/2026, en vigueur 15/06/2026) :
- Ozempic **77,60 €** — remboursé 30 % (DT2), 100 % ALD
- Wegovy **146,91–195,10 €** selon dosage — remboursé 65 % (obésité, sous conditions)
- Mounjaro **176,10–433,80 €** selon dosage — remboursé 65 % (obésité, sous conditions)
- Saxenda : prix libre, **aucun chiffre inventé** (tarif à demander en officine)

Fichiers : `pharmacyPricing.ts` (suppression de `estimatePrice`/hash), `[pharmacie].astro` (20 145 pages), `[ville].astro`, `cp/[zipcode].astro`, `dept/[dept].astro`, `index.astro`, `outils/carte-prix-pharmacies.astro`. Retrait au passage de la reco Charles/Annette (affiliation désactivée).

### 🚀 Scale-up palier 1
- Pages hub villes : **100 → 500** (`[ville].astro`, flag `hasCityPage` de `cp/` synchronisé)
- `prix-mounjaro` : **5 → 200 villes**, via nouveau helper partagé `src/lib/pharmacyCityData.ts`
- **Nouvelles pages `prix-wegovy` et `prix-ozempic`** (200 villes chacune) : tableau prix officiels + reste à charge, liste pharmacies, **CSO/CHU du département** (cso.json, parcours primo-prescription), FAQ locale, maillage croisé prix↔ville↔guides
- Angle différencié Ozempic (DT2, 30 %/ALD) vs Wegovy/Mounjaro (obésité, 65 %)

### ✅ Validations
- Build : 23 612 pages, exit 0, 272 s (baseline 255 s), dist 2,3 GB
- Sitemap : 604 URLs prix incluses, sitemap-index OK
- Grep Zepbound : zéro occurrence contenu (seules les redirections 301 de conformité en .htaccess)
- Spot-checks : paris/index.html (7× 77,60 €, 0× 80,18 €), bobigny/prix-wegovy (146,91 € présent)

### Palier 2 (après vérification deploy + indexation)
Hub villes 500 → 1000, extension prix-* au-delà de 200 villes si l'indexation du palier 1 démarre bien.

⚠️ Le merge déclenche un **full sync FTP** (~25-40 min, `src/pages/pharmacies/` modifié) — comportement attendu du workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7J5qsK2jc3QZyAkBpuY6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7J5qsK2jc3QZyAkBpuY6e)_