### PR TITLE
docs: define official funnel KPIs K1-K6 with 30d baselines in routine A0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,9 +282,9 @@ VALUES (...);
 - Deploy : toucher `src/pages/pharmacies/` ou `pharmacies.json` declenche le full sync FTP (~16-40 min) ; les merges pendant un deploy en cours l'ANNULENT (`cancel-in-progress`) — toujours attendre le vert avant de merger un 2e lot
 
 **Prochains paliers (dans l'ordre, chacun conditionne au precedent)** :
-1. **Attendre l'indexation** : verifier a chaque routine les impressions GSC sur `/pharmacies/.*/prix-` ; premiere evaluation serieuse ~24-25/07
-2. Si l'indexation demarre : palier hubs villes 500 → 1000 (`[ville].astro` + `cp/[zipcode].astro`, slice 500 → 1000) et pages prix ville 200 → 500 (`PRICE_CITIES_LIMIT`, garder les 3 fichiers prix + `[ville].astro` synchronises)
-3. Si ca continue : envisager l'angle "disponibilite/stock communautaire" (retourner l'outil de soumission prix en signalement de stock) — DEMANDER a Robin avant (produit)
+1. ~~Attendre l'indexation~~ — FAIT : decollage confirme le 04/08 (imp x2,5 WoW, 109 pages prix actives)
+2. ~~Palier 2~~ — **DEPLOYE le 04/08/2026** (go Robin, PR #93, deploy vert 13h59) : hubs villes 1000, pages prix ville 500 (`PRICE_CITIES_LIMIT = 500`), cp/[zipcode] seuil 1000. Suivre l'indexation des nouvelles pages a chaque routine.
+3. Si ca continue : palier 3 possible (toutes villes >= 5 pharmacies) et/ou angle "disponibilite/stock communautaire" (retourner l'outil de soumission prix en signalement de stock) — DEMANDER a Robin avant (produit)
 
 **Signaux en surveillance (20/07)** :
 - "ozempic wegovy penurie" : 901 imp/14j, position 3.6, **0 clic** — anormal ; re-checker apres le nouveau title (deploye 20/07). Si toujours 0 clic vers le 24-25/07, investiguer la SERP.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,15 @@ C'est l'objectif principal du site (voir OBJECTIFS BUSINESS). Chaque rapport quo
 6. **Suivi post-achat (OBLIGATOIRE dans chaque rapport)** : pour chaque dossier paye, envoyer l'email de satisfaction a J+2/J+3 via l'edge function `send-feedback-email` (v3, envoyeur generique guarde par token — token lisible dans le source via `mcp__Supabase__get_edge_function`, category `dossier_satisfaction`, trace auto dans email_replies), puis verifier a CHAQUE run si le client a repondu (incoming_emails, sync auto pg_cron toutes les 15 min) et le dire dans le rapport (« relance envoyee le X, pas de reponse » compte comme une info). Etat au 27/07 : client 1 (paye 22/07) email envoye 23/07 sans reponse ; client 2 (paye 24/07) email envoye 27/07.
 Si un dossier est PAYE : PushNotification immediate a Robin (1re conversion = evenement).
 
+**KPIs funnel officiels (definis avec Robin le 04/08/2026 — a reporter dans CHAQUE rapport A0, fenetre glissante 30j)** :
+- **K1 Exposition** = sessions (/outils/test-eligibilite/ + /dossier-glp1/) / sessions site. Baseline 04/08 : **0,69 %** (104/15 095)
+- **K2 Activation** = dossiers crees / sessions /dossier-glp1/. Baseline : **12 %** (6/50)
+- **K3 Paiement** = dossiers payes / dossiers crees. Baseline : **50 %** (3/6)
+- **K4 Conversion funnel** = payes / sessions funnel. Baseline : **2,9 %** (3/104)
+- **K5 Coach** = reponses proposant le Dossier / conversations. Baseline : **11 %** (15/135) — et ventes via chat (1/3 au 04/08)
+- **K6 Capture test** = leads eligibility_test / sessions test. Baseline : **9,3 %** (5/54)
+Le diagnostic de fuite (point 5) se fait en comparant chaque K a sa baseline : le K qui decroche = la fuite du moment. Goulot identifie au 04/08 : **K1** (exposition), le reste du funnel convertit correctement.
+
 ### Phase A — Etat des lieux (collecte, chaque run)
 
 Verifier fraicheur GA4/GSC (regle critique en tete de fichier), site live (home 200, redirect zepbound→mounjaro, sitemap), puis :

--- a/reports/daily-2026-08-04.md
+++ b/reports/daily-2026-08-04.md
@@ -95,6 +95,12 @@ Spot fact-check approfondi sur les 2 articles les plus anciens (voir C2/C3) : le
 - **Aucune mention Zepbound.** Aucune erreur médicale critique.
 - Dossiers : 0 nouveau en 24h.
 
+## ADDENDUM (après-midi, échange avec Robin)
+
+- **Palier 2 pharmacies : GO donné par Robin et DEPLOYE le jour même.** Hubs villes 500→1000, pages prix ville 200→500 (PR #93, build local vert, full sync FTP 26 min, run 482 success à 13h59, pages témoins yerres/prix-mounjaro et prix-wegovy vérifiées 200 en live). ~2 400 pages ajoutées.
+- **Cliente du 01/08 (mazzella.marion)** : a répondu à 10h14 au mail de suivi — elle MAINTIENT sa demande de remboursement (4,99 €) et reproche le caractère « généré par IA » des réponses. Recommandation transmise à Robin : rembourser via Stripe (action Robin). Signal produit noté : premier grief client sur l'authenticité du contenu.
+- Idées recovery proposées à Robin (en attente d'arbitrage) : maillage pages locales → pages prix nationales, refresh des 5 pages baseline mortes, test CTR title prix-ozempic, Coach → lien direct test d'éligibilité (au lieu de collecter l'IMC en chat), page « Observatoire des prix GLP-1 » pour les backlinks.
+
 ## EN ATTENTE DE DECISION ROBIN
 
 1. **Palier 2 pharmacies** : l'indexation du cluster prix décolle (imp x2,5 WoW, 109 pages actives). Prêt à passer hubs villes 500→1000 et pages prix ville 200→500 au prochain run (gros build + full sync FTP ~40 min). Dire « go palier 2 » ou « attends ».


### PR DESCRIPTION
## Résumé

Demande Robin du 04/08 (« définir des taux de conversion à nous qu'on puisse monitorer dans le temps ») : ajout dans CLAUDE.md (Phase A0) de 6 KPIs funnel officiels — K1 Exposition, K2 Activation, K3 Paiement, K4 Conversion funnel, K5 Coach, K6 Capture test — avec définitions exactes (fenêtre glissante 30 jours) et baselines mesurées au 04/08/2026. Chaque rapport quotidien devra les reporter et comparer à la baseline pour identifier la fuite du moment.

Docs uniquement, aucun changement de code ni de site.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcLAzx2VFjGyW2wmFNeUPV)_