### PR TITLE
docs: persist K1 plan with per-action status + test-eligibilite top of GSC queue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,15 @@ Si un dossier est PAYE : PushNotification immediate a Robin (1re conversion = ev
 - **K6 Capture test** = leads eligibility_test / sessions test. Baseline : **9,3 %** (5/54)
 Le diagnostic de fuite (point 5) se fait en comparant chaque K a sa baseline : le K qui decroche = la fuite du moment. Goulot identifie au 04/08 : **K1** (exposition), le reste du funnel convertit correctement.
 
+**PLAN K1 (etabli avec Robin le 04/08/2026 — statuts a tenir a jour a chaque run)** :
+1. **[ACTION ROBIN]** Soumettre `/outils/test-eligibilite/` en GSC (0 impression en 30j alors que la page est indexable — jamais indexee par Google depuis sa creation le 14/07). Ajoutee en tete de la file gsc-submission-queue.md.
+2. **[EN ATTENTE GO ROBIN — « go CTA »]** Encart eligibilite sur `/outils/carte-prix-pharmacies/` (page n°1 du site, 1 872 sessions/30j, AUCUN lien funnel actuellement). Angle : « prix identiques partout — serez-vous rembourse a 65 % ? Test 2 min ».
+3. **[EN ATTENTE GO ROBIN — « go CTA »]** Encart apres le tableau de prix des 3 pages prix nationales (prix-mounjaro/ozempic/wegovy-france, 1 715 sessions/30j cumulees).
+4. **[AUTONOME — A FAIRE au prochain run]** Coach IA : quand intent price/eligibility detecte, proposer le LIEN direct vers /outils/test-eligibilite/ au lieu de collecter poids/taille en chat (0 DOSSIER_READY en 7j, personne ne finit la collecte). Modif prompt systeme + deploy MCP.
+5. **[APRES 2-3]** Meme encart sur les pages prix ville/dept du cluster pharmacies.
+6. **[AUTONOME — backlog]** Email de livraison J0 automatique post-achat Dossier (« votre dossier est pret » + lien /mon-espace/dossier/) — actuellement l'acheteur qui ferme l'onglet de retour Stripe n'a aucun moyen de retrouver son dossier.
+Estimation actions 2+3 a 3 % de clic : K1 0,69 % → ~1,4 %, soit ~6 ventes/mois a K2-K4 constants.
+
 ### Phase A — Etat des lieux (collecte, chaque run)
 
 Verifier fraicheur GA4/GSC (regle critique en tete de fichier), site live (home 200, redirect zepbound→mounjaro, sitemap), puis :

--- a/reports/gsc-submission-queue.md
+++ b/reports/gsc-submission-queue.md
@@ -5,6 +5,8 @@ La routine AJOUTE ici a chaque publication — elle ne relance jamais dans le ch
 
 ## En attente de soumission
 
+- [ ] **https://glp1-france.fr/outils/test-eligibilite/ (PRIORITE ABSOLUE — page funnel, 0 impression GSC en 30j, jamais indexee depuis le 14/07 ; constat du 04/08)**
+
 - [ ] https://glp1-france.fr/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/ (article 01/08, prioritaire)
 - [ ] https://glp1-france.fr/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/ (article 01/08 run 2, prioritaire)
 - [ ] https://glp1-france.fr/collections/glp1-cout/prix-glp1-pharmacie-tableau-2026/ (article 02/08, prioritaire — cible « glp-1 en pharmacie prix »)


### PR DESCRIPTION
## Résumé

Suite au constat de Robin (04/08) : le plan K1 discuté en chat n'était pas persisté et aurait été perdu pour les runs suivants.

- `CLAUDE.md` : bloc « PLAN K1 » sous les KPIs funnel, avec statut par action — [ACTION ROBIN] soumission GSC du test, [EN ATTENTE GO ROBIN « go CTA »] encarts carte-prix + pages prix nationales, [AUTONOME prochain run] Coach → lien direct test, [backlog] email de livraison J0 post-achat
- `reports/gsc-submission-queue.md` : `/outils/test-eligibilite/` ajoutée en tête en PRIORITÉ ABSOLUE (0 impression GSC en 30 jours, jamais indexée depuis le 14/07)

Docs uniquement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcLAzx2VFjGyW2wmFNeUPV)_