### PR TITLE
report: daily SEO recovery + Coach IA 2026-07-31 + deterministic price guard

### DIFF
--- a/reports/daily-2026-07-31.md
+++ b/reports/daily-2026-07-31.md
@@ -1,0 +1,188 @@
+# Rapport quotidien — 31 juillet 2026
+
+Fraîcheur données : GA à jour (31/07), GSC J-2 (29/07, normal). Site live OK : home 200, sitemap 200, redirect zepbound → mounjaro 301 conforme.
+
+---
+
+## ⚠️ ALERTES
+
+1. **Recovery GSC sous le seuil** — moyenne 7j = 40,0 clics/jour = **37,7% de la baseline** (106). Le seuil d'alerte défini (< 50% après le 20/07) est franchi sur la moyenne. Le dernier jour isolé (29/07 : 53 clics) est pile à 50%, mais la moyenne hebdo recule : 44,7 → 40,0 clics/jour d'une semaine à l'autre. **La reprise a calé.**
+
+2. **Le Coach a inventé des prix Wegovy en production le 29/07** — le modèle de repli `mistral-small` a affiché « 0,25 mg : ~169-200€/mois … 2,4 mg : ~295-360€/mois » alors que le prix public plafonne à 195,10€. **Ce message est postérieur au garde-fou déployé le 28/07 (v60)** : celui-ci n'était qu'une consigne de prompt, et le modèle de repli — 38% des réponses sur 7 jours — ne l'a pas respectée. Correctif en code écrit et commité ; **déploiement de l'edge function en attente côté Robin** (voir « En attente de décision »).
+
+3. **Aucune violation Zepbound** dans les conversations ni sur le site. RAS de ce côté.
+
+---
+
+## A0. MONÉTISATION (objectif principal)
+
+### Funnel — 7 derniers jours
+| Étape | Volume 7j | Dernier jour |
+|---|---|---|
+| Visites `/outils/test-eligibilite/` | 29 sessions | 2 |
+| Visites `/dossier-glp1/` | 15 sessions | 1 |
+| Nouveaux leads test d'éligibilité | 2 (dernier : 28/07) | 0 |
+| Dossiers créés | 2 | 0 |
+| Dossiers payés | 0 | 0 |
+
+### État des dossiers (cumul)
+| Email | Statut | Créé | Payé | Via |
+|---|---|---|---|---|
+| francoise.cardon@free.fr | generated | 24/07 | **24/07** | chat |
+| KYM.BEAUTE@GMAIL.COM | generated | 22/07 | **22/07** | formulaire |
+| JONATHANVIALE1@GMAIL.COM | pending | 27/07 | — | checkout abandonné |
+| sruth83@gmail.com | pending | 27/07 | — | checkout abandonné |
+| trash198001@gmail.com | pending | 05/07 | — | email de test |
+
+**2 ventes au total, aucune depuis le 24/07** (7 jours sans conversion).
+
+### Relances et suivi post-achat
+- Les 2 checkouts abandonnés du 27/07 ont **déjà reçu leur relance le 28/07** (`dossier_relance`). Pas de nouvelle relance aujourd'hui — insister à 3 jours d'intervalle serait contre-productif. Prochain point : si toujours rien au 03/08, considérer ces leads comme perdus.
+- **Client 1** (KYM.BEAUTE, payé 22/07) : email satisfaction envoyé le 23/07 → **toujours aucune réponse** à ce jour.
+- **Client 2** (francoise.cardon, payé 24/07) : email satisfaction envoyé le 27/07 → **aucune réponse** à ce jour.
+- Sync IMAP fonctionnelle (dernier email entrant 30/07, 14 emails sur 30 jours).
+
+### Contribution du Coach
+- 3 conversations sur 24h, dont **une candidate idéale au Dossier qui n'a rien reçu** (détail volet B). Aucun `[[DOSSIER_READY]]` émis.
+
+### Diagnostic de fuite
+La fuite n'est pas au checkout : sur 5 dossiers créés, **5 ont atteint Stripe** (100%), et 2 ont payé (40%). Le problème est **en amont** : seulement 15 sessions sur la landing en 7 jours, et 2 dossiers créés. Il n'y a pas assez de monde qui entre dans le funnel. Le Coach, qui devrait être le premier pourvoyeur, a laissé passer un profil parfait cette semaine (IMC 47,8, comorbidités, déjà engagé en CSO) sans proposer le Dossier.
+
+---
+
+## A. SEO RECOVERY WATCH
+
+**Recovery Score GA** : 488 sessions le 30/07 (dernier jour complet) = **52,9%** de la baseline (922).
+**Recovery Score GSC** : 53 clics le 29/07 = **50,0%** de la baseline (106). Moyenne 7j : **37,7%**.
+
+| Date | GA sessions | % baseline | GSC clics | % baseline | Impressions |
+|---|---|---|---|---|---|
+| 24/07 | 456 | 49% | 32 | 30% | 1 825 |
+| 25/07 | 344 | 37% | 33 | 31% | 1 681 |
+| 26/07 | 329 | 36% | 22 | 21% | 1 366 |
+| 27/07 | 505 | 55% | 43 | 41% | 1 931 |
+| 28/07 | 489 | 53% | 57 | 54% | 2 135 |
+| 29/07 | 556 | 60% | 53 | 50% | 1 785 |
+| 30/07 | 488 | 53% | — | — | — |
+
+*(31/07 : 52 sessions à 8h = journée partielle, non comptée.)*
+
+**Tendance** : les impressions tiennent (71% de la baseline) mais les clics stagnent autour de 40/jour. Il n'y a **pas de pente positive exploitable** : la moyenne hebdo recule de 44,7 à 40,0 clics/jour. Toute projection de retour à 100% serait de l'invention — au rythme actuel, il n'y en a pas.
+
+### Pages du top baseline encore loin du compte
+| Page | Clics baseline (23j) | Clics 7j | Impressions 7j |
+|---|---|---|---|
+| `/collections/glp1-cout/prix-mounjaro-france/` | 411 | **16** | 1 694 |
+| `/collections/glp1-cout/prix-wegovy-france/` | 301 | **6** | 676 |
+| `/collections/glp1-cout/prix-ozempic-france/` | 242 | **22** | 2 347 |
+| `/collections/glp1-cout/wegovy-remboursement-mutuelle/` | 60 | **0** | 74 |
+| `/` (home) | 40 | **0** | 143 |
+
+---
+
+## B. DÉCISIONS
+
+### B1. Le cluster prix ne perd pas son classement — il perd sa demande
+
+Constat : `prix-ozempic-france` perd 1 321 impressions en une semaine, `prix-mounjaro` 509, `prix-wegovy` 235. Descente au niveau requête :
+
+| Requête | Impr. S-1 | Impr. S | Position S-1 | Position S |
+|---|---|---|---|---|
+| ozempic sans ordonnance | 402 | **31** (-92%) | 12,4 | **11,8** (meilleure) |
+| ozempic achat en ligne | 491 | 162 (-67%) | 9,7 | 10,5 |
+| ozempic achat | 95 | 16 (-83%) | 11,6 | 16,9 |
+| acheter ozempic en ligne | 51 | 15 (-71%) | 10,2 | 11,0 |
+| mounjaro prix le moins cher | 435 | 167 (-62%) | 8,9 | 10,2 |
+
+**Les positions sont stables, parfois meilleures, pendant que les impressions s'effondrent.** Ce n'est donc pas une perte de ranking. J'ai vérifié qu'il ne s'agissait pas non plus d'une migration interne : ces requêtes chutent **à l'échelle du site entier**, toutes pages confondues (« ozempic sans ordonnance » : 408 → 33 sur l'ensemble du site). Ce n'est pas non plus un effet de la décannibalisation du 28/07.
+
+Le point discriminant : **la chute se concentre sur les requêtes à intention grise** (« sans ordonnance », « achat en ligne », « acheter ») — -67% à -92% — alors que les requêtes prix neutres reculent bien moins (« prix ozempic france » -34%). Sur la même période, le site couvre **plus** de requêtes qu'avant (1 540 → 2 022) et ne perd que 11% d'impressions au total.
+
+**Décision** : hypothèse principale = **Google resserre les SERP sur les requêtes d'achat de médicaments sur ordonnance** (filtrage YMYL), pas une pénalité qui nous viserait. Hypothèse secondaire à ne pas écarter : saisonnalité de fin juillet. → **Ne pas tenter de « récupérer » ce trafic** : il est en intention d'achat illégal, il convertit mal et il est structurellement exposé. Reporter l'effort sur les requêtes de remboursement/éligibilité, qui alimentent le Dossier. À re-mesurer au 07/08 pour trancher entre les deux hypothèses.
+
+### B2. CTR du cluster prix à ~0,9% : c'est là que se joue la recovery
+
+Les trois pages prix affichent 4 717 impressions pour 44 clics sur 7 jours = **0,93% de CTR**, contre 4,2% de CTR moyen à la baseline. Ce sont trois candidates C1 selon les critères de la routine (CTR < 1,5% sur 300+ impressions).
+
+J'ai vérifié les titres réellement servis : **ils se rendent correctement** depuis le correctif du 28/07 (PR #79) — ce n'était pas le cas avant, ce qui explique probablement une partie du trou. Google doit maintenant recrawler.
+
+**Décision** : ne pas réécrire les titres Ozempic et Mounjaro, qui sont bons et viennent d'être corrigés — leur laisser un cycle de crawl. En revanche, corriger Wegovy, dont la description dépassait la limite d'affichage (voir C1).
+
+### B3. SEO programmatique pharmacies : ne pas passer au palier suivant
+
+| Type de page | Pages vues par GSC | Impressions 7j | Clics 7j | Position |
+|---|---|---|---|---|
+| Fiches pharmacie | 632 | 2 274 | 21 | 24,9 |
+| Prix ville | **42** / 600 | 399 | 13 | 17,7 |
+| Prix département | **31** / 306 | 156 | 9 | 37,3 |
+| Hub ville | 17 | 142 | 4 | 13,9 |
+| Hub code postal | 28 | 121 | 1 | 40,4 |
+
+**750 pages vues par GSC sur 23 606 publiées = 3,2% de couverture** après ~6 semaines. Les pages prix ville, cœur du pari, sont à 42 indexées sur 600.
+
+**Décision** : le palier 2 (hubs 500 → 1000, prix ville 200 → 500) était conditionné au démarrage de l'indexation. **Ce démarrage n'a pas lieu** — publier 800 pages de plus ne ferait qu'ajouter des URLs non explorées. → **Palier gelé**, à réévaluer mi-août. Signal supplémentaire de faible qualité : la seule requête nouvelle à 50+ impressions cette semaine est « donjoy noyon » (73 impressions, 0 clic), une marque d'orthopédie sans rapport — ces pages captent du bruit.
+
+---
+
+## C. ACTIONS EXÉCUTÉES
+
+**C1 — Garde-fou prix du Coach, réécrit en code** (`supabase/functions/ai-coach/index.ts`)
+Remplacement de la consigne de prompt (contournée en prod le 29/07) par un contrôle déterministe après génération : `checkPriceCeiling()` détecte tout montant en euros supérieur au plafond public du médicament cité et substitue le bloc de prix officiels. Le contrôle ne porte que sur le **dépassement** — un montant inférieur est le plus souvent un reste à charge légitime. Testé sur 12 cas : le message fautif du 29/07 est bien intercepté, et aucun des 10 cas légitimes ne déclenche à tort (reste à charge 51€, coût annuel « 2 300 € », prix du Dossier 4,99€, comparatif multi-médicaments, plafonds officiels exacts).
+
+**C2 — Titre et description de `prix-wegovy-france`**
+`seoDescription` faisait 209 caractères (tronquée par Google, se terminait sur un « Mis à jour. » orphelin) → 143 caractères. `seoTitle` : « Wegovy Prix Pharmacie **Moins Cher** 2026 » → « Wegovy Prix Pharmacie 2026 : 146,91-195,10 €, **le même partout** ». Le titre promettait un « moins cher » que la page elle-même contredit (prix réglementé identique partout) — cette contradiction pénalise le clic et la satisfaction. `updatedAt` et `dateModified` du schema.org alignés au 31/07.
+
+**C3 — 3 désinscriptions STOP rendues durables** (Supabase)
+La campagne du 27/07 a reçu 3 réponses « Stop » (soraya.vous.m@gmail.com, inezforbes2@gmail.com, balbouy@gmail.com). Elles n'étaient tracées que dans `incoming_emails`, ce qui rendait le respect du STOP dépendant d'une relecture manuelle à chaque run. Les 3 contacts sont désormais `status = 'unsubscribed'`, `newsletter = false`, avec la raison en note.
+
+**Non fait ce run** : la rédaction d'article du plan (C5). Le diagnostic du cluster prix et la correction du Coach ont consommé le budget du run. Le plan reste amorcé sur le sujet n°1 (« Qui peut prescrire Mounjaro ou Wegovy pour être remboursé ? »), qui est aussi la réponse à la question littérale de la cliente n°2 — à traiter en priorité au prochain run.
+
+---
+
+## D. AUDIT DU JOUR — J1 Technique
+
+- **robots.txt** : conforme, sitemap déclaré, `/admin/` bloqué.
+- **Sitemap** : `sitemap-index.xml` → `sitemap-0.xml`, **23 871 URLs / 4,3 Mo** (limites Google : 50 000 URLs / 50 Mo — marge confortable). Réparti en 23 606 pages pharmacies (dont 907 pages prix), 216 collections, 13 retraites. `lastmod` au 27/07, cohérent avec le dernier déploiement de pages.
+- **Codes retour** : 8 pages clés testées (home, dossier, test d'éligibilité, retraites, prix ozempic, carte pharmacies, mon-espace/dossier, contact) → **toutes en 200**, aucune chaîne de redirection.
+- **Liens cités par le Coach** : `/collections/glp1-cout/wegovy-prix/` renvoie un 301 propre vers `prix-wegovy-france`, `/outils/carte-prix-pharmacies/` en 200. Pas de lien mort servi aux utilisateurs.
+- **Redirect DMCA** : `guide-complet-zepbound` → `guide-complet-mounjaro` en 301, conforme.
+
+Aucune anomalie technique bloquante. La faiblesse du site n'est pas technique en ce moment.
+
+---
+
+## B (bis). COACH IA — 24 dernières heures
+
+**KPIs** : 20 messages, 3 conversations, 10 messages utilisateur (≈6,7 messages par conversation — engagement correct). Sur 7 jours : 66 réponses `llama-3.3-70b`, 40 `mistral-small` (**38% de repli**). Aucun fallback v1. Aucune mention Zepbound.
+
+### Problèmes détectés
+
+**1. Prix inventés (grave)** — conv. `41c0fa95`, 29/07
+Dans la même conversation, deux prix Wegovy contradictoires : llama a répondu « 147€ à 195€ » (correct), puis mistral-small a produit une grille par dosage « 169-200€ … 295-360€/mois », intégralement inventée et jusqu'à +85% au-dessus du prix réel. → **corrigé en code (C1), déploiement en attente.**
+
+**2. Prospect parfait perdu (coûteux)** — conv. `41a3f465`, 31/07
+Utilisatrice à 127 kg / 1m63 → **IMC 47,8**, prédiabète et stéatose hépatique, **déjà reçue en CSO**. Le Coach a correctement calculé l'IMC et rendu le verdict « éligible ». Le prompt impose alors de proposer le Dossier « dans cette même réponse ou la suivante au maximum ». **Il ne l'a jamais proposé** sur 5 échanges, alors que la personne exprimait explicitement une urgence (« je veux mon mounjaro sans attendre 6 mois »). C'est le profil le plus qualifié de la semaine, et le funnel l'a laissé filer.
+
+**3. Réponse qui met la personne en difficulté** — même conversation
+Face au parcours de 6 mois exigé par le CSO, le Coach a suggéré de demander « une prise en charge plus rapide ». Or ces 6 mois de prise en charge nutritionnelle sont **une condition réglementaire du remboursement**, pas une lubie du centre : encourager à faire pression prépare un refus. Il fallait expliquer la règle et proposer le Dossier pour préparer le rendez-vous.
+
+**4. Imprécision produit** — même conversation
+« Des stylos préremplis à usage unique, contenant chacun 4 doses » est contradictoire : le KwikPen Mounjaro contient 4 doses (multi-dose), le stylo à usage unique en contient une. Le prompt décrit correctement le KwikPen ; la réponse a mélangé les deux formats.
+
+### Actions recommandées
+- **Prioritaire** : déployer le correctif prix (C1).
+- **Ensuite** : le problème n°2 est le plus rentable à traiter. La règle de déclenchement du Dossier existe dans le prompt mais n'est pas suivie après un verdict positif. Piste à instruire au prochain run : la déclencher côté serveur (le verdict IMC est déjà calculé en code par `buildImcVerdictContext`) plutôt que de compter sur l'obéissance du modèle — même logique que le garde-fou prix.
+
+---
+
+## EN ATTENTE DE DÉCISION ROBIN
+
+1. **Déployer l'edge function `ai-coach`** (correctif prix, commité). Je n'ai pas pu le faire depuis la session distante : `index.ts` fait 34 000 tokens, et le seul canal de déploiement disponible ici (l'outil MCP) exige de retransmettre le fichier entier, ce qui risquait de le tronquer et de mettre le Coach hors service. Aucun jeton de management ni workflow CI ne permet de contourner. En local, une commande suffit :
+   ```
+   supabase functions deploy ai-coach --project-ref ywekaivgjzsmdocchvum
+   ```
+   Tant que ce n'est pas fait, le Coach peut à nouveau inventer des prix (38% des réponses passent par le modèle concerné).
+
+2. **Byline « Dr. Marie Dubois »** — toujours présente sur `prix-wegovy-france` (frontmatter et schema.org `author`), et sur d'autres articles. Point déjà signalé le 14/07 : si cette personne n'existe pas, c'est un risque E-E-A-T et juridique sur des contenus médicaux, aggravé par le fait qu'elle est déclarée en `Person` dans les données structurées. Je ne la modifie pas de ma propre initiative — c'est une décision éditoriale de portée site. À trancher : vrai relecteur crédité, ou bascule vers « Rédaction GLP-1 France ».
+
+3. **Palier pharmacies gelé** (décision B3) — je n'ai rien publié de nouveau, mais si l'intention était de monter à 1 000 hubs en août, la donnée dit d'attendre.

--- a/src/content/glp1-cout/prix-wegovy-france.md
+++ b/src/content/glp1-cout/prix-wegovy-france.md
@@ -4,10 +4,10 @@ thumbnail: "/images/thumbnails/prix-wegovy-france-illus.jpg"
 thumbnailAlt: "Prix et coût du traitement wegovy-france"
 description: "Wegovy prix pharmacie 2026 : à partir de 146,91€/mois (prix réglementé). Tarifs par dosage 0,25 à 2,4 mg, où l'acheter en France et remboursement 65 %."
 keywords: ['prix wegovy', 'wegovy prix', 'prix wegovy france', 'wegovy prix pharmacie moins cher', 'wegovy pharmacie moins cher', 'wegovy pharmacie', 'wegovy prix pharmacie', 'remboursement wegovy', 'wegovy prix 2026', 'coût wegovy', 'wegovy non remboursé', 'prix wegovy 2.4 mg']
-seoTitle: "Wegovy Prix Pharmacie Moins Cher 2026 : dès 146,91€, remboursé 65%"
-seoDescription: "Wegovy prix pharmacie juillet 2026 : 146,91 à 195,10€/mois (prix réglementé, identique partout). Remboursé 65% Sécu depuis juin 2026. Carte des pharmacies disponibles, éligibilité et reste à charge. Mis à jour."
+seoTitle: "Wegovy Prix Pharmacie 2026 : 146,91-195,10 €, le même partout"
+seoDescription: "Prix Wegovy en pharmacie : 146,91 à 195,10 €/mois selon le dosage, réglementé et identique partout. Remboursé 65% : vérifiez votre éligibilité."
 publishedAt: '2025-01-28'
-updatedAt: '2026-07-20'
+updatedAt: '2026-07-31'
 date: '2026-07-19'
 featured: true
 author: 'Dr. Marie Dubois'
@@ -38,7 +38,7 @@ faqSchema:
   "description": "Prix Wegovy en pharmacie : 146,91 à 195,10€/mois selon dosage (prix réglementé). Remboursé à 65 % par l'Assurance Maladie depuis le 15 juin 2026 sous conditions.",
   "url": "https://glp1-france.fr/collections/glp1-cout/prix-wegovy-france",
   "datePublished": "2025-01-28",
-  "dateModified": "2026-07-19",
+  "dateModified": "2026-07-31",
   "author": {
     "@type": "Person",
     "name": "Dr. Marie Dubois"

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -904,6 +904,22 @@ Reste factuel, ne pose pas de diagnostic médical définitif, rappelle que la d�
         }
       }
 
+      // --- Garde-fou prix (déterministe) ---
+      // Le garde-fou prompt-only ajouté le 28/07 (v60) a été ignoré par mistral-small
+      // dès le 29/07 : fourchettes Wegovy inventées (169-200€ à 295-360€/mois) alors que
+      // le prix public plafonne à 195,10€. Un modèle de repli ne respecte pas toujours une
+      // consigne de prompt → on vérifie le texte APRÈS génération, en code.
+      const priceCheck = checkPriceCeiling(cleanResponse);
+      if (priceCheck.violated) {
+        console.warn(
+          `[price-guard] ${usedModel} a cité ${priceCheck.amounts.join("/")}€ > plafond ${priceCheck.ceiling}€ ` +
+          `(${priceCheck.drugs.join(",")}) — réponse remplacée par les prix officiels`,
+        );
+        cleanResponse = OFFICIAL_PRICE_BLOCK;
+        suggestions = [];
+        options = [];
+      }
+
       // Moment chaud → on propose la capture email (le funnel convertit à 0 sans capture).
       const saysEligible = /\béligibl/i.test(cleanResponse);
       const saysNotEligible = /\b(pas|plus)\b[^.]{0,25}éligibl|éligibl[^.]{0,25}\bsi\b/i.test(cleanResponse);
@@ -952,6 +968,52 @@ Reste factuel, ne pose pas de diagnostic médical définitif, rappelle que la d�
     return jsonResponse({ error: (err as Error).message }, 500);
   }
 });
