### PR TITLE
Daily routine 2026-08-01: article "qui peut prescrire remboursé" + primo-prescription fixes + report

### DIFF
--- a/content-plan.md
+++ b/content-plan.md
@@ -21,7 +21,6 @@ Ce fichier est la **source de vérité** de la création de contenu. La routine 
 
 ### P1 — Parcours de soins (l'intention exacte de nos 2 premiers clients payants)
 
-- [ ] **1. Qui peut prescrire Mounjaro ou Wegovy pour être remboursé ? (généraliste vs CSO/CHU)** — collection `medecins-glp1-france`. Preuve : question littérale de la cliente n°2 ("la pharmacie m'a dit de chercher un médecin prescripteur habilité, où en trouver un ?") ; la page télémédecine prend déjà des clics. Angle : primo-prescription CSO/CHU, rôle exact du généraliste (renouvellement), que faire si le généraliste a prescrit à tort, comment trouver le CSO le plus proche (mode d'emploi annuaire ameli, pas de liste inventée). CTA : Dossier 4,99 €. Suivi : —
 - [ ] **2. La pharmacie refuse de délivrer Mounjaro/Wegovy : pourquoi et que faire** — collection `traitements-glp1`. Preuve : pain point client n°2 ; requêtes "pharmacie refuse" à vérifier par WebSearch au moment de la rédaction. Angle : les 4 causes réelles de refus (primo-prescription non conforme, accord préalable, rupture, ordonnance non sécurisée) + parcours de déblocage étape par étape. Suivi : —
 
 ### P2 — Quick wins sur demande GSC mesurée
@@ -49,4 +48,4 @@ _(vide — la routine ajoute ici : sujet, requête cible, preuve de demande chif
 
 ## Publiés
 
-_(la routine déplace ici les items cochés : date, URL, imp J+7, imp J+30)_
+- [x] **1. Qui peut prescrire Mounjaro ou Wegovy pour être remboursé ? (généraliste vs CSO/CHU)** — publié le 01/08/2026 → https://glp1-france.fr/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/ — sources : arrêtés des 10-12/06/2026 (Vidal 37850/37934), ameli.fr, Santé.fr (41 CSO), Moniteur des pharmacies (règle 6 mois / -5 %). Maillage entrant : article généraliste + article télémédecine. Suivi : imp J+7 (~08/08) : — ; imp J+30 (~31/08) : —

--- a/public/images/thumbnails/qui-peut-prescrire-mounjaro-wegovy-rembourse.svg
+++ b/public/images/thumbnails/qui-peut-prescrire-mounjaro-wegovy-rembourse.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1a3c34"/>
+      <stop offset="1" stop-color="#0f2620"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="1080" cy="520" r="200" fill="#16a34a" opacity="0.12"/>
+  <circle cx="150" cy="100" r="140" fill="#16a34a" opacity="0.10"/>
+  <text x="80" y="150" font-family="Georgia, serif" font-size="34" fill="#16a34a" font-weight="bold">GLP-1 FRANCE</text>
+  <text x="80" y="280" font-family="Georgia, serif" font-size="68" fill="#ffffff" font-weight="bold">Qui peut prescrire</text>
+  <text x="80" y="370" font-family="Georgia, serif" font-size="68" fill="#ffffff" font-weight="bold">pour être remboursé ?</text>
+  <rect x="80" y="410" width="120" height="6" fill="#16a34a"/>
+  <text x="80" y="500" font-family="Georgia, serif" font-size="40" fill="#9fd7b4">Généraliste vs CSO / CHU — la règle 2026</text>
+  <g transform="translate(1000,120)">
+    <rect x="-55" y="-20" width="110" height="150" rx="14" fill="#ffffff" opacity="0.92"/>
+    <rect x="-55" y="-20" width="110" height="40" rx="14" fill="#16a34a"/>
+    <rect x="-30" y="40" width="60" height="8" rx="4" fill="#1a3c34" opacity="0.55"/>
+    <rect x="-30" y="62" width="60" height="8" rx="4" fill="#1a3c34" opacity="0.55"/>
+    <rect x="-30" y="84" width="38" height="8" rx="4" fill="#1a3c34" opacity="0.55"/>
+    <path d="M -12 108 l 8 10 l 18 -20" stroke="#16a34a" stroke-width="7" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/reports/daily-2026-08-01.md
+++ b/reports/daily-2026-08-01.md
@@ -1,0 +1,97 @@
+# Rapport quotidien — 2026-08-01
+
+## ALERTES
+
+- **Recovery GSC : 50% le 29/07 — l'alerte "(d) < 50% apres le 20/07" est en train de se lever.** Meilleure sequence de clics depuis la suspension : 43 / 57 / 53 sur les 3 derniers jours GSC (27-29/07). A confirmer 2-3 jours de plus avant de la clore.
+- **Erreur reglementaire du Coach detectee et corrigee a la source (RAG)** : le 01/08 a 08:50, le Coach a affirme « ton medecin traitant peut aussi prescrire directement Wegovy ou Mounjaro (sous conditions de remboursement) » — trompeur depuis le 15/06/2026 (primo-prescription remboursee reservee aux specialistes CSO/CHU/SMR, arretes du 12/06/2026). Cause racine : 6 chunks RAG issus d'articles rediges avant l'arrete. Corriges en base ce run + article source corrige + 4 tickets pour les autres articles concernes. Pas une erreur medicale (pas de danger patient), mais une erreur de parcours qui pouvait envoyer des lecteurs vers une ordonnance non remboursee.
+- Site live : OK (home 200, redirect zepbound→mounjaro 301 en 1 saut, sitemap 200). Fraicheur : GA a jour (01/08), GSC J-3 (29/07, normal, seuil 4 j).
+- Aucune occurrence Zepbound (site + conversations Coach). ✓
+
+---
+
+## A0. MONETISATION (Dossier GLP-1 4,99 EUR)
+
+- **Dossiers** : toujours 5 au total (2 payes/generes, 3 pending). **0 cree sur 24h, 0 paye.** Les 2 checkouts Stripe du 27/07 (sruth83@, JONATHANVIALE1@) n'ont **pas paye** malgre la relance auto J+1 du 28/07.
+  - **Action de ce run** : 2e relance envoyee a chacun (categorie `dossier_relance_2`), angle different — detail du contenu du Dossier (verdict, CSO proches, checklist RDV, reste a charge) + CTA unique. C'etait la decision actee au rapport du 28/07 (« si aucun ne paie d'ici 48h, tester un rappel de contenu »).
+- **Visites funnel (7j)** : /dossier-glp1/ 1-5 sessions/j (15 au total) ; /outils/test-eligibilite/ 1-13 sessions/j (35 au total, pic 27/07 lie a la campagne, retombee a 1-8 ensuite) ; /mon-espace/dossier/ 0. L'exposition reste le premier goulot : le funnel vit surtout des emails, pas encore du SEO.
+- **Contribution Coach (7j)** : 6 propositions du Dossier, 0 `[[DOSSIER_READY]]`, 0 dossier via chat. Occasion manquee reperee (conv `41a3f465`, voir volet B).
+- **Leads test eligibilite** : 1 nouveau — mondon.isabelle.im@ (01/08, IMC 32,4 sans comorbidite, **non eligible**). **Email plan d'action J0 envoye ce run** (contenu honnete : criteres non remplis aujourd'hui, quoi faire, pas de push Dossier). Total leads 7j : 3.
+- **Sequence leads** : **relances J+3 envoyees ce run** aux 2 leads eligibles de la semaine (fanttasia@, chantaljullien63@) — theme unique « avez-vous pris RDV ? comment choisir son CSO ». J+7 (proposition Dossier) prevue vers le 04/08 s'ils n'ont pas achete. Verification STOP faite avant envoi (3 STOP du 27/07 exclus : soraya.vous.m@, inezforbes2@, balbouy@).
+- **Suivi post-achat** : client 1 (KYM.BEAUTE@, paye 22/07, email satisfaction 23/07) — **pas de reponse**. Client 2 (francoise.cardon@, paye 24/07, email satisfaction 27/07) — **pas de reponse**. Rien dans incoming_emails (sync IMAP active, derniers entrants 30/07).
+- **Diagnostic de fuite** : l'etape bloquante reste **checkout → paiement** (2 checkouts, 0 paiement, 2 vagues de relance). Si les relances "contenu" du jour ne convertissent pas d'ici 2-3 runs, le levier suivant est la page landing elle-meme (reassurance paiement / apercu du document) — a chiffrer avant toute modif.
+
+## A. SEO RECOVERY WATCH
+
+- **Recovery GA** : 548 sessions le 31/07 / 922 = **59%**
+- **Recovery GSC** : 53 clics le 29/07 / 106 = **50%** (meilleur niveau depuis la suspension)
+- **Recovery GSC hors cluster /pharmacies/** : 40 clics le 29/07 = **38%** — le cluster pharmacies apporte desormais ~13 clics/j (un quart du total), le thermometre « pages historiques » reste sous les 40%.
+
+| Date | GA sessions | % base (922) | GSC clics | % base (106) | Impressions |
+|---|---|---|---|---|---|
+| 25/07 | 344 | 37% | 33 | 31% | 1 681 |
+| 26/07 | 329 | 36% | 22 | 21% | 1 366 |
+| 27/07 | 505 | 55% | 43 | 41% | 1 931 |
+| 28/07 | 489 | 53% | 57 | 54% | 2 135 |
+| 29/07 | 556 | 60% | 53 | 50% | 1 785 |
+| 30/07 | 493 | 53% | — | — | — |
+| 31/07 | 548 | 59% | — | — | — |
+
+**Tendance** : nette inflexion positive cote GSC (moyenne 51 clics/j sur 27-29/07 vs ~33 la semaine precedente, +55%). GA stable en plateau 53-60%. Si la pente GSC se maintient (~+10 pts/semaine), retour vers 100% possible fin aout/debut septembre — estimation fragile, 3 jours de donnees.
+
+**Top pages 7j vs baseline** : carte-prix-pharmacies 112 clics (26% de sa baseline 438), prix-ozempic 20 (8% de 242), prix-mounjaro 12 (3% de 411), prix-wegovy 3 (1% de 301). Les pages prix historiques restent les grandes blessees — mais voir l'analyse requete en B.1 : ce n'est plus un probleme de position.
+
+**Pages du top baseline toujours absentes du top actuel (liste de soumission GSC manuelle, a coller dans l'inspection d'URL)** :
+1. https://glp1-france.fr/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/ (NOUVEL article du jour — prioritaire)
+2. https://glp1-france.fr/collections/glp1-cout/wegovy-remboursement-mutuelle/ (60 clics baseline → 0)
+3. https://glp1-france.fr/collections/regime-glp1/regime-mounjaro-optimal/ (18 → 1)
+4. https://glp1-france.fr/collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/ (12 → 0)
+5. https://glp1-france.fr/collections/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation/ (9 → 0)
+6. https://glp1-france.fr/guides/suivi-medical-glp1/ (8 → 0)
+7. https://glp1-france.fr/collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/ (8 → 0)
+8. https://glp1-france.fr/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/ (8 → 1)
+
+**Pages Mounjaro (cibles 301 ex-Zepbound)** : prix-mounjaro-france 12 clics / 1 374 impr ; les pages dept prix-mounjaro (75, 13, 57) prennent leurs premiers clics — l'indexation du cluster programmatique progresse.
+
+## B. DECISIONS
+
+1. **Constat** : les 3 pages prix perdent ~50% d'impressions WoW (prix-ozempic -1 947, prix-mounjaro -1 149, prix-wegovy -493). **Analyse requete (obligatoire)** : l'effondrement est concentre sur les requetes transactionnelles — « ozempic achat en ligne » 551→102 impr, « ozempic sans ordonnance » 410→22, « prix ozempic sans ordonnance » 363→171, « mounjaro prix le moins cher » 453→149 — **a positions stables** (8-13 avant comme apres). Pendant ce temps les requetes tete montent : « ozempic prix » 164→547 impr (pos 11,0), « mounjaro prix » 60→111 impr et pos 19,4→**9,2**. **Cause probable** : re-filtrage/reshuffle des SERP Google sur les requetes d'achat de medicaments sur ordonnance (nos pages ne sont plus servies sur ces auctions), plus saisonnalite d'aout — PAS un declassement (les positions tiennent). **Decision** : ne toucher a rien sur ces pages, surveiller 1 semaine ; la strategie reste de gagner sur les requetes informationnelles/prix officiels.
+2. **Constat** : CTR prix-mounjaro-france 0,87% (12/1 374). **Decision** : C1 toujours en attente — les nouveaux seoTitle sont deployes depuis le 27/07 et les donnees GSC (arret au 29/07) ne couvrent que ~2 jours post-deploy, Google n'a probablement pas re-crawle. Reevaluer au run du 03-04/08 avec 4-5 jours de donnees. Ne pas churner les titles.
+3. **Constat** : contamination RAG « le generaliste peut initier » (6 chunks, 5 articles) — source de l'erreur du Coach du 01/08. **Decision** : hotfix DB immediat + correction du fichier source principal + tickets pour le reste (fait, voir C).
+4. **Constat** : cluster pharmacies = ~13 clics/j GSC et premieres pages dept/villes qui cliquent : la condition « l'indexation demarre » du palier 2 est remplie. **Decision** : declencher le palier hubs villes 500→1000 + prix villes 200→500 **au prochain run** (fenetre de veto 24h pour Robin, cout : build plus long + full sync FTP ~40 min).
+5. **Constat** : 2 checkouts non payes malgre relance J+1. **Decision** : 2e relance angle « contenu du Dossier » (decision pre-actee au 28/07) — envoyee ce run.
+
+## B (volet). MONITORING COACH IA (24h)
+
+- **KPIs** : 32 messages (16 user) / 4 conversations / 4 msgs user par conv. Veille : 8 messages (**x4**). 100% LLM (llama-3.3-70b : 11, mistral-small : 5), **0 fallback**.
+- **Intents** : general 14, price 2.
+- **Dossiers via chat** : 0. Propositions Dossier 7j : 6.
+- **Conformite Zepbound : aucune mention.** ✓
+
+**Analyse qualite (4 conversations)** :
+1. Conv `e2d0cb9d` (31/07) — **parcours modele** : IMC 42,7 calcule juste, comorbidites collectees, annuaire ameli donne, **proposition du Dossier au bon moment** (apres verdict + demande CSO). L'utilisateur a repondu « Plus tard » — cloture propre sans insistance. ✓
+2. Conv `41a3f465` (31/07) — IMC 47,8, prediabete : verdict correct, bonne gestion de la frustration (« je veux mon Mounjaro sans attendre 6 mois ») sans contourner la regle des 6 mois. **Mais aucune proposition du Dossier** alors que IMC + comorbidites etaient collectes et que le Coach proposait « t'aider a trouver un CSO » — c'est exactement le declencheur prevu par le prompt (v60). Occasion manquee, a surveiller : si ca se repete, renforcer le declencheur.
+3. Conv `2af63329` (01/08) — **erreur reglementaire** (voir ALERTES) : « ton medecin traitant peut aussi prescrire directement... (sous conditions de remboursement) ». Ce qu'il aurait du dire : primo-prescription remboursee en CSO/CHU/SMR uniquement, le generaliste renouvelle ensuite. Cause racine RAG corrigee ce run (le garde-fou prompt existait deja mais les chunks RAG contredisaient le prompt).
+4. Conv `28a22bb6` (31/07) — question remboursement, reponse correcte (criteres 35+comorbidite / 40). ✓
+
+## C. ACTIONS EXECUTEES
+
+1. **Emails leads (3)** : J0 plan d'action au lead non eligible du 01/08 (mondon.isabelle@ — contenu honnete sans push Dossier) + relances J+3 « avez-vous pris RDV / choisir son CSO » aux 2 leads eligibles (fanttasia@, chantaljullien63@). Via `send-feedback-email`, traces `eligibility_recap` / `eligibility_j3`. Verification STOP faite.
+2. **Relances Dossier 2e vague (2)** : sruth83@ et JONATHANVIALE1@ (checkouts 27/07 non payes) — angle contenu du Dossier, categorie `dossier_relance_2`.
+3. **Hotfix RAG (DB)** : 6 chunks `article_chunks` corriges (ajout du caveat arretes 12/06/2026 : primo-prescription remboursee = CSO/CHU/SMR, generaliste = renouvellement). Effet immediat sur les reponses du Coach.
+4. **Correction factuelle sourcee** de `medecin-generaliste-prescription-wegovy-mounjaro-conditions.md` : encart mise a jour 15/06/2026, FAQ corrigee, conclusion nuancee, sources arretes + ameli ajoutees, updatedAt 01/08. (~15% de l'article, sous le seuil des 30%.)
+5. **4 correction_tickets** (info_outdated, urgent, approved) pour les autres articles contamines : ansm-regles-prescription-glp1-france, glp1-prescription-generaliste-nouvelles-regles-ansm-2026, centres-mounjaro-france, ozempic-ordonnance-prescription-france-2026.
+6. **C5 — Article du plan publie** : « Qui peut prescrire Mounjaro ou Wegovy pour etre rembourse ? (generaliste vs CSO/CHU) » → `/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/`. ~1 100 mots, FAQ schema 5 questions, thumbnail SVG unique, chaque chiffre source (arretes 10-12/06/2026 via Vidal, ameli, Sante.fr pour les 41 CSO, Moniteur des pharmacies pour la regle des 6 mois/-5%). Maillage : 2 liens entrants ajoutes (article generaliste + article telemedecine) et 5 sortants dont 2 funnel (test d'eligibilite, Dossier 4,99 EUR). Item 1 du content-plan coche.
+
+## D. AUDIT DU JOUR — J1 Technique
+
+- **robots.txt** : propre (admin/test/demo bloques, sitemap declare). Finding mineur : `Crawl-delay: 1` est ignore par Google — inutile mais inoffensif, rien a faire.
+- **404** : page inexistante → 404 propre (pas de soft-200). ✓
+- **Chaines de redirects** : bare-path → trailing slash en **1 seul saut** 301 (teste sur 2 URLs). Redirect zepbound → mounjaro : 301 direct. ✓
+- **Canonicals** : self-referencing corrects (testes home + prix-ozempic). ✓
+- **Sitemap** : sitemap-index a jour du deploy du 27/07 ; sera regenere par le deploy de ce run (le nouvel article doit y apparaitre — verifie post-deploy).
+- Aucun probleme bloquant. Pas de ticket necessaire.
+
+## EN ATTENTE DE DECISION ROBIN
+
+- **Palier 2 du SEO programmatique pharmacies** (hubs villes 500→1000, pages prix villes 200→500) : conditions remplies (indexation demarree, ~13 clics/j sur le cluster). **Je le declenche au prochain run sauf veto d'ici la.** Cout : build plus lourd + full sync FTP ~40 min.
+- Rien d'autre — aucune action sensible (suppression, prix, DB schema, refonte) identifiee ce run.

--- a/src/content/medecins-glp1-france/medecin-generaliste-prescription-wegovy-mounjaro-conditions.md
+++ b/src/content/medecins-glp1-france/medecin-generaliste-prescription-wegovy-mounjaro-conditions.md
@@ -1,9 +1,9 @@
 ---
 title: "Médecin Généraliste Prescrire Wegovy Mounjaro : Conditions"
-description: "Médecin généraliste prescrire Wegovy Mounjaro : depuis juin 2025, conditions IMC, formulaire Ameli et critères d'éligibilité en France."
+description: "Le généraliste peut prescrire Wegovy et Mounjaro, mais pas ouvrir le remboursement : primo-prescription en CSO/CHU depuis le 15 juin 2026. Détails."
 pubDate: 2026-03-16
 date: 2026-06-22
-updatedAt: 2026-06-22
+updatedAt: 2026-08-01
 author: "Dr. Marie Dubois"
 category: "Médecins spécialisés"
 tags: ["médecin généraliste", "prescription", "wegovy", "mounjaro", "glp1", "conditions", "imc", "france", "2025"]
@@ -28,7 +28,9 @@ affiliateConfig:
   inlinePositions: [3, 7, 12]
 ---
 
-Depuis juin 2025, tout médecin généraliste en France peut prescrire les traitements GLP-1 pour l'obésité — Wegovy et Mounjaro en tête. Cette évolution majeure des règles de prescription, décidée par l'ANSM, a mis fin à la réservation aux seuls spécialistes qui créait des délais d'attente de plusieurs mois pour les patients. Mais quelles sont exactement les conditions à remplir ? Comment se passe la consultation ? Voici tout ce que vous devez savoir.
+Depuis juin 2025, tout médecin généraliste en France peut prescrire les traitements GLP-1 pour l'obésité — Wegovy et Mounjaro en tête. Cette évolution majeure des règles de prescription, décidée par l'ANSM, a mis fin à la réservation aux seuls spécialistes qui créait des délais d'attente de plusieurs mois pour les patients.
+
+**Mise à jour importante (15 juin 2026)** : depuis l'entrée en vigueur du remboursement à 65 %, une distinction essentielle s'impose. Votre généraliste peut toujours prescrire Wegovy ou Mounjaro, mais **cette ordonnance n'ouvre pas droit au remboursement** : la primo-prescription remboursée est réservée aux médecins spécialistes exerçant en CSO, CHU ou SMR spécialisé (arrêtés du 12 juin 2026). Le généraliste assure ensuite les renouvellements. Tous les détails dans notre guide [qui peut prescrire pour être remboursé](/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/).
 
 ## Ce qui a changé en juin 2025
 
@@ -174,7 +176,7 @@ Consultez notre [guide complet du remboursement GLP-1 2026](/collections/glp1-co
 ## Questions fréquentes
 
 **Mon médecin traitant peut-il vraiment me prescrire Wegovy ou Mounjaro ?**
-Oui, depuis juin 2025. Il n'est plus nécessaire de consulter un spécialiste pour la première prescription. Votre médecin traitant est pleinement habilité à initier et renouveler ces traitements.
+Oui, il peut rédiger l'ordonnance depuis juin 2025 — mais attention : depuis le 15 juin 2026, cette prescription du généraliste n'est **pas remboursée**. Pour bénéficier du remboursement à 65 %, la première prescription doit être faite par un spécialiste en CSO, CHU ou SMR spécialisé ; votre médecin traitant prend ensuite le relais pour les renouvellements.
 
 **Faut-il plusieurs consultations avant d'obtenir la prescription ?**
 Souvent oui. Une première consultation pour l'évaluation et la prescription du bilan biologique, puis une deuxième pour la prescription du traitement après réception des résultats. Certains médecins qui ont déjà accès à votre dossier médical (bilan récent, suivi régulier) peuvent prescrire en une seule consultation.
@@ -193,10 +195,10 @@ La formation des médecins généralistes sur les GLP-1 a considérablement prog
 
 ## Conclusion
 
-L'ouverture de la prescription des GLP-1 aux médecins généralistes est une avancée majeure pour les patients français. Elle rapproche les soins, réduit les inégalités d'accès et permet une prise en charge plus rapide de l'obésité. Votre médecin traitant est aujourd'hui votre premier interlocuteur pour accéder à ces traitements efficaces.
+L'ouverture de la prescription des GLP-1 aux médecins généralistes est une avancée majeure pour les patients français. Elle rapproche les soins et réduit les inégalités d'accès. Mais depuis le 15 juin 2026, le parcours remboursé passe d'abord par un spécialiste en CSO ou CHU pour la primo-prescription : votre médecin traitant reste votre premier interlocuteur pour évaluer votre situation, vous orienter vers le bon centre, puis renouveler le traitement.
 
 Préparez votre consultation, apportez vos antécédents médicaux, et discutez ouvertement de vos objectifs avec votre médecin. C'est la meilleure façon de débuter un traitement qui vous convient vraiment.
 
 ---
 
-*Sources : ANSM - Évolution des conditions de prescription des analogues du GLP-1 (juin 2025), HAS - Avis de remboursement Wegovy (décembre 2024), Ameli.fr. Cet article est fourni à titre informatif et ne remplace pas un avis médical personnalisé. Consultez votre médecin avant de commencer tout traitement.*
+*Sources : ANSM - Évolution des conditions de prescription des analogues du GLP-1 (juin 2025), arrêtés du 12 juin 2026 (conditions de remboursement, [détail Vidal](https://www.vidal.fr/actualites/37934-obesite-le-cadre-de-prescription-de-wegovy-et-mounjaro-precise-pour-le-remboursement.html)), [Ameli.fr](https://www.ameli.fr/assure/actualites/obesite-de-nouveaux-medicaments-peuvent-etre-pris-en-charge-dans-des-conditions-encadrees). Cet article est fourni à titre informatif et ne remplace pas un avis médical personnalisé. Consultez votre médecin avant de commencer tout traitement.*

--- a/src/content/medecins-glp1-france/prescription-glp1-telemedecine-en-ligne-france.md
+++ b/src/content/medecins-glp1-france/prescription-glp1-telemedecine-en-ligne-france.md
@@ -104,7 +104,7 @@ Les tarifs varient selon les plateformes :
 
 ### Le coût du médicament reste inchangé
 
-La téléconsultation ne change rien au prix du médicament lui-même, qui dépend de la pharmacie et de votre couverture santé. En 2026, [Wegovy coûte entre 147 et 350 €/mois](/collections/glp1-cout/prix-wegovy-france/) selon le dosage, et Mounjaro entre 176 et 433 €/mois. Depuis le 15 juin 2026, Wegovy et Mounjaro sont remboursés à 65 % par l'Assurance Maladie pour le traitement de l'obésité, sous conditions : IMC ≥ 35 avec comorbidité ou IMC ≥ 40, après échec documenté d'une prise en charge nutritionnelle, avec une primo-prescription réservée aux CSO, CHU ou services spécialisés. Le renouvellement peut être assuré par votre médecin traitant.
+La téléconsultation ne change rien au prix du médicament lui-même, qui dépend de la pharmacie et de votre couverture santé. En 2026, [Wegovy coûte entre 147 et 350 €/mois](/collections/glp1-cout/prix-wegovy-france/) selon le dosage, et Mounjaro entre 176 et 433 €/mois. Depuis le 15 juin 2026, Wegovy et Mounjaro sont remboursés à 65 % par l'Assurance Maladie pour le traitement de l'obésité, sous conditions : IMC ≥ 35 avec comorbidité ou IMC ≥ 40, après échec documenté d'une prise en charge nutritionnelle, avec une primo-prescription réservée aux CSO, CHU ou services spécialisés. Le renouvellement peut être assuré par votre médecin traitant — une téléconsultation ne peut donc pas ouvrir le droit au remboursement en initiation. Le détail complet dans notre guide [qui peut prescrire Mounjaro ou Wegovy pour être remboursé](/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/).
 
 ## Comment choisir une plateforme sérieuse ?
 

--- a/src/content/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse.md
+++ b/src/content/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse.md
@@ -1,0 +1,98 @@
+---
+title: "Qui peut prescrire Mounjaro ou Wegovy pour être remboursé ? (généraliste vs CSO/CHU)"
+seoTitle: "Qui peut prescrire Mounjaro ou Wegovy remboursé ? CSO, CHU"
+description: "Primo-prescription remboursée : spécialistes en CSO, CHU ou SMR uniquement. Rôle exact du généraliste, que faire s'il a prescrit, trouver son centre."
+seoDescription: "Primo-prescription remboursée : spécialistes en CSO, CHU ou SMR uniquement. Rôle exact du généraliste, que faire s'il a prescrit, trouver son centre."
+pubDate: 2026-08-01
+updatedAt: 2026-08-01
+author: "Rédaction GLP-1 France"
+category: "Médecins spécialisés"
+tags: ["primo-prescription", "CSO", "CHU", "mounjaro", "wegovy", "remboursement", "médecin généraliste", "obésité"]
+collection: "medecins-glp1-france"
+thumbnail: "/images/thumbnails/qui-peut-prescrire-mounjaro-wegovy-rembourse.svg"
+thumbnailAlt: "Qui peut prescrire Mounjaro ou Wegovy pour être remboursé - généraliste vs CSO CHU"
+featured: true
+published: true
+schema: "Article"
+faqSchema:
+  - question: "Mon médecin généraliste peut-il me prescrire Mounjaro ou Wegovy remboursé ?"
+    answer: "Non pour la première prescription : depuis le 15 juin 2026, la primo-prescription ouvrant droit au remboursement à 65 % est réservée aux médecins spécialistes exerçant en CSO, CHU ou SMR spécialisé. Votre généraliste peut en revanche renouveler le traitement une fois cette première prescription faite, et il peut toujours prescrire hors remboursement."
+  - question: "Quels médecins peuvent faire la primo-prescription remboursée de Wegovy ou Mounjaro ?"
+    answer: "Les arrêtés du 12 juin 2026 la réservent aux spécialistes en endocrinologie-diabétologie-nutrition, aux médecins compétents en nutrition et aux chirurgiens bariatriques, exerçant dans un Centre spécialisé de l'obésité (CSO), un CHU ou une structure SMR spécialisée. S'y ajoutent les médecins coordinateurs du parcours « Obésité complexe » et les endocrinologues liés par convention à un CSO."
+  - question: "Que faire si mon généraliste m'a déjà prescrit Wegovy ou Mounjaro ?"
+    answer: "L'ordonnance est valable pour acheter le traitement, mais elle n'ouvre pas le remboursement : la pharmacie le délivrera à plein tarif. Pour être remboursé, il faut obtenir une primo-prescription auprès d'un spécialiste en CSO, CHU ou SMR, puis votre généraliste pourra renouveler."
+  - question: "Comment trouver un CSO ou un CHU pour la primo-prescription ?"
+    answer: "Il existe une quarantaine de Centres spécialisés de l'obésité en France (41 recensés en 2025), adossés à des établissements hospitaliers. Le plus simple : demander à votre médecin traitant un courrier d'adressage vers le CSO de votre région, ou chercher un spécialiste en endocrinologie-diabétologie-nutrition sur l'annuaire officiel annuaire-sante.ameli.fr. Appelez plusieurs centres, les délais varient de quelques semaines à plusieurs mois."
+  - question: "Faut-il vraiment 6 mois de suivi nutritionnel avant la prescription remboursée ?"
+    answer: "Oui. Le remboursement exige l'échec d'une prise en charge nutritionnelle bien conduite et documentée d'au moins 6 mois (perte de poids inférieure à 5 %), associée à un régime hypocalorique et à une activité physique. Commencez ce suivi avec votre médecin traitant ou un diététicien dès maintenant si ce n'est pas fait : ce délai court pendant que vous attendez votre rendez-vous spécialisé."
+mainKeyword: "qui peut prescrire mounjaro wegovy remboursé"
+secondaryKeywords: ["primo-prescription mounjaro", "primo-prescription wegovy", "médecin prescripteur habilité glp1", "cso obésité prescription", "généraliste wegovy remboursement"]
+---
+
+**Réponse courte : depuis le 15 juin 2026, seule une primo-prescription faite par un médecin spécialiste exerçant en CSO, CHU ou SMR spécialisé ouvre droit au remboursement à 65 % de Wegovy et Mounjaro. Votre médecin généraliste ne peut pas initier le traitement remboursé — mais il peut le renouveler ensuite, et son rôle reste central dans le parcours.** Voici qui peut prescrire quoi, et comment obtenir le bon rendez-vous.
+
+## La règle depuis le 15 juin 2026 : deux circuits bien distincts
+
+Le remboursement de Wegovy (sémaglutide) et Mounjaro (tirzépatide) dans l'obésité, effectif depuis le [15 juin 2026](https://www.vidal.fr/actualites/37850-obesite-prise-en-charge-de-wegovy-et-mounjaro-a-partir-du-15-juin-2026-sous-conditions.html), a créé deux circuits de prescription qui coexistent :
+
+- **Le circuit remboursé** : primo-prescription obligatoirement faite par un spécialiste habilité dans une structure de recours (CSO, CHU, SMR), puis renouvellements possibles par le médecin traitant. Prise en charge à 65 % par l'Assurance Maladie.
+- **Le circuit non remboursé** : tout médecin, y compris votre généraliste, peut prescrire Wegovy ou Mounjaro depuis juin 2025 (décision ANSM). L'ordonnance est valable en pharmacie, mais le traitement reste alors entièrement à votre charge — de 146,91 € à 433,80 € par mois selon le médicament et le dosage ([prix officiels](/collections/glp1-cout/prix-mounjaro-france/)).
+
+C'est cette distinction qui explique un malentendu fréquent : « mon médecin m'a prescrit Wegovy, mais la pharmacie refuse de me le passer en remboursé ». L'ordonnance du généraliste n'est pas fausse — elle n'ouvre simplement pas le droit au remboursement en initiation.
+
+## Qui peut faire la primo-prescription remboursée ?
+
+Les [arrêtés du 12 juin 2026](https://www.vidal.fr/actualites/37934-obesite-le-cadre-de-prescription-de-wegovy-et-mounjaro-precise-pour-le-remboursement.html) réservent la prescription initiale remboursée à trois profils de médecins :
+
+- **spécialistes en endocrinologie-diabétologie-nutrition** ;
+- **médecins compétents en nutrition** (DESC, FST ou VAE en nutrition) ;
+- **chirurgiens bariatriques** titulaires du diplôme de chirurgie de l'obésité.
+
+Et à condition qu'ils exercent dans l'une de ces structures :
+
+- un **Centre spécialisé de l'obésité (CSO)** — il en existe une quarantaine en France ([41 recensés en 2025](https://www.sante.fr/les-centres-specialises-obesite-cso)), adossés à des établissements hospitaliers ;
+- un **CHU** ;
+- une **structure SMR** (soins médicaux et de réadaptation) mention gastro-entérologie, endocrinologie, diabétologie, nutrition.
+
+Deux cas particuliers complètent la liste : les **médecins coordinateurs du parcours coordonné renforcé « Obésité complexe »**, et les **endocrinologues de ville liés à un CSO** par une charte ou une activité partielle dans le centre. Autrement dit, certains endocrinologues libéraux peuvent initier le traitement remboursé — demandez-leur explicitement s'ils sont conventionnés avec un CSO avant de prendre rendez-vous.
+
+## Le rôle exact de votre médecin généraliste
+
+Écarté de la primo-prescription, le généraliste reste pourtant le pivot du parcours :
+
+1. **Avant la prescription** : c'est lui qui documente la prise en charge nutritionnelle d'au moins 6 mois exigée pour le remboursement (suivi du poids, régime hypocalorique, activité physique). Sans ce dossier, le spécialiste ne pourra pas prescrire en remboursé.
+2. **L'adressage** : un courrier de votre médecin traitant vers le CSO ou le service spécialisé accélère l'obtention du rendez-vous et évite les dossiers incomplets.
+3. **Après la primo-prescription** : il **renouvelle** les ordonnances et assure le suivi mensuel (tolérance digestive, poids, adaptation du mode de vie), sans que vous ayez à retourner au CSO à chaque boîte.
+
+Notre guide sur la [prescription par le médecin généraliste](/collections/medecins-glp1-france/medecin-generaliste-prescription-wegovy-mounjaro-conditions/) détaille ce que votre médecin traitant peut et ne peut pas faire.
+
+## Mon généraliste m'a prescrit Wegovy ou Mounjaro : que faire ?
+
+Si vous avez déjà une ordonnance de votre généraliste, trois options :
+
+- **Vous visez le remboursement** : gardez l'ordonnance pour plus tard et demandez à votre médecin un courrier d'adressage vers un CSO, CHU ou SMR. La pharmacie ne peut pas appliquer le remboursement sur une initiation hors circuit — ce n'est pas un refus arbitraire, c'est la règle de prise en charge.
+- **Vous êtes prêt à payer plein tarif** : l'ordonnance est utilisable telle quelle. Vérifiez d'abord si vous remplissez [les critères d'éligibilité au remboursement](/outils/test-eligibilite/) — payer 176 à 434 € par mois alors qu'un parcours remboursé est possible serait dommage.
+- **Vous êtes déjà sous traitement non remboursé** : parlez-en au spécialiste lors du rendez-vous ; la bascule vers le circuit remboursé passe par une primo-prescription en bonne et due forme, avec les mêmes critères (IMC ≥ 40, ou ≥ 35 avec comorbidité, après 6 mois de prise en charge nutritionnelle).
+
+## Comment obtenir le rendez-vous en CSO ou CHU (mode d'emploi)
+
+1. **Vérifiez votre éligibilité** : IMC ≥ 40 kg/m², ou IMC ≥ 35 kg/m² avec au moins une comorbidité liée au poids (diabète de type 2, hypertension, apnée du sommeil, dyslipidémie...). Notre [test d'éligibilité gratuit](/outils/test-eligibilite/) vous donne un verdict en 2 minutes.
+2. **Documentez vos 6 mois de suivi nutritionnel** avec votre médecin traitant ou un diététicien — c'est la condition la plus souvent manquante, et le délai court pendant l'attente du rendez-vous.
+3. **Trouvez le bon interlocuteur** : cherchez « endocrinologie-diabétologie-nutrition » sur [annuaire-sante.ameli.fr](https://annuaire-sante.ameli.fr/), ou demandez le CSO de rattachement de votre département à votre médecin.
+4. **Appelez plusieurs centres** : les délais varient de quelques semaines à plusieurs mois selon les régions. Prenez le premier créneau et restez sur liste d'attente ailleurs.
+5. **Préparez le rendez-vous** : comptes rendus (bilan biologique, apnée du sommeil), courbe de poids, liste de vos tentatives passées. Notre [checklist des questions à poser au médecin](/collections/medecins-glp1-france/questions-medecin-avant-glp1-checklist/) vous aide à ne rien oublier.
+
+Pour arriver au rendez-vous avec un dossier complet — verdict d'éligibilité détaillé, centres spécialisés les plus proches de chez vous, checklist personnalisée et estimation de votre reste à charge — le [Dossier GLP-1 Personnalisé](/dossier-glp1/) (4,99 €) rassemble tout en un document prêt à imprimer pour votre médecin.
+
+## En résumé
+
+| Situation | Qui prescrit ? | Remboursé ? |
+|---|---|---|
+| Première prescription (initiation) | Spécialiste en CSO, CHU ou SMR | Oui, 65 % |
+| Renouvellements | Médecin traitant (généraliste) | Oui, 65 % |
+| Prescription initiale par le généraliste | Tout médecin (depuis juin 2025) | Non |
+| Endocrinologue de ville conventionné CSO | Primo-prescription possible | Oui, 65 % |
+
+---
+
+*Sources : arrêtés des 10 et 12 juin 2026 publiés au Journal officiel — synthèses [Vidal (prise en charge)](https://www.vidal.fr/actualites/37850-obesite-prise-en-charge-de-wegovy-et-mounjaro-a-partir-du-15-juin-2026-sous-conditions.html) et [Vidal (prescripteurs)](https://www.vidal.fr/actualites/37934-obesite-le-cadre-de-prescription-de-wegovy-et-mounjaro-precise-pour-le-remboursement.html) ; [Assurance Maladie](https://www.ameli.fr/assure/actualites/obesite-de-nouveaux-medicaments-peuvent-etre-pris-en-charge-dans-des-conditions-encadrees) ; [Le Moniteur des pharmacies](https://www.lemoniteurdespharmacies.fr/therapeutique/medicaments/mieux-delivrer/obesite-les-conditions-de-prescription-de-wegovy-et-mounjaro-revues-avant-leur-remboursement). Cet article est fourni à titre informatif et ne remplace pas un avis médical personnalisé.*


### PR DESCRIPTION
## Résumé

Run quotidien de la routine (01/08/2026) :

- **Nouvel article (content-plan #1)** : `qui-peut-prescrire-mounjaro-wegovy-rembourse` (collection medecins-glp1-france) — primo-prescription remboursée CSO/CHU/SMR vs rôle du généraliste. Chaque chiffre sourcé (arrêtés des 10-12/06/2026 via Vidal, ameli.fr, Santé.fr, Moniteur des pharmacies). FAQ schema 5 questions, thumbnail SVG unique, 2 liens entrants + 5 sortants (dont test d'éligibilité et Dossier 4,99 €).
- **Correction factuelle sourcée** de `medecin-generaliste-prescription-wegovy-mounjaro-conditions.md` : depuis le 15/06/2026 la prescription du généraliste n'ouvre pas le remboursement (encart mise à jour + FAQ + conclusion + sources).
- **Lien entrant** ajouté dans l'article télémédecine.
- **Rapport quotidien** `reports/daily-2026-08-01.md` (recovery GSC 50 %, analyse requêtes des pages prix, monitoring Coach, actions emails).
- content-plan.md : item 1 coché et déplacé en « Publiés ».

Hors diff (déjà appliqué en DB ce run) : hotfix de 6 chunks RAG obsolètes + 4 correction_tickets.

## Validation

- Build Astro local en cours de validation avant merge (merge seulement après build vert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBaCESsuN1S45Px1xi3g7j

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBaCESsuN1S45Px1xi3g7j)_