### PR TITLE
docs(routine) : autonomie merge + deploy actée dans la matrice CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ La routine n'est PAS un rapporteur : c'est un **operateur autonome du site**. A 
 ### Matrice d'autonomie
 
 **Corriger DIRECTEMENT (sans demander)** :
+- **Merger ses propres PRs techniques/SEO et deployer** (autorisation explicite Robin 20/07/2026 : "tu dois etre completement autonome sur ces trucs la") — sauf si la PR touche un point de la liste "DEMANDER" ci-dessous. Apres merge, surveiller le deploy jusqu'au vert et verifier le site live.
 - seoTitle/seoDescription, headings, frontmatter, `updatedAt`
 - Maillage interne (ajout de liens contextuels entre articles)
 - Corrections factuelles SOURCEES (chiffre ANSM/HAS verifie via WebSearch, prix officiel, date)


### PR DESCRIPTION
Une ligne dans la matrice d'autonomie de la routine : les PRs techniques/SEO de la routine peuvent être mergées et déployées de façon autonome (autorisation explicite Robin du 20/07/2026), hors sujets sensibles qui restent soumis à validation. Fichier hors paths du workflow deploy — aucun deploy déclenché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7J5qsK2jc3QZyAkBpuY6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7J5qsK2jc3QZyAkBpuY6e)_