+
+// --- Garde-fou prix : plafonds publics officiels (BDPM, arrêtés du 15/06/2026) ---
+// On ne contrôle QUE le dépassement. Un montant inférieur au prix public est le plus
+// souvent un reste à charge légitime (65% remboursé) ; un montant supérieur au prix
+// public, lui, est toujours une invention — c'est le cas observé en prod le 29/07.
+const PRICE_CEILINGS: Record<string, { pattern: RegExp; max: number }> = {
+  ozempic: { pattern: /ozempic/i, max: 80 },
+  wegovy: { pattern: /wegovy/i, max: 200 },
+  mounjaro: { pattern: /mounjaro/i, max: 440 },
+  saxenda: { pattern: /saxenda/i, max: 290 },
+};
+
+const OFFICIAL_PRICE_BLOCK = `Les prix des GLP-1 sont réglementés : ils sont identiques dans toutes les pharmacies de France (source BDPM).
+
+- **Ozempic** : 77,60 €/stylo (1 stylo = 1 mois) — remboursé 30% pour le diabète T2, 100% en ALD
+- **Wegovy** : 146,91 à 195,10 €/mois selon le dosage — remboursé 65% pour l'obésité
+- **Mounjaro** : 176,10 à 433,80 €/mois selon le dosage — remboursé 65% pour l'obésité
+- **Saxenda** : environ 270 €/mois — non remboursé
+
+Le remboursement à 65% suppose un IMC ≥ 35 avec comorbidité ou ≥ 40, après une prise en charge nutritionnelle, avec une primo-prescription en CSO/CHU.
+
+Veux-tu qu'on vérifie si tu es éligible au remboursement à 65% ?`;
+
+function checkPriceCeiling(
+  text: string,
+): { violated: boolean; amounts: number[]; ceiling: number; drugs: string[] } {
+  const drugs = Object.keys(PRICE_CEILINGS).filter((d) => PRICE_CEILINGS[d].pattern.test(text));
+  if (drugs.length === 0) return { violated: false, amounts: [], ceiling: 0, drugs: [] };
+  // Plusieurs médicaments cités (comparatif) → on retient le plafond le plus élevé,
+  // sinon le prix légitime du plus cher serait signalé à tort.
+  const ceiling = Math.max(...drugs.map((d) => PRICE_CEILINGS[d].max));
+
+  const amounts: number[] = [];
+  // Montants explicitement libellés en euros : les mg, kg, %, IMC et dates sont exclus.
+  const re = /(\d{1,4}(?:[.,]\d{1,2})?)\s*(?:€|EUR\b|euros?\b)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    // "2 300 €" : on tomberait sur "300" — un séparateur de milliers précède le match.
+    if (/\d[\s ]?$/.test(text.slice(Math.max(0, m.index - 2), m.index))) continue;
+    // Coût annuel ("~2400€ par an") : hors périmètre du prix boîte/mois.
+    if (/^\s*(?:\/|par\s+)\s*an(?:née)?\b/i.test(text.slice(m.index + m[0].length))) continue;
+    const value = parseFloat(m[1].replace(",", "."));
+    if (!isNaN(value) && value > ceiling) amounts.push(value);
+  }
+  return { violated: amounts.length > 0, amounts, ceiling, drugs };
+}
 
 // --- Helper: save user + assistant messages ---
 async function saveMessages(


### PR DESCRIPTION
## Ce que contient cette PR

**1. `ai-coach` — garde-fou prix réécrit en code**

Le garde-fou ajouté le 28/07 (v60) était une consigne de prompt. Le 29/07, le modèle de repli `mistral-small` — 38% des réponses sur 7 jours — l'a ignoré et a produit une grille de prix Wegovy entièrement inventée (jusqu'à 360 €/mois contre un plafond public de 195,10 €), dans la même conversation où llama avait donné le bon prix.

