### PR TITLE
Palier 2 bis : 306 pages prix départementales + article Wegovy Espagne + refresh data hebdo

### DIFF
--- a/.github/workflows/refresh-pharmacies-data.yml
+++ b/.github/workflows/refresh-pharmacies-data.yml
@@ -1,0 +1,47 @@
+name: Refresh pharmacies data
+
+# Rafraîchit public/data/pharmacies.json + latest-prices.json depuis Supabase
+# chaque semaine. Un commit sur main déclenche ensuite le deploy (full sync,
+# pharmacies.json étant dans les SHARED_PATTERNS du workflow deploy).
+on:
+  workflow_dispatch:
+  schedule:
+    # Lundi 04:47 UTC (06:47 Paris) — hors pic, avant la routine quotidienne
+    - cron: '47 4 * * 1'
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Export pharmacies + prices from Supabase
+        run: node scripts/pharmacy-map/export-pharmacies-json.mjs
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+
+      - name: Commit and push if data changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/data/pharmacies.json public/data/latest-prices.json
+          if git diff --cached --quiet; then
+            echo "No data changes — skipping commit"
+            exit 0
+          fi
+          git commit -m "chore(data): weekly pharmacies + prices refresh from Supabase"
+          git push

--- a/public/images/thumbnails/wegovy-espagne-prix-illus.svg
+++ b/public/images/thumbnails/wegovy-espagne-prix-illus.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Prix Wegovy Espagne vs France : comparatif 2026">
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a3c34"/>
+      <stop offset="100%" stop-color="#0f2d25"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg2)"/>
+  <!-- Barres comparatives -->
+  <g transform="translate(120,90)">
+    <!-- Espagne -->
+    <rect x="0" y="0" width="180" height="200" rx="12" fill="#ffffff" opacity="0.12"/>
+    <rect x="40" y="40" width="100" height="130" rx="8" fill="#d1d5db"/>
+    <text x="90" y="28" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" font-weight="bold" fill="#e5e7eb">Espagne</text>
+    <text x="90" y="115" text-anchor="middle" font-family="Arial, sans-serif" font-size="26" font-weight="bold" fill="#1a3c34">224 €</text>
+    <text x="90" y="192" text-anchor="middle" font-family="Arial, sans-serif" font-size="15" fill="#e5e7eb">0% remboursé</text>
+  </g>
+  <g transform="translate(480,90)">
+    <!-- France -->
+    <rect x="0" y="0" width="180" height="200" rx="12" fill="#ffffff" opacity="0.12"/>
+    <rect x="40" y="105" width="100" height="65" rx="8" fill="#16a34a"/>
+    <text x="90" y="28" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" font-weight="bold" fill="#86efac">France</text>
+    <text x="90" y="95" text-anchor="middle" font-family="Arial, sans-serif" font-size="26" font-weight="bold" fill="#ffffff">68 €</text>
+    <text x="90" y="192" text-anchor="middle" font-family="Arial, sans-serif" font-size="15" fill="#86efac">65% remboursé</text>
+  </g>
+  <text x="400" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">vs</text>
+  <text x="400" y="370" text-anchor="middle" font-family="Arial, sans-serif" font-size="34" font-weight="bold" fill="#ffffff">Wegovy : Espagne ou France ?</text>
+  <text x="400" y="408" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" fill="#86efac">Le comparatif qui a changé en 2026</text>
+</svg>

