### PR TITLE
feat: plan de contenu SEO (todolist routine) + Phase C5 rédaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ La routine n'est PAS un rapporteur : c'est un **operateur autonome du site**. A 
 - Fixes techniques : liens casses, redirects, sitemap, images manquantes, schema.org, meta robots
 - Tickets correction_tickets + content_opportunities (INSERT Supabase)
 - Emails leads (sequence J0/J+3/J+7 definie plus bas)
+- **Rediger et publier 1 article/run depuis `content-plan.md`** (autorisation Robin 27/07/2026 : "todolist de nouveaux contenus qui suit un plan SEO calibre"). UNIQUEMENT les sujets du plan (file prioritaire, ou backlog present depuis >= 1 run = fenetre de veto 24h). Regles de redaction non negociables dans content-plan.md (chaque chiffre source ou supprime, byline honnete, pas de fausse experience).
 - Toute occurrence Zepbound detectee = suppression IMMEDIATE (jamais d'attente)
 
 **DEMANDER l'avis de Robin avant (AskUserQuestion si interactif, sinon PushNotification + section "EN ATTENTE DE DECISION" en tete de rapport)** :
@@ -119,7 +120,7 @@ La routine n'est PAS un rapporteur : c'est un **operateur autonome du site**. A 
 - Toucher aux prix, a l'offre, a la monetisation, a Stripe
 - Modifier le schema DB, les rate-limits, les workflows CI/CD
 - Refonte structurelle (navigation, layouts, home)
-- Reecrire plus de ~30% d'un article, ou publier un nouvel article
+- Reecrire plus de ~30% d'un article existant, ou publier un article HORS content-plan.md (les sujets du plan sont autonomes, voir ci-dessus)
 - Tout sujet medical/legal incertain (si la source officielle est introuvable → ticket + question, pas d'invention)
 
 ### Phase A0 — MONETISATION (PREMIER volet du rapport, OBLIGATOIRE chaque run)
@@ -204,8 +205,14 @@ INSERT INTO content_opportunities (title, keyword, search_volume_estimate, prior
 VALUES (...);
 ```
 
+**C5. Redaction d'un article du plan (content-plan.md)** — CHAQUE run, sauf urgence critique qui consomme le temps :
+- Prendre le premier sujet non coche de `content-plan.md` (ou un sujet du backlog present depuis >= 1 run), rediger selon les regles du plan (WebSearch obligatoire pour chaque chiffre, byline "Rédaction GLP-1 France", thumbnail SVG unique, FAQ schema, maillage entrant ET sortant dans le meme commit).
+- Publier (commit + PR + merge + deploy vert + verif live), cocher l'item avec date + URL, l'ajouter a la liste de soumission GSC du rapport.
+- Boucle de calibrage : a J+7 et J+30, noter les impressions GSC de chaque article publie dans la colonne Suivi du plan. 2 articles consecutifs invisibles a J+30 sur un meme cluster = stopper le cluster et re-prioriser (le dire dans le rapport).
+- Detecter de nouvelles opportunites (requetes GSC montantes, questions clients/Coach) et les ajouter au backlog du plan avec preuve chiffree.
+
 **Regles d'execution** :
-- **Max 6 actions autonomes par run** (au-dela : tickets pour le pipeline editorial). Une action = 1 fichier corrige, 1 bug Coach fixe+deploye, ou 1 lot de tickets/opportunites insere.
+- **Max 6 actions autonomes par run** (au-dela : tickets pour le pipeline editorial). Une action = 1 fichier corrige, 1 bug Coach fixe+deploye, 1 article du plan redige, ou 1 lot de tickets/opportunites insere.
 - Privilegier dans l'ordre : violation Zepbound > bugs Coach (erreur medicale d'abord) > findings de l'audit Phase D > CTR pages cle > content opportunities
 - Toujours committer a la fin du run : `git add -A && git commit -m "fix/feat: [description]"`
 - Pusher sur la branche de travail de la session (en remote) ou main (en local) pour deployer
@@ -241,6 +248,7 @@ VALUES (...);
 ## Structure du projet
 
 ```
+content-plan.md            — Todolist de contenu SEO (source de verite de la creation, Phase C5)
 config/astro.config.mjs    — Configuration Astro (redirige depuis astro.config.mjs racine)
 src/pages/                 — Pages Astro (statiques)
 src/pages/admin/           — Dashboards admin (fact-check, editorial, integration, agents)

--- a/content-plan.md
+++ b/content-plan.md
@@ -1,0 +1,52 @@
+# PLAN DE CONTENU SEO — todolist de la routine (validé Robin 27/07/2026)
+
+Ce fichier est la **source de vérité** de la création de contenu. La routine quotidienne :
+1. Prend le **premier sujet non coché** (ordre = priorité), rédige l'article, le publie (commit + PR + merge + deploy vert), coche la case avec la date et l'URL.
+2. **Maximum 1 article par run.** Qualité > cadence : un article annulé vaut mieux qu'un article inventé.
+3. Mesure et note dans ce fichier la performance de chaque article publié : impressions GSC à **J+7** et **J+30** (colonne Suivi). Si un article est invisible à J+7 → l'ajouter à la liste de réindexation GSC du rapport.
+4. Peut **ajouter des sujets au backlog** (section en bas, avec preuve de demande GSC/WebSearch) mais ne publie un sujet du backlog qu'au run SUIVANT son ajout — fenêtre de veto de 24h pour Robin.
+5. Robin peut réordonner, supprimer ou ajouter des sujets en éditant ce fichier directement.
+
+## Règles de rédaction (non négociables)
+
+- **Chaque chiffre est sourcé (lien) ou supprimé.** Sources officielles d'abord : ANSM, HAS, BDPM, ameli, JO/arrêtés, sites officiels des établissements. WebSearch obligatoire pendant la rédaction.
+- **Zéro fausse expérience** ("j'ai testé" interdit sauf vécu réel documenté). Byline : `Rédaction GLP-1 France` (pas de médecin fictif).
+- Marque **Zepbound interdite** (DMCA) — dire "tirzépatide" ou "Mounjaro".
+- 900-1 600 mots, structure H2/H3 propre, FAQ schema 3-5 questions, meta title ≤ 65 cars avec le mot-clé en tête, description ≤ 155 cars.
+- **Maillage** : ≥ 3 liens sortants vers nos pages (dont 1 vers le funnel : test d'éligibilité ou Dossier si pertinent) + ajouter ≥ 2 liens entrants depuis des articles existants dans le même commit.
+- Thumbnail SVG **unique** (DA verte #1a3c34 / #16a34a) dans `public/images/thumbnails/`.
+- URLs articles : `/collections/<collection>/<slug>/`.
+
+## File prioritaire
+
+### P1 — Parcours de soins (l'intention exacte de nos 2 premiers clients payants)
+
+- [ ] **1. Qui peut prescrire Mounjaro ou Wegovy pour être remboursé ? (généraliste vs CSO/CHU)** — collection `medecins-glp1-france`. Preuve : question littérale de la cliente n°2 ("la pharmacie m'a dit de chercher un médecin prescripteur habilité, où en trouver un ?") ; la page télémédecine prend déjà des clics. Angle : primo-prescription CSO/CHU, rôle exact du généraliste (renouvellement), que faire si le généraliste a prescrit à tort, comment trouver le CSO le plus proche (mode d'emploi annuaire ameli, pas de liste inventée). CTA : Dossier 4,99 €. Suivi : —
+- [ ] **2. La pharmacie refuse de délivrer Mounjaro/Wegovy : pourquoi et que faire** — collection `traitements-glp1`. Preuve : pain point client n°2 ; requêtes "pharmacie refuse" à vérifier par WebSearch au moment de la rédaction. Angle : les 4 causes réelles de refus (primo-prescription non conforme, accord préalable, rupture, ordonnance non sécurisée) + parcours de déblocage étape par étape. Suivi : —
+
+### P2 — Quick wins sur demande GSC mesurée
+
+- [ ] **3. Prix des GLP-1 en pharmacie : le tableau complet 2026 (Ozempic, Wegovy, Mounjaro, Saxenda, Trulicity, Rybelsus)** — collection `glp1-cout`. Preuve : "glp-1 en pharmacie prix" 201 imp/7j pos 8,1 CTR 0,5% sans page parfaitement dédiée. Angle : LE tableau de référence, prix BDPM sourcés, remboursement par indication, lien carte pharmacies. Suivi : —
+- [ ] **4. Acheter Wegovy ou Mounjaro en Espagne : prix réels et ce qui est légal** — collection `glp1-cout`. Preuve : "wegovy prix pharmacie espagne" 131 imp/7j pos 7,0 ; keywords "mounjaro prix espagne" déjà présents sur nos pages sans contenu dédié. Angle : comparatif prix officiel FR/ES sourcé, règles douanières/ordonnance UE (sourcées), pourquoi le remboursement FR change le calcul. Prudence légale : que du sourcé. Suivi : —
+
+### P3 — Cluster retraites (leadership : déjà position 8 sur "retraite perte de poids" à J+14)
+
+- [ ] **5. Cure thermale obésité : les stations agréées et la procédure de remboursement Sécu** — collection `retraites-bien-etre`. Preuve : "cure thermale minceur remboursé" pos 28,8 SANS page dédiée ; roadmap validée. Liste des stations sourcée (CNETh / ameli), procédure accord préalable. Suivi : —
+- [ ] **6. Brides-les-Bains : avis, prix, résultats — la station minceur de référence** — collection `retraites-bien-etre`. Preuve : requêtes "brides les bains cure minceur/amaigrissement avis" déjà en imp (pos 37-55) sur notre top-10. Prix vérifiables uniquement (site officiel). Suivi : —
+- [ ] **7. Combien coûte une retraite perte de poids en France ? (grille 2026)** — collection `retraites-bien-etre`. Roadmap 13/07 ; requête d'intention commerciale du cluster. Suivi : —
+- [ ] **8. Vittel, Capvern, Contrexéville : les 3 cures thermales minceur comparées (avis, prix)** — collection `retraites-bien-etre`. Roadmap validée ; regroupe 3 sujets en 1 comparatif honnête. Suivi : —
+- [ ] **9. Jeûne et randonnée : comparatif des organisateurs labellisés FFJR** — collection `retraites-bien-etre`. Roadmap validée ; zéro affiliation, prix sourcés. Suivi : —
+
+### P4 — Fond de roadmap
+
+- [ ] **10. Camp / séjour perte de poids pour adulte en France ("fat camp")** — `retraites-bien-etre`. Preuve : "camp perte de poids france" + "fat camp france" (pos 7 !) en imp sur le cluster. Suivi : —
+- [ ] **11. Peau relâchée après perte de poids GLP-1 : solutions (sport, nutrition, médecine esthétique)** — `effets-secondaires-glp1`. Pont vers retraites/Morpheus8 SANS promesse commerciale. Suivi : —
+- [ ] **12. Ozempic 2 mg : pourquoi il n'est pas disponible en France** — `traitements-glp1`. FAQ récurrente de la page prix, format court. Suivi : —
+
+## Backlog candidat (ajouts de la routine — publiables au run suivant leur ajout, veto Robin 24h)
+
+_(vide — la routine ajoute ici : sujet, requête cible, preuve de demande chiffrée, collection proposée)_
+
+## Publiés
+
+_(la routine déplace ici les items cochés : date, URL, imp J+7, imp J+30)_


### PR DESCRIPTION
Demande Robin 27/07 : "todolist dans la routine avec des nouveaux contenus rédigés, qui suit un plan SEO calibré".

**Changements :**
- `content-plan.md` (nouveau) — 12 sujets priorisés avec preuve de demande chiffrée : P1 parcours de soins (l'intention exacte des 2 premiers clients payants), P2 quick wins GSC mesurés, P3 cluster retraites (déjà position 8 sur la requête tête), P4 fond de roadmap. Règles de rédaction non négociables (chaque chiffre sourcé ou supprimé, byline honnête, thumbnails uniques, maillage entrant+sortant), fenêtre de veto Robin 24h sur les sujets ajoutés par la routine, boucle de calibrage J+7/J+30.
- `CLAUDE.md` — publier un sujet du plan devient autonome (GO Robin 27/07), hors-plan reste soumis à validation ; nouvelle Phase C5 (1 article/run max, publier + mesurer + re-prioriser).

Nota : cette PR remplace le contenu initialement ouvert sous ce numéro (décannibalisation ozempic), re-proposé séparément dans une PR dédiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgYzLYLGJKHXD1ygYomhCx