Remplacé par `checkPriceCeiling()`, un contrôle déterministe après génération : tout montant en euros supérieur au plafond public du médicament cité déclenche la substitution par le bloc de prix officiels BDPM.

Le contrôle ne porte que sur le **dépassement** : un montant inférieur est le plus souvent un reste à charge légitime après remboursement à 65%. Vérifié sur 12 cas — le message fautif du 29/07 est intercepté, et aucun des 10 cas légitimes ne déclenche à tort (reste à charge 51 €, coût annuel « 2 300 € », prix du Dossier 4,99 €, comparatif multi-médicaments, plafonds officiels exacts).

⚠️ **Le déploiement de l'edge function reste à faire** : `supabase functions deploy ai-coach --project-ref ywekaivgjzsmdocchvum`. Il n'a pas pu être fait depuis la session distante (fichier de 34 000 tokens, seul canal disponible = retransmission intégrale via MCP, avec un risque de troncature qui aurait mis le Coach hors service).

**2. SEO — `prix-wegovy-france`**

`seoDescription` faisait 209 caractères, tronquée par Google et terminée sur un « Mis à jour. » orphelin → 143 caractères. Le `seoTitle` promettait un « Moins Cher » que la page elle-même contredit (prix réglementé identique partout) → reformulé en « le même partout », qui répond à l'intention de recherche sans la contredire. `updatedAt` et `dateModified` alignés.

