### PR TITLE
feat: eligibility CTA on carte-prix-pharmacies + 3 national price pages (K1 plan)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,8 +180,8 @@ Le diagnostic de fuite (point 5) se fait en comparant chaque K a sa baseline : l
 
 **PLAN K1 (etabli avec Robin le 04/08/2026 — statuts a tenir a jour a chaque run)** :
 1. **[ACTION ROBIN]** Soumettre `/outils/test-eligibilite/` en GSC (0 impression en 30j alors que la page est indexable — jamais indexee par Google depuis sa creation le 14/07). Ajoutee en tete de la file gsc-submission-queue.md.
-2. **[EN ATTENTE GO ROBIN — « go CTA »]** Encart eligibilite sur `/outils/carte-prix-pharmacies/` (page n°1 du site, 1 872 sessions/30j, AUCUN lien funnel actuellement). Angle : « prix identiques partout — serez-vous rembourse a 65 % ? Test 2 min ».
-3. **[EN ATTENTE GO ROBIN — « go CTA »]** Encart apres le tableau de prix des 3 pages prix nationales (prix-mounjaro/ozempic/wegovy-france, 1 715 sessions/30j cumulees).
+2. **[FAIT 06/08/2026 — go Robin « go CTA »]** Encart eligibilite sur `/outils/carte-prix-pharmacies/` (page n°1 du site, 1 872 sessions/30j). Suivre le trafic referral vers /outils/test-eligibilite/ dans les rapports A0.
+3. **[FAIT 06/08/2026 — go Robin « go CTA »]** Encart apres le tableau de prix des 3 pages prix nationales (angle Ozempic adapte : rembourse diabete seulement → renvoi Wegovy/Mounjaro 65 %).
 4. **[AUTONOME — A FAIRE au prochain run]** Coach IA : quand intent price/eligibility detecte, proposer le LIEN direct vers /outils/test-eligibilite/ au lieu de collecter poids/taille en chat (0 DOSSIER_READY en 7j, personne ne finit la collecte). Modif prompt systeme + deploy MCP.
 5. **[APRES 2-3]** Meme encart sur les pages prix ville/dept du cluster pharmacies.
 6. **[AUTONOME — backlog]** Email de livraison J0 automatique post-achat Dossier (« votre dossier est pret » + lien /mon-espace/dossier/) — actuellement l'acheteur qui ferme l'onglet de retour Stripe n'a aucun moyen de retrouver son dossier.

