### PR TITLE
feat: article "pharmacie refuse Mounjaro/Wegovy" + fact-check + daily report 01/08 run 2

### DIFF
--- a/content-plan.md
+++ b/content-plan.md
@@ -21,7 +21,6 @@ Ce fichier est la **source de vérité** de la création de contenu. La routine 
 
 ### P1 — Parcours de soins (l'intention exacte de nos 2 premiers clients payants)
 
-- [ ] **2. La pharmacie refuse de délivrer Mounjaro/Wegovy : pourquoi et que faire** — collection `traitements-glp1`. Preuve : pain point client n°2 ; requêtes "pharmacie refuse" à vérifier par WebSearch au moment de la rédaction. Angle : les 4 causes réelles de refus (primo-prescription non conforme, accord préalable, rupture, ordonnance non sécurisée) + parcours de déblocage étape par étape. Suivi : —
 
 ### P2 — Quick wins sur demande GSC mesurée
 
@@ -48,4 +47,5 @@ _(vide — la routine ajoute ici : sujet, requête cible, preuve de demande chif
 
 ## Publiés
 
+- [x] **2. La pharmacie refuse de délivrer Mounjaro/Wegovy : pourquoi et que faire** — publié le 01/08/2026 (run 2) → https://glp1-france.fr/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/ — sources : Vidal 37850, ameli espace pharmacien (dispositif d'aide à la prescription AGLP-1), FSPF circulaire 2026-30, ANSM disponibilité. Angle ajusté vs plan : les 4 causes documentées sont formulaire ITR manquant, prescripteur non habilité, critères non remplis, rupture (l'« accord préalable » et l'« ordonnance non sécurisée » du plan n'ont pas de source officielle pour Wegovy/Mounjaro — non retenus). Preuve GSC : « formulaire remboursement mounjaro » pos 7,7 ; « ou trouver le mounjaro le moins cher » 173 imp/28j. Maillage entrant : article qui-peut-prescrire + article pénurie. Suivi : imp J+7 (~08/08) : — ; imp J+30 (~31/08) : —
 - [x] **1. Qui peut prescrire Mounjaro ou Wegovy pour être remboursé ? (généraliste vs CSO/CHU)** — publié le 01/08/2026 → https://glp1-france.fr/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/ — sources : arrêtés des 10-12/06/2026 (Vidal 37850/37934), ameli.fr, Santé.fr (41 CSO), Moniteur des pharmacies (règle 6 mois / -5 %). Maillage entrant : article généraliste + article télémédecine. Suivi : imp J+7 (~08/08) : — ; imp J+30 (~31/08) : —

--- a/public/images/thumbnails/pharmacie-refuse-delivrer-mounjaro-wegovy.svg
+++ b/public/images/thumbnails/pharmacie-refuse-delivrer-mounjaro-wegovy.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1a3c34"/>
+      <stop offset="1" stop-color="#0f2620"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="1100" cy="110" r="180" fill="#16a34a" opacity="0.10"/>
+  <circle cx="120" cy="540" r="160" fill="#16a34a" opacity="0.12"/>
+  <text x="80" y="150" font-family="Georgia, serif" font-size="34" fill="#16a34a" font-weight="bold">GLP-1 FRANCE</text>
+  <text x="80" y="280" font-family="Georgia, serif" font-size="66" fill="#ffffff" font-weight="bold">La pharmacie refuse</text>
+  <text x="80" y="370" font-family="Georgia, serif" font-size="66" fill="#ffffff" font-weight="bold">Mounjaro ou Wegovy ?</text>
+  <rect x="80" y="410" width="120" height="6" fill="#16a34a"/>
+  <text x="80" y="500" font-family="Georgia, serif" font-size="40" fill="#9fd7b4">4 causes réelles, 4 solutions — règle 2026</text>
+  <g transform="translate(1010,300)">
+    <rect x="-70" y="-90" width="140" height="180" rx="16" fill="#ffffff" opacity="0.92"/>
+    <rect x="-14" y="-64" width="28" height="76" rx="6" fill="#16a34a"/>
+    <rect x="-38" y="-40" width="76" height="28" rx="6" fill="#16a34a"/>
+    <circle cx="0" cy="52" r="26" fill="none" stroke="#1a3c34" stroke-width="7" opacity="0.7"/>
+    <line x1="-15" y1="67" x2="15" y2="37" stroke="#1a3c34" stroke-width="7" opacity="0.7" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/reports/daily-2026-08-01-run2.md
+++ b/reports/daily-2026-08-01-run2.md
@@ -1,0 +1,41 @@
+# Rapport quotidien — 2026-08-01 — RUN 2 (après-midi)
+
+Complète le rapport du matin (`daily-2026-08-01.md`). Seuls les faits NOUVEAUX depuis le run 1 (~12h23) sont détaillés ici.
+
+## ALERTES
+
+- Aucune nouvelle alerte. Site live OK (home 200, redirect zepbound→mounjaro 301, sitemap 200). Fraîcheur : GA à jour (01/08), GSC J-3 (29/07, sous le seuil de 4 j). Aucune occurrence Zepbound.
+
+## A0. MONETISATION — 3e VENTE DU DOSSIER ✦
+
+- **3e Dossier payé** : mazzella.marion@gmail.com, dossier créé le 01/08 à 12:57 Paris et **payé 37 secondes après création**, PDF généré immédiatement (`generated`, pdf_url OK). PushNotification envoyée à Robin.
+  - **Nouveau client spontané** : PAS un des 2 checkouts relancés du 27/07 (sruth83@, JONATHANVIALE1@ — toujours pending), pas via chat (conversation_id null). Le run 1 de ce matin n'avait pas ce paiement (postérieur au rapport).
+  - Parcours ultra-court création→paiement = le formulaire et le checkout ne sont pas le problème une fois l'intention là ; la fuite reste l'EXPOSITION de la landing (1-5 sessions/j).
+  - **Suivi post-achat** : email satisfaction à programmer J+2/J+3 → **run du 03-04/08** (catégorie `dossier_satisfaction`).
+- Totaux dossiers : 6 (3 payés/générés, 3 pending). Conversion 7j : 3 checkouts → 1 payé.
+- Clients 1 et 2 : toujours pas de réponse aux emails de satisfaction (incoming_emails vérifiée ce run).
+- Leads test éligibilité : 0 nouveau depuis le run 1 (total 24h : 1, déjà traité ce matin).
+
+## B. MONITORING COACH IA (24h, delta run 1)
+
+- 20 messages / 3 conversations sur 24h glissantes — pas de nouvelle conversation depuis le run 1 (les 3 conv. `e2d0cb9d`, `41a3f465`→`28a22bb6`, `2af63329` déjà analysées ce matin). 100 % LLM, 0 fallback, 0 mention Zepbound.
+- L'erreur réglementaire de la conv `2af63329` (généraliste primo-prescripteur) a été corrigée à la source (RAG) au run 1 — pas de récidive observée depuis.
+
+## C. ACTIONS EXECUTEES (run 2)
+
+1. **C5 — Article du plan publié (item 2, P1)** : « La pharmacie refuse de délivrer Mounjaro ou Wegovy : pourquoi et que faire » → `/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/`. ~1 200 mots, FAQ schema 5 questions, thumbnail SVG unique, tableau récapitulatif. Chaque affirmation sourcée : Vidal 37850 (conditions 15/06/2026), ameli espace pharmacien (dispositif d'aide à la prescription AGLP-1), FSPF circulaire 2026-30 (formulaire conditionnant le remboursement), LEO Officine (règle « sans ITR = pas de remboursement », 3 scénarios de délivrance), ANSM (disponibilité). Angle ajusté vs plan : « accord préalable » et « ordonnance non sécurisée » non sourcés pour Wegovy/Mounjaro → remplacés par les 4 causes documentées (formulaire ITR manquant, prescripteur non habilité, critères non remplis, rupture). Maillage : 7 liens sortants dont 2 funnel (test éligibilité + Dossier 4,99 €) ; 2 liens entrants ajoutés (article qui-peut-prescrire du run 1 + article pénurie) dans le même commit. 1 URL ajoutée à la file GSC (`reports/gsc-submission-queue.md`).
+2. **C6 — Fact-check rotatif (2 articles les plus anciens par last_fact_checked)** :
+   - `baisse-prix-ozempic-wegovy-2027-france` (jamais fact-checké) : **OK, aucune correction**. Vérifié via WebSearch : prix direct-consommateur Novo 349 $ (confirmé), prix catalogue 675 $ au 01/01/2027 = -50 % Wegovy / -35 % Ozempic (CBS News, HCPLive), prix FR officiels conformes (77,60 € / 146,91-195,10 € / 176,10-433,80 €), brevets sémaglutide 2031-2032. `last_fact_checked` mis à jour.
+   - `regime-paleo-glp1` (10/06) : **OK, aucune correction**. Contenu nutritionnel générique, aucun chiffre réglementaire/prix à vérifier. Note : `draft: true` (article non publié) et byline « Dr. Sophie Dubois » fictive — même sujet que le point ouvert E-E-A-T du 14/07, à traiter globalement, pas article par article. `last_fact_checked` mis à jour.
+3. **PushNotification à Robin** : 3e vente Dossier (événement conversion, matrice d'autonomie).
+
+## D. AUDIT / DECISIONS (run 2)
+
+- Pas de nouvel audit rotatif (J1 Technique déjà fait au run 1 du jour). Prochaine dimension : J2 On-page au run du 02/08.
+- **Palier 2 pharmacies (hubs 500→1000, prix villes 200→500)** : annoncé « au prochain run sauf veto » au run 1 (~12h30). Ce run 2 arrive ~4h après : fenêtre de veto trop courte pour valoir consentement — **déclenchement reporté au run du 02/08** pour laisser les 24h pleines à Robin.
+- Décision éditoriale consignée : item 2 du plan publié avec angle corrigé (causes non sourcées écartées) — conforme à la règle « chaque affirmation sourcée ou supprimée ».
+
+## EN ATTENTE DE DECISION ROBIN
+
+- **Palier 2 SEO programmatique pharmacies** : sera déclenché au run du 02/08 sauf veto d'ici là (voir rapport du matin, section EN ATTENTE).
+- Rien d'autre.

--- a/reports/gsc-submission-queue.md
+++ b/reports/gsc-submission-queue.md
@@ -6,6 +6,7 @@ La routine AJOUTE ici a chaque publication — elle ne relance jamais dans le ch
 ## En attente de soumission
 
 - [ ] https://glp1-france.fr/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/ (article 01/08, prioritaire)
+- [ ] https://glp1-france.fr/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/ (article 01/08 run 2, prioritaire)
 - [ ] https://glp1-france.fr/collections/glp1-cout/wegovy-remboursement-mutuelle/ (60 clics baseline → 0)
 - [ ] https://glp1-france.fr/collections/regime-glp1/regime-mounjaro-optimal/
 - [ ] https://glp1-france.fr/collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/

--- a/src/content/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse.md
+++ b/src/content/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse.md
@@ -38,7 +38,7 @@ Le remboursement de Wegovy (sémaglutide) et Mounjaro (tirzépatide) dans l'obé
 - **Le circuit remboursé** : primo-prescription obligatoirement faite par un spécialiste habilité dans une structure de recours (CSO, CHU, SMR), puis renouvellements possibles par le médecin traitant. Prise en charge à 65 % par l'Assurance Maladie.
 - **Le circuit non remboursé** : tout médecin, y compris votre généraliste, peut prescrire Wegovy ou Mounjaro depuis juin 2025 (décision ANSM). L'ordonnance est valable en pharmacie, mais le traitement reste alors entièrement à votre charge — de 146,91 € à 433,80 € par mois selon le médicament et le dosage ([prix officiels](/collections/glp1-cout/prix-mounjaro-france/)).
 
-C'est cette distinction qui explique un malentendu fréquent : « mon médecin m'a prescrit Wegovy, mais la pharmacie refuse de me le passer en remboursé ». L'ordonnance du généraliste n'est pas fausse — elle n'ouvre simplement pas le droit au remboursement en initiation.
+C'est cette distinction qui explique un malentendu fréquent : « mon médecin m'a prescrit Wegovy, mais la pharmacie refuse de me le passer en remboursé ». L'ordonnance du généraliste n'est pas fausse — elle n'ouvre simplement pas le droit au remboursement en initiation. Toutes les causes de blocage au comptoir (formulaire manquant, prescripteur, critères, rupture) sont détaillées dans notre guide [la pharmacie refuse de délivrer Mounjaro ou Wegovy : que faire](/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/).
 
 ## Qui peut faire la primo-prescription remboursée ?
 

--- a/src/content/traitements-glp1/penurie-ozempic-wegovy-mounjaro-rupture-stock-france-alternatives.md
+++ b/src/content/traitements-glp1/penurie-ozempic-wegovy-mounjaro-rupture-stock-france-alternatives.md
@@ -50,7 +50,7 @@ Plusieurs facteurs ont alimenté les tensions pendant la crise :
 
 ## Ma pharmacie n'a plus de stock — que faire maintenant ?
 
-La pénurie nationale est résolue, mais votre pharmacie de quartier peut ponctuellement être en rupture de stock sur un dosage spécifique. La première chose à faire : consulter notre **[carte des pharmacies avec GLP-1 disponible](/outils/carte-prix-pharmacies/)**, mise à jour régulièrement, qui localise les officines ayant signalé du stock dans votre région. Changer de pharmacie — y compris une pharmacie hospitalière ou une grande pharmacie de centre commercial — suffit souvent à résoudre le problème en 24-48h.
+La pénurie nationale est résolue, mais votre pharmacie de quartier peut ponctuellement être en rupture de stock sur un dosage spécifique. Attention aussi à ne pas confondre rupture et refus administratif : depuis le remboursement du 15 juin 2026, un refus au comptoir vient le plus souvent d'un document manquant — notre guide [la pharmacie refuse de délivrer Mounjaro ou Wegovy : pourquoi et que faire](/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/) distingue les deux cas. La première chose à faire en cas de vraie rupture : consulter notre **[carte des pharmacies avec GLP-1 disponible](/outils/carte-prix-pharmacies/)**, mise à jour régulièrement, qui localise les officines ayant signalé du stock dans votre région. Changer de pharmacie — y compris une pharmacie hospitalière ou une grande pharmacie de centre commercial — suffit souvent à résoudre le problème en 24-48h.
 
 ## Les bons réflexes si votre pharmacie est en rupture
 

--- a/src/content/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire.md
+++ b/src/content/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire.md
@@ -1,0 +1,91 @@
+---
+title: "La pharmacie refuse de délivrer Mounjaro ou Wegovy : pourquoi et que faire"
+seoTitle: "Pharmacie refuse Mounjaro ou Wegovy : 4 causes et solutions"
+description: "Formulaire manquant, prescripteur non habilité, critères, rupture : les 4 vraies raisons d'un refus en pharmacie et le parcours de déblocage étape par étape."
+seoDescription: "Formulaire manquant, prescripteur non habilité, critères, rupture : les 4 vraies raisons d'un refus en pharmacie et le parcours de déblocage étape par étape."
+pubDate: 2026-08-01
+updatedAt: 2026-08-01
+author: "Rédaction GLP-1 France"
+category: "Traitements"
+tags: ["mounjaro", "wegovy", "pharmacie", "délivrance", "remboursement", "formulaire ITR", "rupture de stock", "ordonnance"]
+collection: "traitements-glp1"
+thumbnail: "/images/thumbnails/pharmacie-refuse-delivrer-mounjaro-wegovy.svg"
+thumbnailAlt: "Pharmacie qui refuse de délivrer Mounjaro ou Wegovy - causes et solutions"
+featured: true
+published: true
+schema: "Article"
+faqSchema:
+  - question: "Pourquoi ma pharmacie refuse-t-elle de me délivrer Mounjaro ou Wegovy en remboursé ?"
+    answer: "Dans la grande majorité des cas, il manque l'un des deux documents exigés depuis le 15 juin 2026 : l'ordonnance ET le formulaire du dispositif d'aide à la prescription (attestation que la prescription respecte les conditions de remboursement). Sans ce formulaire, le pharmacien n'a pas le droit de facturer le traitement en remboursé — il peut seulement le délivrer à plein tarif."
+  - question: "Qu'est-ce que le formulaire exigé en pharmacie pour Wegovy ou Mounjaro ?"
+    answer: "Depuis le 15 juin 2026, Wegovy et Mounjaro sont intégrés au dispositif d'aide à la prescription des AGLP-1 de l'Assurance Maladie : le médecin remplit un formulaire attestant que le patient remplit les conditions de remboursement (indication, IMC, parcours de soins) et le remet au patient avec l'ordonnance. C'est ce document que le pharmacien doit vérifier avant de facturer en remboursé."
+  - question: "La pharmacie peut-elle me vendre Wegovy ou Mounjaro sans le formulaire ?"
+    answer: "Oui, si l'ordonnance est valable : le pharmacien peut délivrer le médicament, mais en non remboursé, c'est-à-dire à plein tarif (146,91 à 195,10 € par mois pour Wegovy, 176,10 à 433,80 € pour Mounjaro selon le dosage). Si vous visez le remboursement à 65 %, mieux vaut retourner vers le prescripteur pour obtenir le formulaire plutôt que de payer plein pot."
+  - question: "Mon généraliste m'a prescrit Mounjaro, pourquoi le remboursement est-il refusé ?"
+    answer: "Parce que la première prescription remboursée est réservée aux médecins spécialistes exerçant en CSO, CHU ou SMR spécialisé (arrêtés du 12 juin 2026). L'ordonnance de votre généraliste est valable pour acheter le traitement à plein tarif, mais elle n'ouvre pas le droit au remboursement en initiation. Le généraliste peut en revanche renouveler un traitement initié par un spécialiste habilité."
+  - question: "Que faire si Mounjaro ou Wegovy est en rupture de stock dans ma pharmacie ?"
+    answer: "Demandez au pharmacien de vérifier la disponibilité chez ses grossistes et le délai de réapprovisionnement, appelez plusieurs pharmacies autour de chez vous, et consultez la page disponibilité des médicaments de l'ANSM pour vérifier s'il s'agit d'une tension nationale ou d'un simple aléa local. Ne commandez jamais sur des sites étrangers non autorisés."
+mainKeyword: "pharmacie refuse mounjaro wegovy"
+secondaryKeywords: ["pharmacie refuse de délivrer wegovy", "formulaire remboursement mounjaro", "formulaire remboursement wegovy", "où trouver mounjaro", "mounjaro non remboursé pharmacie"]
+---
+
+**Vous arrivez au comptoir avec votre ordonnance de Mounjaro ou de Wegovy, et la pharmacie refuse de vous le délivrer — ou refuse de vous le passer en remboursé.** Depuis le remboursement du 15 juin 2026, ce scénario est devenu l'un des motifs de frustration les plus fréquents chez les patients. La bonne nouvelle : dans la quasi-totalité des cas, ce n'est ni de la mauvaise volonté ni une erreur du pharmacien, mais une règle de délivrance précise — et il existe un parcours de déblocage pour chaque situation.
+
+## Ce que le pharmacien doit vérifier depuis le 15 juin 2026
+
+Le remboursement à 65 % de Wegovy (sémaglutide) et Mounjaro (tirzépatide) dans l'obésité, effectif depuis le [15 juin 2026](https://www.vidal.fr/actualites/37850-obesite-prise-en-charge-de-wegovy-et-mounjaro-a-partir-du-15-juin-2026-sous-conditions.html), s'accompagne d'un contrôle renforcé au comptoir. Les deux médicaments sont intégrés au **dispositif d'aide à la prescription des AGLP-1** de l'Assurance Maladie ([ameli, espace pharmacien](https://www.ameli.fr/pharmacien/actualites/wegovy-et-mounjaro-desormais-concernes-par-le-dispositif-d-aide-la-prescription-des-aglp-1)) : pour facturer en remboursé, le pharmacien doit avoir sous les yeux **deux documents** :
+
+1. **l'ordonnance**, émise par un prescripteur habilité pour l'initiation ;
+2. **le formulaire du dispositif d'aide à la prescription** (parfois appelé formulaire ITR, pour « indication thérapeutique remboursable »), rempli par le médecin et remis au patient avec l'ordonnance — il atteste que la prescription respecte les conditions de remboursement ([Fédération des pharmaciens de France, circulaire 2026-30](https://www.fspf.fr/wegovy-mounjaro-2026-30/)).
+
+La règle est binaire : **sans formulaire, pas de facturation en remboursé possible** — quelle que soit votre situation médicale réelle. Le pharmacien qui « refuse » applique la réglementation ; s'il facturait quand même, la caisse rejetterait la facturation.
+
+## Les 4 causes réelles de refus (et comment débloquer chacune)
+
+### 1. Le formulaire d'aide à la prescription manque
+
+C'est la cause n°1, surtout dans les premières semaines du dispositif : le médecin a fait l'ordonnance mais n'a pas rempli ou pas remis le formulaire.
+
+**Que faire** : recontactez le cabinet du prescripteur et demandez le formulaire du dispositif d'aide à la prescription des AGLP-1 — c'est un document standard que le médecin remplit en quelques minutes (via le téléservice ou le formulaire papier). Inutile de refaire une consultation complète dans la plupart des cas. Revenez ensuite en pharmacie avec les deux documents.
+
+### 2. La primo-prescription ne vient pas d'un prescripteur habilité
+
+Depuis les arrêtés du 12 juin 2026, la **première prescription remboursée** est réservée aux spécialistes exerçant en **CSO, CHU ou structure SMR spécialisée** (plus quelques cas particuliers, comme les endocrinologues conventionnés avec un CSO). Une ordonnance initiale de votre médecin généraliste est **valable pour acheter** le traitement, mais n'ouvre **pas le remboursement** : la pharmacie ne peut la servir qu'à plein tarif.
+
+**Que faire** : demandez à votre médecin traitant un courrier d'adressage vers le CSO ou le CHU de votre région pour obtenir une primo-prescription en bonne et due forme — notre guide [qui peut prescrire Mounjaro ou Wegovy pour être remboursé](/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/) détaille les prescripteurs habilités et le mode d'emploi du rendez-vous. Une fois l'initiation faite par le spécialiste, votre généraliste pourra renouveler en remboursé.
+
+### 3. Les conditions de remboursement ne sont pas remplies
+
+Le remboursement est réservé aux adultes avec un **IMC ≥ 40 kg/m², ou ≥ 35 kg/m² avec au moins une comorbidité** liée au poids, **après au moins 6 mois de prise en charge nutritionnelle** bien conduite avec une perte de poids inférieure à 5 % ([conditions officielles](https://www.vidal.fr/actualites/37850-obesite-prise-en-charge-de-wegovy-et-mounjaro-a-partir-du-15-juin-2026-sous-conditions.html)). Hors de ces critères, le médecin ne peut pas remplir le formulaire, et la délivrance ne peut se faire qu'en non remboursé.
+
+**Que faire** : vérifiez d'abord où vous en êtes avec notre [test d'éligibilité gratuit](/outils/test-eligibilite/) (2 minutes). Si le critère manquant est le suivi nutritionnel de 6 mois, commencez-le dès maintenant avec votre médecin ou un diététicien : le délai court pendant que vous attendez un rendez-vous spécialisé. Si vous êtes hors critères, le traitement reste accessible à plein tarif — [146,91 à 195,10 € par mois pour Wegovy, 176,10 à 433,80 € pour Mounjaro](/collections/glp1-cout/prix-mounjaro-france/) selon le dosage.
+
+### 4. Le médicament est en rupture ou en tension d'approvisionnement
+
+Dernière cause, indépendante de votre dossier : le stock. Les GLP-1 ont connu de fortes tensions entre 2023 et 2025 ; la situation s'est normalisée avant l'ouverture du remboursement, mais des tensions locales ou ponctuelles sur certains dosages restent possibles, et la demande a fortement augmenté depuis le 15 juin 2026.
+
+**Que faire** : demandez au pharmacien le délai de réapprovisionnement chez ses grossistes et laissez vos coordonnées ; appelez plusieurs officines autour de chez vous (notre [carte des pharmacies](/outils/carte-prix-pharmacies/) vous aide à les localiser) ; vérifiez sur la [page disponibilité de l'ANSM](https://ansm.sante.fr/disponibilites-des-produits-de-sante/medicaments) s'il s'agit d'une tension nationale déclarée. Notre article sur [les pénuries d'Ozempic, Wegovy et Mounjaro](/collections/traitements-glp1/penurie-ozempic-wegovy-mounjaro-rupture-stock-france-alternatives/) explique les alternatives possibles avec votre médecin en cas de rupture prolongée. Et surtout : n'achetez jamais sur des sites étrangers non autorisés, le risque de contrefaçon est réel.
+
+## Le pharmacien a-t-il le droit de refuser ?
+
+Il faut distinguer deux situations :
+
+- **Refus de facturer en remboursé** : ce n'est pas un choix du pharmacien. Sans formulaire conforme et prescripteur habilité, la réglementation lui interdit la facturation à l'Assurance Maladie. Le « refus » est en réalité une application du dispositif.
+- **Refus de délivrer tout court** : avec une ordonnance valable, le pharmacien délivre normalement le traitement (au besoin en non remboursé). Un refus sec est rare et généralement lié au stock ou à un doute sérieux sur l'ordonnance — dans ce cas, demandez une explication claire et, si besoin, essayez une autre officine.
+
+Dans tous les cas, le comptoir n'est pas le bon endroit pour régulariser un dossier incomplet : c'est du côté du **prescripteur** que ça se débloque.
+
+## En résumé : le bon réflexe selon la cause du refus
+
+| Cause du refus | Solution | Interlocuteur |
+|---|---|---|
+| Formulaire d'aide à la prescription manquant | Le faire remplir et le rapporter | Le médecin prescripteur |
+| Primo-prescription du généraliste | Adressage vers CSO/CHU/SMR pour initier en remboursé | Médecin traitant → spécialiste |
+| Critères de remboursement non remplis | Vérifier son éligibilité, documenter 6 mois de suivi | Médecin traitant / diététicien |
+| Rupture de stock | Grossistes, autres officines, page ANSM | Pharmacien |
+
+Pour arriver en consultation avec un dossier complet — verdict d'éligibilité, centres spécialisés proches de chez vous, checklist de rendez-vous et estimation du reste à charge — le [Dossier GLP-1 Personnalisé](/dossier-glp1/) (4,99 €) rassemble tout en un document prêt à présenter à votre médecin.
+
+---
+
+*Sources : [Vidal — prise en charge de Wegovy et Mounjaro au 15 juin 2026](https://www.vidal.fr/actualites/37850-obesite-prise-en-charge-de-wegovy-et-mounjaro-a-partir-du-15-juin-2026-sous-conditions.html) ; [ameli (espace pharmacien) — dispositif d'aide à la prescription des AGLP-1](https://www.ameli.fr/pharmacien/actualites/wegovy-et-mounjaro-desormais-concernes-par-le-dispositif-d-aide-la-prescription-des-aglp-1) ; [FSPF — circulaire Wegovy/Mounjaro 2026-30](https://www.fspf.fr/wegovy-mounjaro-2026-30/) ; [ANSM — disponibilité des médicaments](https://ansm.sante.fr/disponibilites-des-produits-de-sante/medicaments). Cet article est fourni à titre informatif et ne remplace pas un avis médical ou pharmaceutique personnalisé.*


### PR DESCRIPTION
## Contenu

- **C5 — Article du plan (item 2, P1)** : « La pharmacie refuse de délivrer Mounjaro ou Wegovy : pourquoi et que faire » → `/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/` (~1 200 mots, FAQ schema 5 questions, thumbnail SVG unique, tableau récapitulatif). Sources : Vidal 37850, ameli espace pharmacien (dispositif d'aide à la prescription AGLP-1), FSPF circulaire 2026-30, ANSM. Maillage : 7 sortants dont 2 funnel ; 2 entrants ajoutés (qui-peut-prescrire + pénurie).
- **C6 — Fact-check rotatif** : `baisse-prix-ozempic-wegovy-2027-france` (OK, chiffres US 349 $/675 $ 2027 confirmés) et `regime-paleo-glp1` (OK, draft) — `last_fact_checked` mis à jour en base.
- **Rapport run 2** : `reports/daily-2026-08-01-run2.md` (3e vente Dossier 4,99 € à 12h57, nouveau client spontané).
- File GSC : 1 URL ajoutée ; content-plan item 2 coché.

Build local vérifié avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LeXGmmVWXsQK9XZthsBPp

---
_Generated by [Claude Code](https://claude.ai/code/session_014LeXGmmVWXsQK9XZthsBPp)_