**3. Désinscriptions STOP**

3 réponses « Stop » à la campagne du 27/07 n'étaient tracées que dans `incoming_emails`, ce qui faisait dépendre le respect du STOP d'une relecture manuelle à chaque run. Les contacts sont désormais `status = 'unsubscribed'` avec la raison en note.

## Ce que dit le rapport

- **Recovery GSC à 37,7% en moyenne 7j** (seuil d'alerte franchi) : les impressions tiennent à 71% de la baseline, mais les clics stagnent et la moyenne hebdo recule de 44,7 à 40,0 clics/jour.
- **Le cluster prix ne perd pas son classement, il perd sa demande** : les positions sont stables voire meilleures pendant que les impressions s'effondrent de 62 à 92%, et la chute se concentre sur les requêtes à intention grise (« sans ordonnance », « achat en ligne »). Vérifié qu'il ne s'agit ni d'une migration interne ni d'un effet de la décannibalisation du 28/07.
- **SEO programmatique pharmacies : palier gelé** — 750 pages vues par GSC sur 23 606 publiées (3,2%), et 42 pages prix ville indexées sur 600. Publier 800 pages de plus n'ajouterait que des URLs non explorées.
- **Coach : un prospect à IMC 47,8 déjà engagé en CSO n'a jamais reçu la proposition de Dossier**, alors que le prompt l'impose après un verdict positif. C'est le profil le plus qualifié de la semaine.

Rapport complet : `reports/daily-2026-07-31.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fV2hNJjbisAJEnNViuqnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013fV2hNJjbisAJEnNViuqnQ)_