--- a/src/content/glp1-cout/prix-mounjaro-france.md
+++ b/src/content/glp1-cout/prix-mounjaro-france.md
@@ -6,7 +6,7 @@ keywords: ['prix mounjaro france', 'mounjaro prix', 'prix mounjaro 2026', 'mounj
 seoTitle: "Prix Mounjaro 2026 : 176-433 € — même prix partout, -65% Sécu"
 seoDescription: "Prix Mounjaro officiel : 176 à 434 €/mois selon dosage, identique dans toutes les pharmacies. Remboursé à 65 % depuis juin 2026 — vérifiez votre éligibilité."
 publishedAt: '2025-09-06'
-updatedAt: '2026-07-27'
+updatedAt: '2026-08-06'
 date: 2026-07-20
 featured: true
 priority: 1
@@ -304,6 +304,12 @@ Retrouvez aussi nos pages locales avec la liste des pharmacies et les centres de
 | 12,5-15 mg | 433,80 € | ~151 €/mois |
 
 *Tous les dosages sont remboursés à 65% par l'Assurance Maladie pour les patients éligibles (depuis le 15 juin 2026). Ticket modérateur de 35% complété par la mutuelle selon votre contrat.*
+
+<div style="background:#f0fdf4;border:2px solid #16a34a;border-radius:12px;padding:20px 24px;margin:24px 0;">
+  <p style="margin:0 0 8px;font-weight:700;color:#1a3c34;font-size:1.05em;">De 176-434 €/mois à 61-151 €/mois : tout se joue sur l'éligibilité</p>
+  <p style="margin:0 0 14px;color:#374151;">Le remboursement à 65 % dépend de critères précis : IMC ≥ 40, ou ≥ 35 avec comorbidité, après 6 mois de prise en charge nutritionnelle. Vérifiez les vôtres avant le rendez-vous médecin.</p>
+  <a href="/outils/test-eligibilite/" style="display:inline-block;background:#16a34a;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Faire le test d'éligibilité → 2 min</a>
+</div>
 
 ## Obtenir le Remboursement Mounjaro : 4 Étapes Concrètes {#remboursement-etapes}
 

--- a/src/content/glp1-cout/prix-ozempic-france.md
+++ b/src/content/glp1-cout/prix-ozempic-france.md
@@ -7,7 +7,7 @@ seoTitle: "Prix Ozempic 2026 : 77,60 €/stylo — remboursé 30%, 100% en ALD"
 seoDescription: "Prix officiel Ozempic : 77,60 € TTC le stylo (1 mois), identique dans toutes les pharmacies. Remboursé 30% diabète type 2, 100% en ALD. Point juillet 2026."
 mainKeyword: "prix Ozempic France"
 publishedAt: '2025-01-28'
-updatedAt: '2026-07-27'
+updatedAt: '2026-08-06'
 date: 2026-06-22
 featured: true
 author: 'Rédaction GLP-1 France'
@@ -105,6 +105,12 @@ Le **prix Ozempic en pharmacie** en France est fixé à **77,60€ TTC par stylo
 | 2 mg | AMM européenne, non commercialisé en France | — |
 
 **Prix mensuel** : 77,60 € quel que soit le dosage (chaque stylo contient 4 doses, soit 1 stylo/mois)
+
+<div style="background:#f0fdf4;border:2px solid #16a34a;border-radius:12px;padding:20px 24px;margin:24px 0;">
+  <p style="margin:0 0 8px;font-weight:700;color:#1a3c34;font-size:1.05em;">Ozempic n'est remboursé que pour le diabète — pour la perte de poids, c'est Wegovy ou Mounjaro (65 %)</p>
+  <p style="margin:0 0 14px;color:#374151;">Si votre objectif est de maigrir, le remboursement à 65 % passe par Wegovy ou Mounjaro, sous conditions : IMC ≥ 40, ou ≥ 35 avec comorbidité, après 6 mois de suivi nutritionnel. Vérifiez vos critères.</p>
+  <a href="/outils/test-eligibilite/" style="display:inline-block;background:#16a34a;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Faire le test d'éligibilité → 2 min</a>
+</div>
 
 ### Comparaison avec autres GLP-1
 

--- a/src/content/glp1-cout/prix-wegovy-france.md
+++ b/src/content/glp1-cout/prix-wegovy-france.md
@@ -7,7 +7,7 @@ keywords: ['prix wegovy', 'wegovy prix', 'prix wegovy france', 'wegovy prix phar
 seoTitle: "Wegovy Prix Pharmacie Moins Cher 2026 : dès 146,91€, remboursé 65%"
 seoDescription: "Wegovy prix pharmacie juillet 2026 : 146,91 à 195,10€/mois (prix réglementé, identique partout). Remboursé 65% Sécu depuis juin 2026. Carte des pharmacies disponibles, éligibilité et reste à charge. Mis à jour."
 publishedAt: '2025-01-28'
-updatedAt: '2026-07-20'
+updatedAt: '2026-08-06'
 date: '2026-07-19'
 featured: true
 author: 'Dr. Marie Dubois'
@@ -100,6 +100,12 @@ faqSchema:
 | 2.4 mg | 195,10 € | 65 % (sous conditions) |
 
 **Prix mensuel réglementé** : 146,91-195,10 €/mois selon le dosage, **remboursé à 65 % depuis le 15 juin 2026** sous conditions (IMC ≥ 35 + comorbidité ou IMC ≥ 40)
+
+<div style="background:#f0fdf4;border:2px solid #16a34a;border-radius:12px;padding:20px 24px;margin:24px 0;">
+  <p style="margin:0 0 8px;font-weight:700;color:#1a3c34;font-size:1.05em;">De 147-195 €/mois à 51-68 €/mois : tout se joue sur l'éligibilité</p>
+  <p style="margin:0 0 14px;color:#374151;">Le remboursement à 65 % dépend de critères précis : IMC ≥ 40, ou ≥ 35 avec comorbidité, après 6 mois de prise en charge nutritionnelle. Vérifiez les vôtres avant le rendez-vous médecin.</p>
+  <a href="/outils/test-eligibilite/" style="display:inline-block;background:#16a34a;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Faire le test d'éligibilité → 2 min</a>
+</div>
 
 ### Comparaison avec autres GLP-1
 

--- a/src/pages/outils/carte-prix-pharmacies.astro
+++ b/src/pages/outils/carte-prix-pharmacies.astro
@@ -113,6 +113,17 @@ const updatedFr = stats.updated_at
       <div id="map-loading" class="map-loading">Chargement de la carte…</div>
     </div>
 
+    <!-- CTA éligibilité (plan K1, go Robin 06/08/2026) -->
+    <section style="background:#f0fdf4;border-top:1px solid #dcfce7;border-bottom:1px solid #dcfce7;padding:28px 16px;">
+      <div style="max-width:960px;margin:0 auto;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:16px;">
+        <div style="flex:1 1 480px;">
+          <h2 style="margin:0 0 6px;color:#1a3c34;font-size:1.25rem;">Les prix sont identiques partout — votre reste à charge, non</h2>
+          <p style="margin:0;color:#374151;">Wegovy et Mounjaro sont remboursés à 65&nbsp;% depuis juin 2026, sous conditions (IMC, comorbidités, suivi). La vraie question n'est pas où acheter, mais si vous êtes éligible.</p>
+        </div>
+        <a href="/outils/test-eligibilite/" style="display:inline-block;background:#16a34a;color:#fff;padding:12px 22px;border-radius:8px;text-decoration:none;font-weight:600;white-space:nowrap;">Vérifier mon éligibilité → 2 min</a>
+      </div>
+    </section>
+
     <!-- Contrib CTA -->
     <section class="contrib-banner">
       <div class="contrib-inner">


### PR DESCRIPTION
## Résumé

Actions 2 et 3 du plan K1 (CLAUDE.md), validées par Robin le 06/08 (« go cta ») pour augmenter l'exposition du funnel (K1 baseline 0,69 %) :

- `/outils/carte-prix-pharmacies/` (1 872 sessions/30j, page n°1 du site) : encart « Les prix sont identiques partout — votre reste à charge, non » entre la carte et le bandeau contribution → bouton vers `/outils/test-eligibilite/`
- `prix-mounjaro-france.md` : encart après le tableau de prix (« De 176-434 €/mois à 61-151 €/mois : tout se joue sur l'éligibilité »)
- `prix-wegovy-france.md` : idem (« De 147-195 €/mois à 51-68 €/mois »)
- `prix-ozempic-france.md` : angle adapté (Ozempic remboursé diabète uniquement → renvoi Wegovy/Mounjaro 65 %)
- `updatedAt` → 2026-08-06 sur les 3 articles ; statuts PLAN K1 mis à jour dans CLAUDE.md (actions 2-3 FAIT)

## Validation

- Build local vert (exit 0), les 4 encarts vérifiés présents dans le HTML généré
- DA respectée : fond #f0fdf4, bordure/bouton #16a34a, texte #1a3c34 — un seul encart par page
- Estimation (à 3 % de clic) : K1 0,69 % → ~1,4 %

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcLAzx2VFjGyW2wmFNeUPV)_