### PR TITLE
Rapport 07/08 : corrections suivi client + conformité désinscription

### DIFF
--- a/reports/daily-2026-08-07.md
+++ b/reports/daily-2026-08-07.md
@@ -2,6 +2,7 @@
 
 **Alertes** : 1 bug corrigé en cours de run (prix périmés servis par le Coach IA — détail en C).
 Site live OK : home 200, redirect zepbound → guide-complet-mounjaro 301, sitemap-0.xml 200, /outils/test-eligibilite/ 200.
+**Déploiement du run vérifié vert** : PR #99 mergée, deploy FTP terminé — article live en 200, prix corrigés confirmés en production (`146,91-195,10` et `176,10-433,80` servis sur les pages comparatives).
 Fraîcheur données : GA à jour (07/08, 0 j de retard), GSC 04/08 (3 j — normal).
 
 ---
@@ -32,7 +33,19 @@ Fraîcheur données : GA à jour (07/08, 0 j de retard), GSC 04/08 (3 j — norm
    | Sessions /outils/test-eligibilite/ | 8 | 3 | 4 | 6 | 9 | **14** |
 
    Le 06/08 est un record sur la période et correspond au jour du déploiement des encarts (carte prix pharmacies + 3 pages prix nationales). La fuite se déplace donc vers **K2/K3** : le trafic arrive au test, mais ne se transforme pas encore en dossier payé. À surveiller sur 7 jours avant toute conclusion (volumes faibles).
-6. **Suivi post-achat** : clients 1 et 2 — emails de satisfaction envoyés (23/07 et 27/07), **toujours aucune réponse** dans `incoming_emails`. Aucun nouvel achat ce run, donc aucun nouvel envoi J+2/J+3 à programmer.
+6. **Suivi post-achat** — 3 dossiers payés au total, situation réelle :
+
+   | Client | Payé | Statut | Suivi |
+   |---|---|---|---|
+   | KYM.BEAUTE@GMAIL.COM | 22/07 | generated | email satisfaction 23/07, pas de réponse |
+   | francoise.cardon@free.fr | 24/07 | generated | email satisfaction 27/07, pas de réponse |
+   | mazzella.marion@gmail.com | 01/08 | generated | **incident + remboursement effectué le 04/08** |
+
+   **Incident client à retenir (client 3)** : le lien de son dossier affichait « uniquement une page de code » (HTML servi brut au lieu d'être rendu). Elle a demandé le remboursement le 01/08 ; un dossier corrigé lui a été renvoyé le 02/08 ; le 04/08 elle a maintenu sa demande en reprochant explicitement une **réponse générée par IA** (« générer une réponse ChatGPT je trouve ça très décevant »). Remboursement envoyé le 04/08 à 14h24 — **dossier clos**, mais deux leçons : (a) le rendu du dossier livré doit être vérifié côté client, (b) une réponse SAV manifestement automatique sur un litige de paiement aggrave le mécontentement.
+
+   **Net réel : 2 clients payants conservés sur 3.** Le taux de paiement K3 affiché plus haut ne tient pas compte de ce remboursement.
+
+7. **Conformité désinscription — point de vigilance** : `s.ruth83@gmail.com` a répondu **« STOP »** le 01/08 à la campagne de prospection. Aucun email ne lui a été envoyé depuis (vérifié dans `email_replies`) — conformité respectée à ce jour. **Mais** : son dossier en base porte l'adresse `sruth83@gmail.com` (sans point), variante que Gmail considère comme identique. Une campagne future ciblant cette seconde forme la re-contacterait malgré son STOP. Il n'existe **aucune table de suppression/désinscription** dans la base : la règle STOP repose entièrement sur une relecture manuelle de `incoming_emails` à chaque run. → proposition en fin de rapport.
 
 ### Plan K1 — statuts
 
@@ -173,4 +186,18 @@ La page `prix-mounjaro-france` a perdu 53 % de ses impressions et « mounjaro pr
 Ma recommandation : **(b)**, et surtout **ne pas lancer le palier 3** tant que « mounjaro prix » n'est pas remontée.
 *Réponds « b » ou « c » si tu veux que je l'applique ; sans réponse, j'applique (a) et je remesure au prochain run.*
 
-**2. Soumission GSC de `/outils/test-eligibilite/`** (rappel unique, déjà en tête de file) : la page a 0 impression en 30 jours alors qu'elle est indexable et qu'elle reçoit maintenant du trafic interne. C'est la dernière action manuelle qui bloque K1.
+**2. Table de suppression email (anti-STOP) — feu vert demandé.**
+La règle « ne jamais réémailer une adresse ayant répondu STOP » n'est aujourd'hui garantie par rien de technique : elle dépend d'une relecture manuelle de `incoming_emails` à chaque run, et elle est déjà contournable par une simple variante d'adresse (`s.ruth83@` vs `sruth83@`, même boîte Gmail). Je propose de créer une table `email_suppression` (email normalisé — minuscules, points retirés avant le `@` pour Gmail —, motif, date) et de filtrer tout envoi dessus.
+C'est une **modification de schéma DB**, donc hors autonomie : je ne fais rien sans ton accord.
+*Réponds « go suppression » et je la crée au prochain run ; sinon je continue au contrôle manuel.*
+
+**3. Soumission GSC de `/outils/test-eligibilite/`** (rappel unique, déjà en tête de file) : la page a 0 impression en 30 jours alors qu'elle est indexable et qu'elle reçoit maintenant du trafic interne. C'est la dernière action manuelle qui bloque K1.
+
+---
+
+## Backlog technique noté ce run
+
+- **Garde-fou serveur sur les prix dans le Coach** : le fallback `mistral-small-latest` ne respecte pas l'interdiction des fourchettes périmées (constaté en prod ce run). Un nettoyage déterministe de la réponse serait plus fiable que la consigne de prompt.
+- **Réindexation RAG** après les corrections de prix de ce run : les chunks vectorisés portent encore les anciennes valeurs.
+- **Vérification du rendu du dossier livré** (incident client 3) : s'assurer que le lien signé du bucket sert bien du HTML rendu et non du code brut.
+- **Email de livraison J0 post-achat** (action 6 du plan K1, toujours en attente).


### PR DESCRIPTION
## Ce que fait cette PR

Correctif du rapport quotidien du 07/08 (`reports/daily-2026-08-07.md`) après vérification de la boîte mail entrante. Document uniquement — aucun changement de code ou de contenu du site.

### Corrections apportées

**1. Suivi post-achat — la version initiale était fausse.**
Le rapport disait « clients 1 et 2, aucune réponse ». En réalité il y a **3 dossiers payés**, et le 3ᵉ a connu un incident :
- `mazzella.marion@gmail.com` (payé le 01/08) : le lien de son dossier affichait « uniquement une page de code » (HTML servi brut). Demande de remboursement le 01/08, dossier corrigé renvoyé le 02/08, demande maintenue le 04/08 avec un reproche explicite sur la réponse SAV générée par IA. **Remboursement envoyé le 04/08 à 14h24 — dossier clos.**
- Net réel : **2 clients payants conservés sur 3**, ce que le K3 affiché ne reflétait pas.

**2. Conformité désinscription — écart signalé.**
`s.ruth83@gmail.com` a répondu « STOP » le 01/08. Aucun email ne lui a été envoyé depuis (vérifié), donc conformité respectée à ce jour. Mais son dossier en base porte `sruth83@gmail.com` (sans point) — même boîte Gmail, chaîne différente. Une campagne future ciblant cette variante la re-contacterait malgré son STOP, et **il n'existe aucune table de suppression** : la règle repose entièrement sur une relecture manuelle de `incoming_emails`.

**3. Backlog technique consigné**
Garde-fou serveur sur les prix pour le fallback Mistral du Coach, réindexation RAG après les corrections de prix, vérification du rendu du dossier livré, email de livraison J0.

**4. Déploiement du run précédent confirmé vert**
PR #99 mergée, deploy FTP terminé : article live en 200, prix corrigés vérifiés en production.

## Décision demandée
Création d'une table `email_suppression` (normalisation Gmail incluse) pour rendre la règle STOP techniquement opposable. C'est une modification de schéma DB, donc hors autonomie — rien ne sera fait sans accord explicite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFZmDRsZ9j8SdixGVZjZZc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFZmDRsZ9j8SdixGVZjZZc)_