### PR TITLE
report: daily SEO recovery + Coach IA 2026-07-26 + ai-coach v58 conservation fix

### DIFF
--- a/reports/daily-2026-07-26.md
+++ b/reports/daily-2026-07-26.md
@@ -1,0 +1,116 @@
+# Rapport quotidien — 26 juillet 2026
+
+## ALERTES
+
+1. **ALERTE (d) — Recovery GSC < 50% après le 20 juillet** : 38% au 23/07 (40 clics / 106 baseline). Le plateau dure depuis ~2 semaines (35-54%), la pente est nulle. La recovery organique a **calé à ~40%**.
+2. **ALERTE (c) — Sessions GA en baisse 3 jours consécutifs** : 22/07 544 → 23/07 525 → 24/07 456 → 25/07 344. Le 25/07 est un samedi (effet week-end partiel), mais 344 vs 448 le samedi précédent = **-23% d'une semaine sur l'autre**. Les impressions GSC baissent aussi (1 968 → 1 518 sur 14 jours). À surveiller de près : si la baisse continue lundi-mardi, ce n'est plus le week-end.
+3. **ERREUR MÉDICALE DU COACH (corrigée ce jour)** : le Coach a conseillé de **jeter un stylo Mounjaro resté 2 jours hors frigo** ("plus de 24h hors du frigo, même non ouvert → jeter"). C'est FAUX : la notice autorise jusqu'à **21 jours hors réfrigérateur à < 30°C** avant première utilisation (30 jours après ouverture du KwikPen, < 30°C). Ce conseil fait jeter un traitement à 176-434 EUR. **Fix déployé : ai-coach v58** (bloc CONSERVATION ajouté au prompt système). Sources : notice EMA/Lilly (medical.lilly.com), vérifié par WebSearch ce jour.
+
+Site live : OK (home 200, redirect zepbound→mounjaro 301, sitemap-0.xml 200). Aucune occurrence Zepbound dans les conversations Coach. Fraîcheur données : GA à jour (0 j), GSC J-3 (normal, seuil d'alerte à 4 j).
+
+---
+
+## A. SEO RECOVERY WATCH
+
+**Baseline pré-suspension (15-23 juin, fixe)** : GA 922 sessions/j — GSC 106 clics/j, 2 514 impressions/j.
+
+- **Recovery Score GA : 37%** (344 sessions le 25/07, dernier jour complet ; le 26/07 est partiel)
+- **Recovery Score GSC : 38%** (40 clics le 23/07, dernier jour dispo)
+
+### 7 derniers jours
+
+| Date | GA sessions | % baseline | GSC clics | % baseline | GSC impressions |
+|------|------------|-----------|-----------|-----------|-----------------|
+| 19/07 (dim) | 455 | 49% | 37 | 35% | 1 770 |
+| 20/07 | 587 | 64% | 40 | 38% | 1 740 |
+| 21/07 | 578 | 63% | 44 | 42% | 1 826 |
+| 22/07 | 544 | 59% | 57 | 54% | 1 675 |
+| 23/07 | 525 | 57% | 40 | 38% | 1 518 |
+| 24/07 | 456 | 49% | — | — | — |
+| 25/07 (sam) | 344 | 37% | — | — | — |
+
+**Tendance** : plate sur les clics GSC (35-54% depuis 2 semaines), **négative sur les impressions** (-23% entre le 12/07 et le 23/07) et sur les sessions GA en fin de semaine. Position moyenne stable (~12-13). **Pas de date de retour à 100% estimable sur cette trajectoire** — la recovery ne progresse plus d'elle-même ; ce sont les pages perdues (ci-dessous) qui bloquent.
+
+### Pages du top baseline absentes ou faibles aujourd'hui → candidates à une demande de réindexation GSC
+
+| Page | Clics baseline (1-23/06) | Clics 7 derniers jours | Récupération |
+|------|--------------------------|------------------------|--------------|
+| /collections/glp1-cout/prix-mounjaro-france/ | 411 | 25 | 6% ⚠️ |
+| /collections/glp1-cout/prix-wegovy-france/ | 301 | 18 | 6% ⚠️ |
+| /collections/glp1-cout/wegovy-remboursement-mutuelle/ | 60 | 0 | 0% ⚠️ |
+| /collections/regime-glp1/regime-mounjaro-optimal/ | 18 | 0 | 0% |
+| /collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/ | 12 | 0 | 0% |
+| /guides/suivi-medical-glp1/ | 8 | 0 | 0% |
+| /collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/ | 8 | 0 | 0% |
+| /collections/effets-secondaires-glp1/effets-secondaires-mounjaro/ | 8 | 0 | 0% |
+
+**URLs à coller dans l'inspection GSC (demande d'indexation manuelle, priorisées par potentiel)** :
+```
+https://glp1-france.fr/collections/glp1-cout/prix-mounjaro-france/
+https://glp1-france.fr/collections/glp1-cout/prix-wegovy-france/
+https://glp1-france.fr/collections/glp1-cout/wegovy-remboursement-mutuelle/
+https://glp1-france.fr/collections/regime-glp1/regime-mounjaro-optimal/
+https://glp1-france.fr/collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/
+https://glp1-france.fr/guides/suivi-medical-glp1/
+https://glp1-france.fr/collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/
+https://glp1-france.fr/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/
+```
+
+À l'inverse, **prix-ozempic-france a dépassé sa baseline en rythme** (43 clics/7j vs 242 clics/23j ≈ 74/semaine baseline — soit ~58% récupéré, le meilleur des pages prix) et **carte-prix-pharmacies est à ~50%** (67 clics/7j vs ~133/semaine baseline). Les deux gros trous restent **prix-mounjaro et prix-wegovy à 6%** : c'est là que se joue le retour au niveau d'avant.
+
+### Pages Mounjaro (cibles des 301 ex-Zepbound)
+
+prix-mounjaro-france : 25 clics / 1 687 impressions (7j) — CTR 1,5%, position à re-suivre. Les autres pages Mounjaro font 0-2 clics. La page pénurie (352 imp, 2 clics, CTR 0,6%) reste faible malgré le nouveau title déployé le 20/07 — à re-vérifier vers le 28-29/07 avec plus de recul GSC.
+
+---
+
+## MONÉTISATION (contexte A0)
+
+- **Funnel Dossier 4,99 EUR (7 j)** : /outils/test-eligibilite/ 14 sessions, /dossier-glp1/ 10 sessions, /mon-espace/dossier/ 0. Volume d'exposition toujours très faible : le funnel manque de trafic, pas (encore) de conversion.
+- **Dossiers** : 0 créé en 24h. Cumul : 2 `generated`, 1 `pending`. Aucun paiement nouveau.
+- **Leads test d'éligibilité** : 1 sur 7 jours, 0 en 24h — cohérent avec les 14 sessions de la page (taux de capture ~7%, mais l'échantillon est trop petit pour conclure).
+- **Diagnostic** : la fuite est en **amont** (exposition/trafic), pas dans le formulaire. Les pages du funnel dépendent du trafic SEO global, qui a calé (volet A). Les 2 actions les plus rentables restent la réindexation des pages prix (trafic → funnel) et le Coach (8 conversations/24h, 2 flux éligibilité amorcés — aucun mené jusqu'au verdict).
+
+---
+
+## B. MONITORING COACH IA (24 dernières heures)
+
+### KPIs
+
+- **38 messages / 8 conversations / 19 messages user** (~2,4 msgs user par conversation)
+- vs veille : 38 vs 18 messages = **+111%**
+- **Modèles** : llama-3.3-70b 13, mistral-small 6 → **100% LLM, 0 fallback** ✓
+- **Intents** : general 13, prescription 2, price 1, selling 1, weight 1, availability 1
+- **Dossiers via chat** : 0 `[[DOSSIER_READY]]` émis, 0 proposition du Dossier observée dans les 8 conversations
+- **Conformité Zepbound** : aucune mention ✓
+
+### Analyse qualité par conversation
+
+1. **ed7710e5 (conservation Mounjaro)** — ⚠️ **ERREUR MÉDICALE** (voir alerte 3). User : "mounjaro non utilisé est resté deux jours hors frigo que faire ?" → Coach : "le jeter" puis "jette ton stylo s'il est resté plus de 24h hors du frigo (même non ouvert)". **Attendu** : un stylo non entamé < 30°C reste utilisable jusqu'à 21 jours cumulés hors frigo ; en cas de doute, demander au pharmacien avant de jeter. En plus, sur "combien de temps se conserve un stylo ouvert ?", le Coach a répondu "je n'ai pas trouvé d'information" (gap de connaissance). **Corrigé en v58.**
+2. **6202c57c (pochette frio vs isotherme)** — réponses contradictoires en 4 tours (isotherme obligatoire → frio suffit → re-comparaison). L'utilisateur a dû reposer 3 fois la question. Le bloc CONSERVATION v58 couvre désormais le cas voyage (règle simple : quelques heures < 30°C = pas de problème).
+3. **4f09e5a3 (Mounjaro 7,5 mg)** — bon funnel (proposition éligibilité, lien carte prix, parcours pharmacie) mais prix annoncé "395-440 EUR/mois" pour le 7,5 mg : hors de la grille officielle (176,10-433,80 EUR selon dosage). Chiffre inventé entre les bornes du prompt. Mineur mais à surveiller : si ça se répète, injecter la grille par dosage.
+4. **395d706f (ordonnance en ligne)** — bonne réponse de fond (pas d'ordonnance sans vraie consultation, téléconsultation légale possible). Bizarrerie : la 1re réponse (à "Bonjour,") parlait déjà d'ordonnance d'Ozempic 1mg avant que la question soit posée — probablement le contexte de page injecté ; à garder à l'œil, non bloquant.
+5. **73e4153a ("Suis-je éligible ?")** — réponse parfaite ("Vérifions ensemble ! Quel est ton poids et ta taille ?"), mais l'utilisateur n'a pas répondu. Flux abandonné à l'étape 1.
+6. **75ea0c67 (interaction Abilify)** — prudent et correct (orientation médecin/pharmacien, pas d'invention). ✓
+7. **a0b113f9 (maigrir/métabolisme)** — correct mais générique ; n'a pas proposé le test d'éligibilité alors que c'était le moment naturel. Occasion manquée.
+8. **af3f3cd4 (médecin prescripteur)** — très bonne réponse (annuaire ameli + CSO/CHU + proposition éligibilité). ✓
+
+### Constat funnel Coach
+
+2 flux d'éligibilité amorcés en 24h, 0 mené au verdict (abandons utilisateur à la 1re question). 0 proposition de Dossier — normal : le Dossier ne se propose qu'après IMC + comorbidités collectés, jamais atteint. Le Coach fait sa part ; c'est le volume d'entrée (8 conversations/jour) qui est trop faible pour produire des conversions régulières.
+
+---
+
+## C. ACTIONS EXÉCUTÉES
+
+1. **Fix erreur médicale Coach + déploiement ai-coach v58** (via MCP `deploy_edge_function`, `verify_jwt: false` conservé) : ajout d'un bloc "CONSERVATION DES STYLOS" sourcé (notices EMA/Lilly/Novo Nordisk) dans le prompt système — règles Mounjaro (21 j hors frigo < 30°C non entamé / 30 j entamé), Ozempic/Wegovy (6 semaines entamé), Saxenda/Victoza (1 mois entamé), interdiction de conseiller de jeter un stylo resté quelques heures/jours < 30°C, cas réels où ne pas utiliser (congélation, > 30°C, durées dépassées, aspect anormal), conseil voyage. Diff : +9 lignes dans `supabase/functions/ai-coach/index.ts`.
+2. **Liste de réindexation GSC produite** (8 URLs priorisées, volet A) — soumission manuelle à faire par Robin dans l'inspection GSC.
+
+## D. AUDIT DU JOUR
+
+Dimension couverte ce jour : **qualité Coach IA** (analyse des 8 conversations, 1 erreur médicale corrigée + 3 défauts mineurs documentés). Le prochain run reprend la rotation J1-J7 (technique).
+
+## EN ATTENTE DE DÉCISION ROBIN
+
+- **Soumission GSC manuelle** : coller les 8 URLs ci-dessus dans l'inspection d'URL Search Console (aucune API ne permet de le faire automatiquement). C'est l'action n°1 pour débloquer la recovery — prix-mounjaro et prix-wegovy à 6% de leur baseline représentent l'essentiel du trafic manquant.
+- Aucune autre décision sensible en attente.

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -60,6 +60,15 @@ CONTEXTE IMPORTANT :
 - IMPORTANT : Quand un patient demande le remboursement, donne une réponse COMPLÈTE et NUANCÉE : mentionne les conditions d'éligibilité (IMC), le parcours (prescription initiale en CSO/CHU), le taux (65%), et conseille de vérifier auprès de sa mutuelle pour le reste à charge. Ne sois jamais trop affirmatif sans nuance.
 - Si la personne est victime d'arnaque avérée : orienter calmement vers signal.conso.gouv.fr et pré-plainte-en-ligne.gouv.fr
 
+CONSERVATION DES STYLOS (FAITS OFFICIELS — notices EMA, applique-les STRICTEMENT, ne JAMAIS improviser) :
+- Règle générale : avant première utilisation, tous les stylos GLP-1 se conservent au réfrigérateur (2-8°C), jamais au congélateur.
+- Mounjaro (tirzépatide) : peut rester HORS frigo jusqu'à 21 jours maximum à moins de 30°C avant la première utilisation. Après la première utilisation (KwikPen entamé) : à conserver sous 30°C et à utiliser dans les 30 jours.
+- Ozempic et Wegovy (sémaglutide) : après première utilisation, conservation 6 semaines sous 30°C (ou au frigo).
+- Saxenda/Victoza (liraglutide) : après première utilisation, 1 mois sous 30°C (ou au frigo).
+- ⛔ NE DIS JAMAIS de jeter un stylo resté quelques heures ou quelques jours hors du frigo à température ambiante (< 30°C) : c'est FAUX et ça fait jeter un traitement qui coûte cher. Un stylo Mounjaro non entamé resté 2 jours hors frigo sous 30°C reste utilisable (limite : 21 jours cumulés).
+- Cas où il faut recommander de NE PAS utiliser le stylo : congélation (même partielle), exposition au-delà de 30°C ou en plein soleil, dépassement des durées ci-dessus, aspect anormal du liquide (trouble, particules). En cas de doute sur une exposition à la chaleur, conseiller de demander au pharmacien AVANT de jeter.
+- En voyage : pochette isotherme avec pain de gel NON congelé (le stylo ne doit pas toucher le gel froid) pour les longs trajets ou les fortes chaleurs ; quelques heures sous 30°C ne posent aucun problème pour un stylo entamé.
+
 ORIENTATION MÉDICALE (PRESCRIPTION / MÉDECIN / SUIVI) :
 - Pour une prescription ou un médecin : oriente vers le médecin traitant, un endocrinologue ou un médecin de l'obésité. Pour la primo-prescription ouvrant droit au remboursement obésité, elle doit être faite dans un centre spécialisé de l'obésité (CSO) ou un CHU ; le renouvellement peut ensuite se faire chez le généraliste. Annuaire officiel : annuaire-sante.ameli.fr.
 - ⚠️ NE DIS JAMAIS que le médecin traitant peut INITIER la primo-prescription du remboursement obésité, ni "faire le dossier" de primo-prescription : c'est FAUX. La primo-prescription se fait en CSO/CHU ; le généraliste ne fait que RENOUVELER ensuite. Pas de "depuis juin 2025 le médecin traitant peut initier" — c'est inexact.


### PR DESCRIPTION
## Résumé

Routine quotidienne du 26/07/2026 : rapport SEO recovery + monitoring Coach IA, et **correction d'une erreur médicale du Coach** (règles de conservation des stylos GLP-1).

### Rapport (`reports/daily-2026-07-26.md`)
- **Recovery GSC calée à ~38%** (40 clics / 106 baseline au 23/07), plateau depuis 2 semaines — alerte seuil < 50% déclenchée
- **Sessions GA en baisse 3 jours consécutifs** (544 → 525 → 456 → 344), -23% vs samedi précédent
- Pages prix-mounjaro et prix-wegovy à **6% de leur baseline** : liste de 8 URLs prête pour réindexation manuelle GSC (action Robin)
- Coach IA : 38 messages / 8 conversations (+111% vs veille), 100% LLM, 0 mention Zepbound

### Fix Coach IA (`supabase/functions/ai-coach/index.ts`) — **déployé en v58**
Le Coach a conseillé de jeter un stylo Mounjaro resté 2 jours hors frigo ("plus de 24h → jeter") : c'est faux (notice EMA/Lilly : 21 jours < 30°C avant première utilisation, 30 jours après ouverture du KwikPen) et ça fait jeter un traitement à 176-434 EUR. Ajout d'un bloc "CONSERVATION DES STYLOS" sourcé dans le prompt système (Mounjaro, Ozempic/Wegovy, Saxenda/Victoza, cas où ne pas utiliser, conseil voyage). Edge function déployée via MCP Supabase (v58, `verify_jwt: false` conservé) — le déploiement est indépendant du merge de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015W4G4zvLPVaDfY6Tt17ZKx

---
_Generated by [Claude Code](https://claude.ai/code/session_015W4G4zvLPVaDfY6Tt17ZKx)_