--- a/src/components/pharmacies/PrixDeptContent.astro
+++ b/src/components/pharmacies/PrixDeptContent.astro
@@ -1,0 +1,151 @@
+---
+// Corps commun des pages /pharmacies/dept/[dept]/prix-{mounjaro,wegovy,ozempic}/
+// Prix officiels réglementés (BDPM / arrêtés JO 28/05/2026, en vigueur 15/06/2026).
+import { titleCaseCity } from '../../lib/pharmacyCityData';
+
+interface Props {
+  drug: 'mounjaro' | 'wegovy' | 'ozempic';
+  deptCode: string;
+  deptLabel: string;
+  totalPharmas: number;
+  topCities: { slug: string; city: string; count: number; hasPricePage: boolean }[];
+  csos: { name: string; city: string; postal_code: string; phone: string | null; parent_hospital: string | null }[];
+}
+
+const { drug, deptCode, deptLabel, totalPharmas, topCities, csos } = Astro.props;
+
+const DRUG_CONFIG = {
+  mounjaro: {
+    name: 'Mounjaro',
+    molecule: 'tirzépatide',
+    priceRange: '176,10 à 433,80 €',
+    doses: [
+      { dose: '2,5 mg (initiation)', prix: '176,10 €' },
+      { dose: '5 mg', prix: '237,68 €' },
+      { dose: '7,5 – 10 mg', prix: '335,95 €' },
+      { dose: '12,5 – 15 mg', prix: '433,80 €' },
+    ],
+    remboursement: 'remboursé à 65 % dans l\'obésité (sous conditions)',
+    resteACharge: (p: string) => (parseFloat(p.replace(',', '.')) * 0.35).toFixed(2).replace('.', ','),
+    guide: '/collections/glp1-cout/prix-mounjaro-france/',
+    needsCso: true,
+  },
+  wegovy: {
+    name: 'Wegovy',
+    molecule: 'sémaglutide',
+    priceRange: '146,91 à 195,10 €',
+    doses: [
+      { dose: '0,25 – 1 mg (initiation et titration)', prix: '146,91 €' },
+      { dose: '1,7 mg', prix: '169,31 €' },
+      { dose: '2,4 mg (entretien)', prix: '195,10 €' },
+    ],
+    remboursement: 'remboursé à 65 % dans l\'obésité (sous conditions)',
+    resteACharge: (p: string) => (parseFloat(p.replace(',', '.')) * 0.35).toFixed(2).replace('.', ','),
+    guide: '/collections/glp1-cout/prix-wegovy-france/',
+    needsCso: true,
+  },
+  ozempic: {
+    name: 'Ozempic',
+    molecule: 'sémaglutide',
+    priceRange: '77,60 €',
+    doses: [
+      { dose: '0,25 / 0,5 / 1 mg', prix: '77,60 €' },
+    ],
+    remboursement: 'remboursé à 30 % pour le diabète de type 2 (100 % en ALD)',
+    resteACharge: (p: string) => (parseFloat(p.replace(',', '.')) * 0.70).toFixed(2).replace('.', ','),
+    guide: '/collections/glp1-cout/prix-ozempic-france/',
+    needsCso: false,
+  },
+} as const;
+
+const cfg = DRUG_CONFIG[drug];
+const drugSlug = drug;
+---
+
+<div class="min-h-screen py-10" style="background: linear-gradient(160deg, #f0fdf4 0%, #ffffff 50%);">
+  <div class="container mx-auto px-4 max-w-3xl">
+
+    <nav class="text-sm text-gray-500 mb-4">
+      <a href="/pharmacies/" style="color:#16a34a;">Pharmacies</a> ›
+      <a href={`/pharmacies/dept/${deptCode}/`} style="color:#16a34a;">{deptLabel} ({deptCode})</a> ›
+      <strong>Prix {cfg.name}</strong>
+    </nav>
+
+    <h1 class="text-3xl md:text-4xl font-bold mb-4" style="color:#1a3c34;">Prix {cfg.name} en {deptLabel} ({deptCode}) : identique dans les {totalPharmas.toLocaleString('fr-FR')} pharmacies</h1>
+
+    <p class="text-lg text-gray-700 mb-6">
+      Le prix de {cfg.name} ({cfg.molecule}) est <strong>réglementé par l'État depuis le 15 juin 2026</strong> :
+      {cfg.priceRange} par mois, identique dans les {totalPharmas.toLocaleString('fr-FR')} pharmacies du département {deptLabel}
+      comme partout en France. Il est {cfg.remboursement}. La seule chose qui varie d'une officine à l'autre, c'est la <strong>disponibilité en stock</strong>.
+    </p>
+
+    <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Prix officiels 2026 (toutes pharmacies du {deptCode})</h2>
+    <div class="overflow-x-auto mb-6">
+      <table class="w-full bg-white rounded-xl shadow border border-gray-100 text-left">
+        <thead><tr style="background:#1a3c34; color:white;"><th class="p-3">Dosage</th><th class="p-3">Prix mensuel TTC</th><th class="p-3">Reste à charge*</th></tr></thead>
+        <tbody>
+          {cfg.doses.map((d) => (
+            <tr class="border-t border-gray-100">
+              <td class="p-3 font-medium">{d.dose}</td>
+              <td class="p-3">{d.prix}</td>
+              <td class="p-3 text-gray-600">{cfg.resteACharge(d.prix)} €</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <p class="text-sm text-gray-500 mb-8">* Si éligible au remboursement ; votre mutuelle peut couvrir ce reste à charge.
+      <a href="/outils/test-eligibilite/" style="color:#16a34a; font-weight:600;">Vérifiez votre éligibilité en 2 minutes →</a></p>
+
+    <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Où trouver {cfg.name} en {deptLabel} ?</h2>
+    <p class="text-gray-700 mb-4">
+      Toutes les pharmacies du département peuvent délivrer {cfg.name} sur ordonnance et commander sous 24-48 h.
+      Voici les principales villes du {deptCode} par nombre de pharmacies :
+    </p>
+    <div class="bg-white rounded-xl shadow border border-gray-100 p-4 mb-8">
+      <ul class="grid md:grid-cols-2 gap-x-6 gap-y-2 text-sm text-gray-700">
+        {topCities.map((c) => (
+          <li>
+            {c.hasPricePage ? (
+              <a href={`/pharmacies/${c.slug}/prix-${drugSlug}/`} style="color:#16a34a; font-weight:600;">{titleCaseCity(c.city)}</a>
+            ) : (
+              <a href={`/pharmacies/${c.slug}/`} style="color:#1a3c34;">{titleCaseCity(c.city)}</a>
+            )}
+            <span class="text-gray-400"> — {c.count} pharmacie{c.count > 1 ? 's' : ''}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+
+    {cfg.needsCso && csos.length > 0 && (
+      <>
+        <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Primo-prescription : les centres spécialisés du {deptCode}</h2>
+        <p class="text-gray-700 mb-4">
+          Pour être remboursé, {cfg.name} doit d'abord être prescrit par un <strong>spécialiste de l'obésité</strong>
+          (CSO ou service hospitalier). Le renouvellement peut ensuite être fait par votre médecin traitant.
+        </p>
+        <div class="bg-white rounded-xl shadow border border-gray-100 p-4 mb-8">
+          <ul class="space-y-2 text-sm text-gray-700">
+            {csos.map((c) => (
+              <li>
+                <strong>{c.name}</strong>{c.parent_hospital ? ` — ${c.parent_hospital}` : ''}<br />
+                <span class="text-gray-500">{c.postal_code} {c.city}{c.phone ? ` · ${c.phone}` : ''}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </>
+    )}
+
+    <div class="text-sm text-gray-500">
+      Pour aller plus loin : <a href={cfg.guide} style="color:#16a34a;">prix {cfg.name} en France (guide complet)</a> ·
+      <a href={`/pharmacies/dept/${deptCode}/`} style="color:#16a34a;">toutes les pharmacies du {deptLabel}</a> ·
+      <a href="/outils/carte-prix-pharmacies/" style="color:#16a34a;">carte des pharmacies</a>
+    </div>
+
+    <p class="text-xs text-gray-400 mt-8">
+      Prix réglementés (arrêtés JO du 28 mai 2026, en vigueur au 15 juin 2026), identiques dans toutes les pharmacies françaises.
+      Sources : Base de données publique des médicaments, Légifrance, référentiel FINESS. Page informative, ne remplace pas un avis médical.
+    </p>
+  </div>
+</div>

--- a/src/content/glp1-cout/prix-wegovy-france.md
+++ b/src/content/glp1-cout/prix-wegovy-france.md
@@ -226,9 +226,10 @@ Retrouvez aussi nos pages locales avec la liste des pharmacies et les centres de
 Certains patients envisagent de s'approvisionner à l'étranger pour réduire le coût. Voici les réalités du marché européen :
 
 **Espagne :**
-- Prix constaté : environ **220 à 280 € par stylo** selon les dosages, prix libre (non remboursé en Espagne pour l'obésité)
+- Prix constaté après la baisse Novo Nordisk de mars 2026 : environ **136 à 224 €/mois** selon le dosage (200,19 € en 1,7 mg, 223,64 € en 2,4 mg), non remboursé en Espagne pour l'obésité
 - Disponibilité variable selon les communautés autonomes
 - **Important** : l'importation personnelle de médicaments depuis l'Espagne avec une ordonnance française n'est pas reconnue en pharmacie française. Il s'agit d'un usage à titre personnel soumis à déclaration douanière.
+- Notre comparatif détaillé : [Prix Wegovy en Espagne 2026 : pourquoi ça ne vaut plus le coup](/collections/glp1-cout/wegovy-espagne-prix-comparatif-france/)
 
 **Belgique :**
 - Prix constaté : **160 à 340 €/mois** selon dosage (remboursement partiel possible pour les patients belges avec certaines conditions)

--- a/src/content/glp1-cout/wegovy-espagne-prix-comparatif-france.md
+++ b/src/content/glp1-cout/wegovy-espagne-prix-comparatif-france.md
@@ -1,0 +1,80 @@
+---
+title: "Prix Wegovy en Espagne 2026 : Pourquoi Ça Ne Vaut Plus le Coup"
+description: "Wegovy coûte 136 à 224 €/mois en Espagne, non remboursé. En France, il est remboursé à 65 % depuis juin 2026 : reste à charge 51-68 €. Le comparatif complet."
+keywords: ['wegovy espagne', 'prix wegovy espagne', 'wegovy prix pharmacie espagne', 'acheter wegovy espagne', 'wegovy moins cher espagne', 'semaglutide espagne prix']
+seoTitle: "Prix Wegovy Espagne 2026 : 136-224 € Non Remboursé vs France 65%"
+seoDescription: "Wegovy en Espagne : 136 à 224 €/mois, 0% remboursé. En France, remboursé 65% depuis juin 2026 (reste à charge 51-68 €). Comparatif chiffré, légalité et conditions."
+publishedAt: '2026-07-20'
+updatedAt: '2026-07-20'
+date: 2026-07-20
+featured: false
+priority: 4
+author: 'Dr. Marie Dubois'
+readingTime: 8
+thumbnail: "/images/thumbnails/wegovy-espagne-prix-illus.svg"
+thumbnailAlt: "Comparatif prix Wegovy Espagne vs France 2026"
+collection: "glp1-cout"
+affiliateCollection: "glp1-cout"
+mainKeyword: "prix wegovy espagne"
+secondaryKeywords: ["wegovy prix pharmacie espagne", "acheter wegovy en espagne", "wegovy espagne sans ordonnance", "wegovy moins cher a l etranger", "semaglutide prix espagne 2026"]
+---
+
+Pendant deux ans, acheter Wegovy en Espagne a été un vrai plan pour les patients français : le médicament y était disponible plus tôt, et parfois moins cher. **En 2026, la donne s'est complètement inversée** : Wegovy est remboursé à 65 % en France depuis le 15 juin 2026, alors qu'il reste entièrement à la charge du patient en Espagne. Voici le comparatif chiffré.
+
+## Prix Wegovy en Espagne (2026)
+
+En Espagne, Wegovy est vendu en pharmacie sur ordonnance, mais **n'est pas financé par le système de santé public** (Seguridad Social) pour l'obésité. Le patient paie plein tarif. Après la [baisse de prix annoncée par Novo Nordisk au 1er mars 2026](https://www.redaccionmedica.com/secciones/industria/wegovy-farmaco-para-perder-peso-reduce-su-precio-en-espana-hasta-un-17--3908) :
+
+| Dosage | Prix Espagne (indicatif) | Remboursement |
+|--------|--------------------------|---------------|
+| 0,25 – 0,5 mg | ~136 €/mois | 0 % |
+| 1 mg | ~180 €/mois | 0 % |
+| 1,7 mg | 200,19 €/mois | 0 % |
+| 2,4 mg (entretien) | 223,64 €/mois | 0 % |
+
+Les prix peuvent varier légèrement selon la pharmacie et la communauté autonome ([source : presse médicale espagnole](https://www.mediquo.com/blog/clinica-perdida-de-peso/wegovy-precio-espana-baja-cuanto-cuesta-inyeccion-adelgazar/)). À la dose d'entretien, une année de traitement en Espagne représente **environ 2 700 €, intégralement de votre poche**.
+
+## Prix Wegovy en France (2026) : la comparaison qui change tout
+
+En France, le prix est [réglementé et identique dans toutes les pharmacies](/collections/glp1-cout/prix-wegovy-france/) depuis le 15 juin 2026 — et surtout, **remboursé à 65 % par l'Assurance Maladie** sous conditions :
+
+| Dosage | Prix France | Reste à charge (65 % remboursé) |
+|--------|-------------|--------------------------------|
+| 0,25 – 1 mg | 146,91 € | ~51 €/mois |
+| 1,7 mg | 169,31 € | ~59 €/mois |
+| 2,4 mg (entretien) | 195,10 € | ~68 €/mois |
+
+Avec une mutuelle qui couvre le ticket modérateur, le reste à charge peut tomber à **0 €**. Même sans mutuelle, un patient français éligible paie **68 €/mois à la dose d'entretien, contre 224 € en Espagne** : l'écart est de 156 €/mois, soit près de **1 900 € par an**.
+
+### Conditions du remboursement français
+
+- IMC ≥ 40, ou IMC ≥ 35 avec comorbidité (hypertension, diabète, apnée du sommeil...)
+- Échec documenté de 6 mois de prise en charge nutritionnelle
+- Première prescription par un spécialiste de l'obésité (CSO, CHU) — renouvellement par votre médecin traitant
+
+→ **[Vérifiez votre éligibilité en 2 minutes](/outils/test-eligibilite/)** avant d'envisager quoi que ce soit d'autre.
+
+## Dans quels cas l'Espagne peut-elle encore avoir un intérêt ?
+
+Honnêtement, il n'en reste qu'un : **si vous n'êtes pas éligible au remboursement français** (IMC entre 30 et 35 sans comorbidité, par exemple). Dans ce cas, le prix plein tarif espagnol (136-224 €) est comparable au prix plein tarif français (146,91-195,10 €) — l'écart ne justifie généralement pas le déplacement, sauf si vous résidez près de la frontière.
+
+Trois règles à connaître si vous y pensez quand même :
+
+1. **L'ordonnance reste obligatoire en Espagne.** Un médecin espagnol (ou une ordonnance européenne valide) est nécessaire — les circuits "sans ordonnance" sont illégaux et exposent aux [mêmes risques de contrefaçon qu'en ligne](/collections/traitements-glp1/ozempic-sans-ordonnance-achat-en-ligne-france/).
+2. **Le transport d'un traitement personnel est toléré dans des limites strictes** (usage personnel, quantités limitées, ordonnance à présenter).
+3. **Aucun remboursement français** ne s'applique à un achat à l'étranger hors procédure de soins programmés — le "bon plan" espagnol est donc un plein tarif définitif.
+
+## Verdict 2026
+
+| Critère | Espagne | France |
+|---------|---------|--------|
+| Prix mensuel (entretien 2,4 mg) | 223,64 € | 195,10 € |
+| Remboursement | 0 % | 65 % (sous conditions) |
+| Reste à charge réel | 223,64 € | ~68 € (0 € avec mutuelle) |
+| Coût annuel | ~2 700 € | ~820 € (avant mutuelle) |
+
+Pour un patient français éligible, **le détour par l'Espagne n'a plus aucun sens économique en 2026**. La priorité est de faire valider votre éligibilité et d'obtenir la primo-prescription en CSO/CHU — notre guide [remboursement Wegovy et mutuelle](/collections/glp1-cout/wegovy-remboursement-mutuelle/) détaille chaque étape, et nos [pages pharmacies par ville](/pharmacies/) listent les centres de primo-prescription de votre département.
+
+---
+
+*Article informatif, ne remplace pas un avis médical. Prix espagnols : [Redacción Médica](https://www.redaccionmedica.com/secciones/industria/wegovy-farmaco-para-perder-peso-reduce-su-precio-en-espana-hasta-un-17--3908) (baisse Novo Nordisk mars 2026), [MediQuo](https://www.mediquo.com/blog/clinica-perdida-de-peso/wegovy-precio-espana-baja-cuanto-cuesta-inyeccion-adelgazar/). Prix français : Base de données publique des médicaments, arrêtés JO du 28 mai 2026. Mis à jour le 20 juillet 2026.*

--- a/src/lib/pharmacyCityData.ts
+++ b/src/lib/pharmacyCityData.ts
@@ -69,3 +69,98 @@ export function getPriceCityPaths(limit: number = PRICE_CITIES_LIMIT): PriceCity
 export function titleCaseCity(s: string): string {
   return (s || '').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase());
 }
+
+export const DEPT_LABELS: Record<string, string> = {
+  '01': 'Ain', '02': 'Aisne', '03': 'Allier', '04': 'Alpes-de-Haute-Provence', '05': 'Hautes-Alpes',
+  '06': 'Alpes-Maritimes', '07': 'Ardèche', '08': 'Ardennes', '09': 'Ariège', '10': 'Aube',
+  '11': 'Aude', '12': 'Aveyron', '13': 'Bouches-du-Rhône', '14': 'Calvados', '15': 'Cantal',
+  '16': 'Charente', '17': 'Charente-Maritime', '18': 'Cher', '19': 'Corrèze', '21': "Côte-d'Or",
+  '22': "Côtes-d'Armor", '23': 'Creuse', '24': 'Dordogne', '25': 'Doubs', '26': 'Drôme',
+  '27': 'Eure', '28': 'Eure-et-Loir', '29': 'Finistère', '2A': 'Corse-du-Sud', '2B': 'Haute-Corse',
+  '30': 'Gard', '31': 'Haute-Garonne', '32': 'Gers', '33': 'Gironde', '34': 'Hérault',
+  '35': 'Ille-et-Vilaine', '36': 'Indre', '37': 'Indre-et-Loire', '38': 'Isère', '39': 'Jura',
+  '40': 'Landes', '41': 'Loir-et-Cher', '42': 'Loire', '43': 'Haute-Loire', '44': 'Loire-Atlantique',
+  '45': 'Loiret', '46': 'Lot', '47': 'Lot-et-Garonne', '48': 'Lozère', '49': 'Maine-et-Loire',
+  '50': 'Manche', '51': 'Marne', '52': 'Haute-Marne', '53': 'Mayenne', '54': 'Meurthe-et-Moselle',
+  '55': 'Meuse', '56': 'Morbihan', '57': 'Moselle', '58': 'Nièvre', '59': 'Nord',
+  '60': 'Oise', '61': 'Orne', '62': 'Pas-de-Calais', '63': 'Puy-de-Dôme', '64': 'Pyrénées-Atlantiques',
+  '65': 'Hautes-Pyrénées', '66': 'Pyrénées-Orientales', '67': 'Bas-Rhin', '68': 'Haut-Rhin', '69': 'Rhône',
+  '70': 'Haute-Saône', '71': 'Saône-et-Loire', '72': 'Sarthe', '73': 'Savoie', '74': 'Haute-Savoie',
+  '75': 'Paris', '76': 'Seine-Maritime', '77': 'Seine-et-Marne', '78': 'Yvelines', '79': 'Deux-Sèvres',
+  '80': 'Somme', '81': 'Tarn', '82': 'Tarn-et-Garonne', '83': 'Var', '84': 'Vaucluse',
+  '85': 'Vendée', '86': 'Vienne', '87': 'Haute-Vienne', '88': 'Vosges', '89': 'Yonne',
+  '90': 'Territoire de Belfort', '91': 'Essonne', '92': 'Hauts-de-Seine', '93': 'Seine-Saint-Denis',
+  '94': 'Val-de-Marne', '95': "Val-d'Oise", '971': 'Guadeloupe', '972': 'Martinique',
+  '973': 'Guyane', '974': 'La Réunion', '975': 'Saint-Pierre-et-Miquelon', '976': 'Mayotte',
+};
+
+export interface PriceDeptPath {
+  params: { dept: string };
+  props: {
+    deptLabel: string;
+    totalPharmas: number;
+    topCities: { slug: string; city: string; count: number; hasPricePage: boolean }[];
+    csos: { name: string; city: string; postal_code: string; phone: string | null; parent_hospital: string | null }[];
+  };
+}
+
+// Une page prix par département (102) : top villes du departement + CSO + total pharmacies.
+export function getPriceDeptPaths(): PriceDeptPath[] {
+  const dataPath = path.resolve(process.cwd(), 'public/data/pharmacies.json');
+  const csoPath = path.resolve(process.cwd(), 'public/data/cso.json');
+  let pharmacies: { schema: string[]; rows: any[][] } = { schema: [], rows: [] };
+  let csos: any[] = [];
+  try { pharmacies = JSON.parse(fs.readFileSync(dataPath, 'utf-8')); } catch {}
+  try { csos = JSON.parse(fs.readFileSync(csoPath, 'utf-8')); } catch {}
+
+  const iCity = pharmacies.schema.indexOf('city');
+  const iSlug = pharmacies.schema.indexOf('city_slug');
+  const iDept = pharmacies.schema.indexOf('department');
+
+  // Villes ayant une page prix ville (top 200 national, meme calcul que getPriceCityPaths)
+  const cityCounts: Record<string, number> = {};
+  for (const row of pharmacies.rows) {
+    const slug = row[iSlug];
+    if (slug) cityCounts[slug] = (cityCounts[slug] || 0) + 1;
+  }
+  const priceCitySlugs = new Set(
+    Object.entries(cityCounts).sort((a, b) => b[1] - a[1]).slice(0, PRICE_CITIES_LIMIT).map(([s]) => s)
+  );
+
+  const byDept: Record<string, { total: number; cities: Record<string, { slug: string; city: string; count: number }> }> = {};
+  for (const row of pharmacies.rows) {
+    const dept = String(row[iDept]);
+    const slug = row[iSlug];
+    if (!dept || !slug) continue;
+    if (!byDept[dept]) byDept[dept] = { total: 0, cities: {} };
+    byDept[dept].total++;
+    if (!byDept[dept].cities[slug]) byDept[dept].cities[slug] = { slug, city: row[iCity], count: 0 };
+    byDept[dept].cities[slug].count++;
+  }
+
+  const csosByDept: Record<string, any[]> = {};
+  for (const c of csos) {
+    const d = String(c.department);
+    if (!csosByDept[d]) csosByDept[d] = [];
+    csosByDept[d].push(c);
+  }
+
+  return Object.entries(byDept).map(([dept, data]) => ({
+    params: { dept },
+    props: {
+      deptLabel: DEPT_LABELS[dept] || `Département ${dept}`,
+      totalPharmas: data.total,
+      topCities: Object.values(data.cities)
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 12)
+        .map((c) => ({ ...c, hasPricePage: priceCitySlugs.has(c.slug) })),
+      csos: (csosByDept[dept] || []).slice(0, 5).map((x) => ({
+        name: x.name,
+        city: x.city,
+        postal_code: x.postal_code,
+        phone: x.phone ?? null,
+        parent_hospital: x.parent_hospital ?? null,
+      })),
+    },
+  }));
+}

--- a/src/pages/pharmacies/dept/[dept].astro
+++ b/src/pages/pharmacies/dept/[dept].astro
@@ -447,7 +447,8 @@ const wikiUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(deptLabel.re
               <div class="price-meta">TTC par stylo · identique France entière</div>
             </div>
             <p class="drug-note">Remboursé 30 % (diabète type 2) · 100 % en ALD.</p>
-            <a href="/collections/glp1-cout/prix-ozempic-france/" class="link-small">Détails prix Ozempic →</a>
+            <a href={`/pharmacies/dept/${deptCode}/prix-ozempic/`} class="link-small">Prix Ozempic en {deptLabel} →</a>
+            <a href="/collections/glp1-cout/prix-ozempic-france/" class="link-small">Guide national →</a>
           </div>
 
           <div class="drug-card">
@@ -461,7 +462,8 @@ const wikiUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(deptLabel.re
               <div class="price-meta">selon dosage · identique France entière</div>
             </div>
             <p class="drug-note">Remboursé 65 % depuis le 15/06/2026 (obésité, sous conditions IMC + primo-prescription spécialiste).</p>
-            <a href="/collections/glp1-cout/prix-wegovy-france/" class="link-small">Détails prix Wegovy →</a>
+            <a href={`/pharmacies/dept/${deptCode}/prix-wegovy/`} class="link-small">Prix Wegovy en {deptLabel} →</a>
+            <a href="/collections/glp1-cout/prix-wegovy-france/" class="link-small">Guide national →</a>
           </div>
 
           <div class="drug-card">
@@ -475,7 +477,8 @@ const wikiUrl = `https://fr.wikipedia.org/wiki/${encodeURIComponent(deptLabel.re
               <div class="price-meta">selon dosage · identique France entière</div>
             </div>
             <p class="drug-note">Remboursé 65 % depuis le 15/06/2026 (obésité, sous conditions IMC + primo-prescription spécialiste).</p>
-            <a href="/collections/glp1-cout/prix-mounjaro-france/" class="link-small">Détails prix Mounjaro →</a>
+            <a href={`/pharmacies/dept/${deptCode}/prix-mounjaro/`} class="link-small">Prix Mounjaro en {deptLabel} →</a>
+            <a href="/collections/glp1-cout/prix-mounjaro-france/" class="link-small">Guide national →</a>
           </div>
         </div>
       </div>

--- a/src/pages/pharmacies/dept/[dept]/prix-mounjaro.astro
+++ b/src/pages/pharmacies/dept/[dept]/prix-mounjaro.astro
@@ -1,0 +1,30 @@
+---
+import StaticLayout from '../../../../layouts/StaticLayout.astro';
+import PrixDeptContent from '../../../../components/pharmacies/PrixDeptContent.astro';
+import { getPriceDeptPaths } from '../../../../lib/pharmacyCityData';
+
+export async function getStaticPaths() {
+  return getPriceDeptPaths();
+}
+
+const { deptLabel, totalPharmas, topCities, csos } = Astro.props;
+const dept = Astro.params.dept;
+
+const faqJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: `Quel est le prix de Mounjaro en ${deptLabel} ?`, acceptedAnswer: { '@type': 'Answer', text: `Le prix de Mounjaro est réglementé et identique dans toutes les pharmacies du département ${deptLabel} (${dept}) : de 176,10 € (2,5 mg) à 433,80 € (15 mg) par mois selon le dosage. Il est remboursé à 65 % par l'Assurance Maladie sous conditions.` } },
+    { '@type': 'Question', name: `Où obtenir une prescription de Mounjaro en ${deptLabel} ?`, acceptedAnswer: { '@type': 'Answer', text: `La première prescription remboursable doit être faite par un spécialiste de l'obésité (CSO, CHU). Le renouvellement peut être fait par votre médecin traitant.` } },
+  ],
+});
+---
+
+<StaticLayout
+  title={`Prix Mounjaro ${deptLabel} (${dept}) 2026 : 176,10 € réglementé — Pharmacies`}
+  description={`Prix de Mounjaro en ${deptLabel} : 176,10 à 433,80 €/mois, identique dans les ${totalPharmas} pharmacies du département (prix réglementé). Remboursé 65 %. Villes et centres de primo-prescription.`}
+  keywords={`mounjaro ${deptLabel.toLowerCase()}, prix mounjaro ${dept}, pharmacie mounjaro ${deptLabel.toLowerCase()}`}
+>
+  <script type="application/ld+json" set:html={faqJsonLd} />
+  <PrixDeptContent drug="mounjaro" deptCode={dept} deptLabel={deptLabel} totalPharmas={totalPharmas} topCities={topCities} csos={csos} />
+</StaticLayout>

--- a/src/pages/pharmacies/dept/[dept]/prix-ozempic.astro
+++ b/src/pages/pharmacies/dept/[dept]/prix-ozempic.astro
@@ -1,0 +1,30 @@
+---
+import StaticLayout from '../../../../layouts/StaticLayout.astro';
+import PrixDeptContent from '../../../../components/pharmacies/PrixDeptContent.astro';
+import { getPriceDeptPaths } from '../../../../lib/pharmacyCityData';
+
+export async function getStaticPaths() {
+  return getPriceDeptPaths();
+}
+
+const { deptLabel, totalPharmas, topCities, csos } = Astro.props;
+const dept = Astro.params.dept;
+
+const faqJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: `Quel est le prix d'Ozempic en ${deptLabel} ?`, acceptedAnswer: { '@type': 'Answer', text: `Ozempic coûte 77,60 € TTC par stylo, prix officiel identique dans toutes les pharmacies du département ${deptLabel} (${dept}). Il est remboursé à 30 % pour le diabète de type 2, et à 100 % pour les patients en ALD.` } },
+    { '@type': 'Question', name: `Ozempic est-il remboursé pour maigrir en ${deptLabel} ?`, acceptedAnswer: { '@type': 'Answer', text: `Non. Ozempic n'est remboursé que pour le diabète de type 2. Pour la perte de poids, Wegovy et Mounjaro sont remboursés à 65 % depuis le 15 juin 2026, sous conditions.` } },
+  ],
+});
+---
+
+<StaticLayout
+  title={`Prix Ozempic ${deptLabel} (${dept}) 2026 : 77,60 € officiel — Pharmacies`}
+  description={`Prix d'Ozempic en ${deptLabel} : 77,60 € TTC le stylo, identique dans les ${totalPharmas} pharmacies du département. Remboursé 30 % (diabète type 2), 100 % en ALD. Villes et disponibilité.`}
+  keywords={`ozempic ${deptLabel.toLowerCase()}, prix ozempic ${dept}, pharmacie ozempic ${deptLabel.toLowerCase()}`}
+>
+  <script type="application/ld+json" set:html={faqJsonLd} />
+  <PrixDeptContent drug="ozempic" deptCode={dept} deptLabel={deptLabel} totalPharmas={totalPharmas} topCities={topCities} csos={csos} />
+</StaticLayout>

--- a/src/pages/pharmacies/dept/[dept]/prix-wegovy.astro
+++ b/src/pages/pharmacies/dept/[dept]/prix-wegovy.astro
@@ -1,0 +1,30 @@
+---
+import StaticLayout from '../../../../layouts/StaticLayout.astro';
+import PrixDeptContent from '../../../../components/pharmacies/PrixDeptContent.astro';
+import { getPriceDeptPaths } from '../../../../lib/pharmacyCityData';
+
+export async function getStaticPaths() {
+  return getPriceDeptPaths();
+}
+
+const { deptLabel, totalPharmas, topCities, csos } = Astro.props;
+const dept = Astro.params.dept;
+
+const faqJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    { '@type': 'Question', name: `Quel est le prix de Wegovy en ${deptLabel} ?`, acceptedAnswer: { '@type': 'Answer', text: `Le prix de Wegovy est réglementé et identique dans toutes les pharmacies du département ${deptLabel} (${dept}) : de 146,91 € (0,25 à 1 mg) à 195,10 € (2,4 mg) par mois selon le dosage. Il est remboursé à 65 % par l'Assurance Maladie sous conditions.` } },
+    { '@type': 'Question', name: `Où obtenir une prescription de Wegovy en ${deptLabel} ?`, acceptedAnswer: { '@type': 'Answer', text: `La première prescription remboursable doit être faite par un spécialiste de l'obésité (CSO, CHU). Le renouvellement peut être fait par votre médecin traitant.` } },
+  ],
+});
+---
+
+<StaticLayout
+  title={`Prix Wegovy ${deptLabel} (${dept}) 2026 : 146,91 € réglementé — Pharmacies`}
+  description={`Prix de Wegovy en ${deptLabel} : 146,91 à 195,10 €/mois, identique dans les ${totalPharmas} pharmacies du département (prix réglementé). Remboursé 65 %. Villes et centres de primo-prescription.`}
+  keywords={`wegovy ${deptLabel.toLowerCase()}, prix wegovy ${dept}, pharmacie wegovy ${deptLabel.toLowerCase()}`}
+>
+  <script type="application/ld+json" set:html={faqJsonLd} />
+  <PrixDeptContent drug="wegovy" deptCode={dept} deptLabel={deptLabel} totalPharmas={totalPharmas} topCities={topCities} csos={csos} />
+</StaticLayout>


### PR DESCRIPTION
## Résumé

Suite du "go" Robin — exécution des opportunités identifiées dans GSC :

### 306 pages prix départementales
- `dept/[dept]/prix-{mounjaro,wegovy,ozempic}` (102 départements × 3) via composant partagé `PrixDeptContent` + helper `getPriceDeptPaths`
- Contenu : prix officiels réglementés, reste à charge par dosage, top 12 villes du département (liées aux pages prix ville quand elles existent), centres CSO/CHU de primo-prescription, FAQ schema
- Cible le pattern GSC "pharmacie moins cher autour de moi / [ville]" (~960 imp/14j)
- Hubs départementaux liés vers leurs pages prix

### Article Wegovy Espagne (opportunité GSC : 206 imp/14j, pos 5.4)
- `wegovy-espagne-prix-comparatif-france` — comparatif sourcé : Espagne 136-224 €/mois non remboursé (baisse Novo mars 2026, Redacción Médica) vs France remboursée 65% (reste à charge 51-68 €)
- Verdict chiffré : ~1 900 €/an d'écart pour un éligible français
- Section Espagne de prix-wegovy-france mise à jour avec les prix exacts + lien

### Infra
- `refresh-pharmacies-data.yml` : export Supabase hebdomadaire (lundi 06:47 Paris) → commit si diff → déclenche le deploy. Les 20k pages pharmacies ne seront plus jamais sur des données figées.

### Validations
- Build : 23 920 pages (+307), exit 0
- Zéro occurrence Zepbound dans les nouvelles pages
- content_opportunities mises à jour (2 passées en published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7J5qsK2jc3QZyAkBpuY6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7J5qsK2jc3QZyAkBpuY6e)_