### PR TITLE
docs: mark pharmacies palier 2 as deployed + daily report addendum 2026-08-04

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,9 +282,9 @@ VALUES (...);
 - Deploy : toucher `src/pages/pharmacies/` ou `pharmacies.json` declenche le full sync FTP (~16-40 min) ; les merges pendant un deploy en cours l'ANNULENT (`cancel-in-progress`) — toujours attendre le vert avant de merger un 2e lot
 
 **Prochains paliers (dans l'ordre, chacun conditionne au precedent)** :
-1. **Attendre l'indexation** : verifier a chaque routine les impressions GSC sur `/pharmacies/.*/prix-` ; premiere evaluation serieuse ~24-25/07
-2. Si l'indexation demarre : palier hubs villes 500 → 1000 (`[ville].astro` + `cp/[zipcode].astro`, slice 500 → 1000) et pages prix ville 200 → 500 (`PRICE_CITIES_LIMIT`, garder les 3 fichiers prix + `[ville].astro` synchronises)
-3. Si ca continue : envisager l'angle "disponibilite/stock communautaire" (retourner l'outil de soumission prix en signalement de stock) — DEMANDER a Robin avant (produit)
+1. ~~Attendre l'indexation~~ — FAIT : decollage confirme le 04/08 (imp x2,5 WoW, 109 pages prix actives)
+2. ~~Palier 2~~ — **DEPLOYE le 04/08/2026** (go Robin, PR #93, deploy vert 13h59) : hubs villes 1000, pages prix ville 500 (`PRICE_CITIES_LIMIT = 500`), cp/[zipcode] seuil 1000. Suivre l'indexation des nouvelles pages a chaque routine.
+3. Si ca continue : palier 3 possible (toutes villes >= 5 pharmacies) et/ou angle "disponibilite/stock communautaire" (retourner l'outil de soumission prix en signalement de stock) — DEMANDER a Robin avant (produit)
 
 **Signaux en surveillance (20/07)** :
 - "ozempic wegovy penurie" : 901 imp/14j, position 3.6, **0 clic** — anormal ; re-checker apres le nouveau title (deploye 20/07). Si toujours 0 clic vers le 24-25/07, investiguer la SERP.

--- a/reports/daily-2026-08-04.md
+++ b/reports/daily-2026-08-04.md
@@ -95,6 +95,12 @@ Spot fact-check approfondi sur les 2 articles les plus anciens (voir C2/C3) : le
 - **Aucune mention Zepbound.** Aucune erreur médicale critique.
 - Dossiers : 0 nouveau en 24h.
 
+## ADDENDUM (après-midi, échange avec Robin)
+
+- **Palier 2 pharmacies : GO donné par Robin et DEPLOYE le jour même.** Hubs villes 500→1000, pages prix ville 200→500 (PR #93, build local vert, full sync FTP 26 min, run 482 success à 13h59, pages témoins yerres/prix-mounjaro et prix-wegovy vérifiées 200 en live). ~2 400 pages ajoutées.
+- **Cliente du 01/08 (mazzella.marion)** : a répondu à 10h14 au mail de suivi — elle MAINTIENT sa demande de remboursement (4,99 €) et reproche le caractère « généré par IA » des réponses. Recommandation transmise à Robin : rembourser via Stripe (action Robin). Signal produit noté : premier grief client sur l'authenticité du contenu.
+- Idées recovery proposées à Robin (en attente d'arbitrage) : maillage pages locales → pages prix nationales, refresh des 5 pages baseline mortes, test CTR title prix-ozempic, Coach → lien direct test d'éligibilité (au lieu de collecter l'IMC en chat), page « Observatoire des prix GLP-1 » pour les backlinks.
+
 ## EN ATTENTE DE DECISION ROBIN
 
 1. **Palier 2 pharmacies** : l'indexation du cluster prix décolle (imp x2,5 WoW, 109 pages actives). Prêt à passer hubs villes 500→1000 et pages prix ville 200→500 au prochain run (gros build + full sync FTP ~40 min). Dire « go palier 2 » ou « attends ».


### PR DESCRIPTION
## Résumé

Mise à jour documentaire post-palier 2 (aucun changement de code) :

- `CLAUDE.md` : section pharmacies — palier 2 marqué DEPLOYE (04/08, PR #93, deploy vert run 482), prochaine étape = palier 3 (sur décision Robin)
- `reports/daily-2026-08-04.md` : addendum après-midi — go + deploy palier 2, réponse de la cliente du 01/08 (maintient sa demande de remboursement, action Stripe côté Robin), idées recovery proposées

Évite qu'un prochain run re-propose le palier 2 déjà appliqué.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcLAzx2VFjGyW2wmFNeUPV)_