### PR TITLE
SEO : maillage guides prix nationaux → pages pharmacies locales + fix FAQ Wegovy

### DIFF
--- a/src/content/glp1-cout/prix-mounjaro-france.md
+++ b/src/content/glp1-cout/prix-mounjaro-france.md
@@ -292,6 +292,8 @@ Depuis le 15 juin 2026, le prix de Mounjaro est **réglementé et identique dans
 
 La carte recense les pharmacies ayant du Mounjaro en stock, classées par département et par dosage. Elle est mise à jour régulièrement par notre équipe.
 
+Retrouvez aussi nos pages locales avec la liste des pharmacies et les centres de primo-prescription (CSO/CHU) de votre département : [Mounjaro à Paris](/pharmacies/paris/prix-mounjaro/), [Marseille](/pharmacies/marseille/prix-mounjaro/), [Lyon](/pharmacies/lyon/prix-mounjaro/), [Toulouse](/pharmacies/toulouse/prix-mounjaro/), [Nice](/pharmacies/nice/prix-mounjaro/), [Nantes](/pharmacies/nantes/prix-mounjaro/), [Bordeaux](/pharmacies/bordeaux/prix-mounjaro/), [Lille](/pharmacies/lille/prix-mounjaro/) — ou l'[annuaire complet des pharmacies par ville](/pharmacies/).
+
 ### Rappel des prix par dosage
 
 | Dosage | Prix pharmacie | Reste à charge (65% remboursé) |

--- a/src/content/glp1-cout/prix-ozempic-france.md
+++ b/src/content/glp1-cout/prix-ozempic-france.md
@@ -249,7 +249,9 @@ Le **prix Ozempic en pharmacie** en France est fixé à **77,60€ TTC par stylo
 
 
 
-*Prix mis à jour en mars 2026. Les tarifs peuvent varier selon les pharmacies et régions.*
+*Prix mis à jour en juillet 2026. Le prix d'Ozempic est officiel et identique dans toutes les pharmacies françaises.*
+
+Retrouvez nos pages locales avec la liste des pharmacies de votre ville : [Ozempic à Paris](/pharmacies/paris/prix-ozempic/), [Marseille](/pharmacies/marseille/prix-ozempic/), [Lyon](/pharmacies/lyon/prix-ozempic/), [Toulouse](/pharmacies/toulouse/prix-ozempic/), [Nice](/pharmacies/nice/prix-ozempic/), [Nantes](/pharmacies/nantes/prix-ozempic/), [Bordeaux](/pharmacies/bordeaux/prix-ozempic/), [Lille](/pharmacies/lille/prix-ozempic/) — ou l'[annuaire complet des pharmacies par ville](/pharmacies/).
 
 ## ❓ Questions Fréquentes sur le Prix d'Ozempic
 

--- a/src/content/glp1-cout/prix-wegovy-france.md
+++ b/src/content/glp1-cout/prix-wegovy-france.md
@@ -7,7 +7,7 @@ keywords: ['prix wegovy', 'wegovy prix', 'prix wegovy france', 'wegovy prix phar
 seoTitle: "Wegovy Prix Pharmacie Moins Cher 2026 : dès 146,91€, remboursé 65%"
 seoDescription: "Wegovy prix pharmacie juillet 2026 : 146,91 à 195,10€/mois (prix réglementé, identique partout). Remboursé 65% Sécu depuis juin 2026. Carte des pharmacies disponibles, éligibilité et reste à charge. Mis à jour."
 publishedAt: '2025-01-28'
-updatedAt: '2026-07-19'
+updatedAt: '2026-07-20'
 date: '2026-07-19'
 featured: true
 author: 'Dr. Marie Dubois'
@@ -218,6 +218,8 @@ Depuis le 15 juin 2026, le prix de Wegovy est **réglementé et identique dans t
   <br><br>
   <a href="/outils/carte-prix-pharmacies/" class="cta-button">→ Voir la carte des pharmacies Wegovy disponibles</a>
 </div>
+
+Retrouvez aussi nos pages locales avec la liste des pharmacies et les centres de primo-prescription (CSO/CHU) de votre département : [Wegovy à Paris](/pharmacies/paris/prix-wegovy/), [Marseille](/pharmacies/marseille/prix-wegovy/), [Lyon](/pharmacies/lyon/prix-wegovy/), [Toulouse](/pharmacies/toulouse/prix-wegovy/), [Nice](/pharmacies/nice/prix-wegovy/), [Nantes](/pharmacies/nantes/prix-wegovy/), [Bordeaux](/pharmacies/bordeaux/prix-wegovy/), [Lille](/pharmacies/lille/prix-wegovy/) — ou l'[annuaire complet des pharmacies par ville](/pharmacies/).
 
 ### Prix Wegovy en Espagne et en Belgique (mars 2026)
 

--- a/src/content/glp1-cout/prix-wegovy-france.md
+++ b/src/content/glp1-cout/prix-wegovy-france.md
@@ -25,7 +25,7 @@ faqSchema:
   - question: "Où trouver le Wegovy le moins cher près de chez moi ?"
     answer: "Depuis le 15 juin 2026, le prix du Wegovy est réglementé et identique dans toutes les pharmacies françaises (146,91 à 195,10 euros par mois selon le dosage). Il n'y a donc plus d'écart de prix entre officines."
   - question: "Le Wegovy est-il disponible en pharmacie Lafayette ?"
-    answer: "Oui, le Wegovy est disponible dans les pharmacies Lafayette et autres grandes pharmacies en France. Le prix peut varier selon l'officine. Vérifiez la disponibilité auprès de votre pharmacie."
+    answer: "Oui, le Wegovy est disponible dans les pharmacies Lafayette et autres grandes pharmacies en France, au même prix réglementé que partout (146,91 à 195,10 euros selon le dosage). Vérifiez simplement la disponibilité auprès de votre pharmacie."
   - question: "Peut-on se faire rembourser le Wegovy par sa mutuelle ?"
     answer: "Depuis le 15 juin 2026, Wegovy est remboursé à 65 % par l'Assurance Maladie sous conditions. Votre mutuelle intervient sur le ticket modérateur de 35 %. Vérifiez les conditions de votre contrat pour connaître votre reste à charge."
 ---


### PR DESCRIPTION
## Résumé

Maillage interne pour amorcer l'indexation du cluster programmatique déployé (PR #61) :
- 8 liens top-villes par médicament depuis les 3 guides prix nationaux (prix-mounjaro-france, prix-wegovy-france, prix-ozempic-france) vers les pages `/pharmacies/[ville]/prix-*/` + lien annuaire
- Fix note périmée dans prix-ozempic ("les tarifs peuvent varier selon les régions" → prix officiel identique partout)
- Fix FAQ Wegovy/Lafayette qui disait encore que le prix varie selon l'officine
- `updatedAt` bumpé au 20/07

Attendu après merge : deploy scoped rapide (~3-5 min, pas de full sync — seul `src/content/` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7J5qsK2jc3QZyAkBpuY6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7J5qsK2jc3QZyAkBpuY6e)_