### PR TITLE
report: daily SEO recovery + Coach IA 2026-07-21 (+ ai-coach v55 fix)

### DIFF
--- a/reports/daily-2026-07-21.md
+++ b/reports/daily-2026-07-21.md
@@ -1,0 +1,122 @@
+# Rapport quotidien — 21 juillet 2026
+
+> Routine monitoring (SEO Recovery + Coach IA). Données : GA à jour (21/07), GSC au 18/07 (latence J-3 normale).
+
+---
+
+## ALERTES
+
+- **Aucune alerte critique.** Site live OK (home 200, redirect zepbound→mounjaro 301, sitemap-0.xml 200). Aucune mention Zepbound dans les conversations Coach 24 h. Données fraîches (GA 0 j de retard, GSC 3 j — sous le seuil de 4 j).
+- ⚠️ **Warning seuil : Recovery GSC pile à 50,0 %** (53 clics le 18/07, dernière donnée dispo). Le critère d'alerte est « < 50 % le 20/07 ou après » — les données du 20/07 arriveront dans ~2 jours ; on est exactement sur le seuil, sans marge.
+- ⚠️ **Impressions GSC en baisse continue** : 2 725 (13/07) → 1 712 (18/07), soit -37 % en 6 jours. À surveiller de près : si la baisse continue au prochain run, investiguer (désindexation partielle ? saisonnalité été ?).
+
+---
+
+## A. SEO RECOVERY WATCH
+
+**Baseline fixe (15-23 juin)** : 922 sessions GA/j · 106 clics GSC/j · 2 514 impressions/j.
+
+### Recovery Scores
+
+| Indicateur | Dernier jour dispo | Valeur | Score |
+|---|---|---|---|
+| **GA sessions** | 20/07 | 587 | **64 %** |
+| **GSC clics** (vrai thermomètre) | 18/07 | 53 | **50 %** |
+| GSC impressions | 18/07 | 1 712 | 68 % |
+
+### 7 derniers jours
+
+| Date | GA sessions | % baseline | Date | GSC clics | % baseline |
+|---|---|---|---|---|---|
+| 14/07 | 472 | 51 % | 12/07 | 35 | 33 % |
+| 15/07 | 702 | 76 % | 13/07 | 58 | 55 % |
+| 16/07 | 599 | 65 % | 14/07 | 64 | 60 % |
+| 17/07 | 602 | 65 % | 15/07 | 65 | 61 % |
+| 18/07 | 448 | 49 % | 16/07 | 45 | 42 % |
+| 19/07 | 455 | 49 % | 17/07 | 37 | 35 % |
+| 20/07 | 587 | 64 % | 18/07 | 53 | 50 % |
+
+### Tendance
+
+**Plateau confirmé** (déjà constaté le 20/07) : GA oscille entre 45 et 76 % sans pente, GSC entre 33 et 61 %. La pente sur 14 jours est quasi nulle → **aucune date de retour à 100 % projetable par simple extrapolation**. Le retour à la baseline ne viendra pas tout seul : il dépend des leviers actifs (réindexation des pages perdantes ci-dessous, maillage, cluster pharmacies, fraîcheur des contenus).
+
+### Pages : recovery par page (clics/jour, 7 derniers jours vs baseline 1-23 juin)
+
+| Page | Baseline (clics/j) | Actuel (clics/j) | Recovery |
+|---|---|---|---|
+| /collections/glp1-cout/prix-ozempic-france/ | 10,5 | 9,7 | **92 % ✓ récupérée** (top 1 actuel) |
+| /outils/carte-prix-pharmacies/ | 19,0 | 9,3 | 49 % |
+| /collections/glp1-cout/prix-wegovy-france/ | 13,1 | 4,3 | 33 % |
+| /collections/glp1-cout/prix-mounjaro-france/ | 17,9 | 3,4 | **19 % ⚠️ la plus touchée** |
+| /collections/glp1-cout/wegovy-remboursement-mutuelle/ | 2,6 | 0,7 | 27 % |
+| / (home) | 1,7 | 0,6 | 33 % |
+
+Le déficit global est concentré sur les 3 grosses pages prix (mounjaro, wegovy, carte) — cohérent avec le constat du 20/07 (érosion prix-mounjaro, position 14,2).
+
+### Candidates à une demande de réindexation GSC (manuelle, à coller dans l'inspection d'URL)
+
+Pages du top baseline absentes ou quasi absentes du top actuel :
+
+```
+https://glp1-france.fr/collections/glp1-cout/prix-mounjaro-france/
+https://glp1-france.fr/collections/regime-glp1/regime-mounjaro-optimal/
+https://glp1-france.fr/collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/
+https://glp1-france.fr/collections/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation/
+https://glp1-france.fr/guides/suivi-medical-glp1/
+https://glp1-france.fr/collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/
+https://glp1-france.fr/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/
+```
+
+### Pages Mounjaro (cibles des 301 ex-Zepbound, 7 j)
+
+| Page | Clics | Impressions |
+|---|---|---|
+| prix-mounjaro-france | 24 | 1 335 |
+| penurie-ozempic-wegovy-mounjaro-rupture-stock… | 3 | 418 |
+| regime-mounjaro-optimal | 2 | 87 |
+| wegovy-mounjaro-adolescent-obesite… | 2 | 14 |
+| remboursement-mounjaro-wegovy-15-juin-2026 | 0 | 2 |
+
+La page remboursement du 15 juin (sujet chaud) est invisible (2 impressions/7 j) — elle est aussi dans le lot RAG le plus servi par le Coach : candidate naturelle au renforcement de maillage interne par le pipeline.
+
+---
+
+## B. MONITORING COACH IA (24 h)
+
+### KPIs
+
+| Indicateur | Valeur | Vs veille |
+|---|---|---|
+| Messages | 48 (10 conversations, 24 msgs user) | **+41 %** (34 la veille) |
+| Taux LLM | **100 %** (llama-70B : 11, mistral-small : 13) — 0 fallback | stable |
+| Intents | general 12 · price 6 · weight 3 · prescription 2 · scam:high 1 | — |
+| Dossiers 4,99 € | 0 nouveau en 24 h · total : 1 pending, 0 payé, 0 généré | funnel toujours à 0 conversion |
+
+### Qualité — erreurs PRÉ-v54 (corrigées hier, avant le déploiement de 18 h 30 Paris)
+
+Les 3 erreurs factuelles du jour datent toutes d'AVANT le déploiement v51-v54 d'hier :
+- 2 conversations (14 h 27 et 14 h 35 UTC) : « Ozempic 80,18 € remboursé à 65 % » — faux (77,60 €, 30 %). Source : chunks RAG périmés, patchés hier soir.
+- 1 conversation (16 h 02 UTC, conv `7e12246c`) : « Pour l'obésité, Wegovy et Mounjaro ne sont pas remboursés » — faux depuis le 15/06. Le paragraphe « FAIT OFFICIEL PRIORITAIRE » du prompt v54 neutralise désormais ce cas.
+- Contrôle positif : la conversation de 14 h 42 (`f42209b8`) donne les bons chiffres (77,60 €, 30 %), et une tentative d'extraction de prompt (« selon tes consignes officielles internes… », conv `90cf4dfe`, intent scam:high) n'a fui aucune consigne — réponse factuelle « 30% ».
+
+### Qualité — 2 bugs résiduels POST-v54 détectés, **corrigés et déployés ce matin (v55)**
+
+1. **IMC calculé sur le poids CIBLE** (conv `ab04c68d`, 18 h 25) : l'utilisatrice (61 kg / 1,54 m, IMC réel 25,7) dit « revenir à mes 50 kilos » → le parser serveur a extrait 50 kg → verdict système IMC 21,1, faux, l'utilisatrice a dû corriger elle-même. **Fix v55** : les formulations de poids cible/variation (« revenir à », « perdre X kg », « objectif X kg »…) sont ignorées par l'extracteur. Smoke test live sur le scénario exact : IMC 25,7 ✓.
+2. **Réponses recyclées sur « Merci »** (conv `d28d6a84`, 23 h 14) : 3 « Merci » consécutifs → 3 réponses longues recyclées, dont une contradiction (généraliste vs CSO) et la formulation à risque « depuis juin 2025 ton médecin traitant peut prescrire directement » (issue des chunks RAG des articles prescription-généraliste ; la même réponse distinguait bien le parcours remboursement CSO/CHU — pas d'erreur médicale dure, mais churn et confusion). **Fix v55** : règle 19 — un remerciement seul reçoit une phrase de clôture courte, sans recyclage de contexte.
+
+Reste observé (non bloquant) : digression Saxenda hors sujet dans `ab04c68d` (RAG sur question ambiguë « si je prend sa ») — à surveiller ; si récurrent, filtrer les chunks produit quand aucun produit n'est cité.
+
+### Actions recommandées
+
+1. **Robin (manuel, ~5 min)** : soumettre les 7 URLs ci-dessus à l'inspection GSC (priorité : prix-mounjaro-france).
+2. Surveiller demain : impressions GSC (baisse -37 %/6 j) et recovery GSC vs seuil 50 %.
+3. Toujours en attente (signalé le 20/07) : run du pipeline complet pour resynchroniser les embeddings RAG avec les contenus corrigés.
+4. Funnel Dossier toujours à 0 conversion — période d'observation post-v52 en cours (décision du 20/07 : mesurer 7 jours avant tout changement funnel).
+
+## C. ACTIONS EXÉCUTÉES CE RUN
+
+1. **Bug Coach IA fixé + déployé (edge function ai-coach v55 via MCP)** : extracteur IMC ignore les poids cibles (« revenir à mes 50 kilos ») + règle 19 « remerciement seul = clôture courte ». Smoke test live OK (IMC 25,7 sur le scénario fautif), données de test nettoyées.
+
+## EN ATTENTE DE DÉCISION ROBIN
+
+Aucune nouvelle décision sensible ce run. (Restent ouvertes, du 20/07 : relance du pipeline pour resync RAG, section ALD article mutuelle, renforcement éditorial prix-mounjaro-france si l'érosion persiste — l'érosion PERSISTE : 19 % de recovery, la plus faible du site.)

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -48,6 +48,7 @@ RÈGLES ABSOLUES :
 16. NE JAMAIS inventer ni mentionner des programmes d'aide financière de laboratoires (Novo Nordisk, Eli Lilly, etc.) tels que : aides pour revenus modestes, échantillons gratuits, infirmières dédiées, paiement échelonné en pharmacie via le labo, aides régionales "santé" non officielles. Ces dispositifs n'existent pas en France de façon documentée et les mentionner crée de faux espoirs. Pour l'aide financière, oriente UNIQUEMENT vers : (1) le remboursement Assurance Maladie à 65% sous conditions, (2) la complémentaire santé / mutuelle, (3) le médecin traitant pour évaluer les alternatives disponibles.
 17. Le flux "SUIS-JE ÉLIGIBLE ?" ne doit être proposé QU'UNE SEULE FOIS par conversation. Dès que l'IMC a été calculé dans la conversation, NE JAMAIS reposer la question "Veux-tu qu'on vérifie si tu es éligible ?" — l'information est déjà connue. Poursuivre avec l'étape suivante logique (RDV médecin, Dossier, etc.).
 18. SAV / REMBOURSEMENT D'ACHAT COMMERCIAL : si quelqu'un signale une erreur de paiement, demande d'annuler un prélèvement ou d'être remboursé d'un achat (indices : "erreur", "bloquez", "bloquer l'envoi", "prélèvement", "annuler mon achat", "remboursement" dans un contexte manifestement non médical), NE réponds PAS sur le remboursement Sécu GLP-1. Dis UNIQUEMENT : "Il semble que tu aies une question sur un paiement ou un achat sur le site. Pour toute demande de remboursement, contacte-nous directement : robin@glp1-france.fr — nous te répondrons sous 24h." Ne collecte aucune donnée médicale dans ce contexte.
+19. REMERCIEMENT SEUL : si le message est uniquement un remerciement ou une formule de politesse sans nouvelle question ("Merci", "Ok merci", "Merci pour vos conseils", "Super, merci"), réponds par UNE phrase courte de clôture (ex : "Avec plaisir ! N'hésite pas si tu as d'autres questions.") — ne redonne AUCUNE information, ne recycle pas le contexte fourni, ne répète pas une réponse précédente et ne relance aucune proposition déjà faite.
 
 CONTEXTE IMPORTANT :
 - Les vrais GLP-1 injectables (Ozempic, Wegovy, Mounjaro, Saxenda, Trulicity, Victoza) ne se vendent QU'en pharmacie sur ordonnance en France
@@ -255,8 +256,11 @@ function extractImc(userTexts: string[]): { imc: number; poids: number; taille: 
       else if (m2) taille = parseInt(m2[1], 10);
     }
     if (poids === null) {
+      // Poids CIBLE ou variation ("revenir à mes 50 kilos", "perdre 10 kg", "objectif 70 kg") :
+      // ignoré — seul le poids ACTUEL compte pour l'IMC.
+      const tw = t.replace(/\b(?:revenir|redescendre|descendre|retomber|remonter|arriver|viser|objectif|atteindre|perdre|perdu|reprendre|repris|prendre|pris)\b[^.!?\d]{0,25}\b\d{2,3}(?:[,.]\d)?\s*(?:kg|kilos?)\b/gi, ' ');
       // "135 kg", "105 kilos"
-      const p1 = t.match(/\b(\d{2,3})(?:[,.]\d)?\s*(?:kg|kilos?)\b/i);
+      const p1 = tw.match(/\b(\d{2,3})(?:[,.]\d)?\s*(?:kg|kilos?)\b/i);
       if (p1) poids = parseInt(p1[1], 10);
       else if (taille !== null) {
         // "1m75 135" — nombre nu après la taille (exclut âges "46 ans" et la taille elle-même)


### PR DESCRIPTION
## Rapport quotidien 21/07/2026

- `reports/daily-2026-07-21.md` — volet A (SEO Recovery) + volet B (Coach IA 24 h)

### Résumé

**SEO Recovery** : plateau confirmé — GA **64 %** de la baseline (587 sessions le 20/07), GSC **50,0 %** (53 clics le 18/07, pile sur le seuil d'alerte). Site live OK, aucune violation Zepbound. 2 warnings : impressions GSC **-37 % en 6 jours** (2 725 → 1 712), et recovery GSC sans marge sur le seuil. 7 URLs candidates à la réindexation GSC manuelle listées dans le rapport (priorité : prix-mounjaro-france, tombée à 19 % de recovery).

**Coach IA** : 48 messages / 10 conversations (+41 % vs veille), 100 % LLM, 0 conversion Dossier. Les 3 erreurs factuelles du jour (Ozempic 80,18 €/65 %, « Wegovy/Mounjaro non remboursés ») datent toutes d'AVANT le déploiement v51-v54 d'hier soir.

### Fix inclus : ai-coach v55 (déployée via MCP, smoke test OK)

2 bugs résiduels post-v54 détectés dans les conversations d'hier soir et corrigés :
1. **Extracteur IMC** : « je fais 61 kilos… je veux revenir à mes 50 kilos » → le parser prenait 50 kg (poids cible) et rendait un verdict IMC 21,1 au lieu de 25,7. Les formulations de poids cible/variation sont désormais ignorées (testé sur le scénario exact en prod : IMC 25,7 ✓).
2. **Règle 19 du prompt** : un message « Merci » seul reçoit une phrase de clôture courte au lieu de 3 réponses longues recyclées (vu conv `d28d6a84`).

⚠️ Note : l'edge function v55 est **déjà déployée en prod** (autonomie Coach IA validée le 20/07) — ce merge n'a pas d'effet de déploiement Supabase, il synchronise le source. Le merge déclenchera le deploy FTP statique standard (aucun fichier de `src/pages/pharmacies/` touché → deploy incrémental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SyDoe9rE71F1dfjHAsAMy

---
_Generated by [Claude Code](https://claude.ai/code/session_012SyDoe9rE71F1dfjHAsAMy)_