### PR TITLE
Run 07/08 (2) : viewer dossier inline, garde-fou prix Coach, anti-cannibalisation prix

### DIFF
--- a/src/pages/mon-espace/dossier/index.astro
+++ b/src/pages/mon-espace/dossier/index.astro
@@ -30,11 +30,15 @@ import { supabaseConfig } from '../../../lib/supabase';
     @keyframes spin{to{transform:rotate(360deg)}}
     a.back{display:inline-block;margin-top:18px;color:#6b7280;font-size:.85rem;text-decoration:none}
     .center{text-align:center}
+    /* le dossier est plus large que la carte de statut : on deborde le .wrap */
+    #viewer:not(:empty){margin-top:20px;width:min(920px,100vw - 40px);margin-left:50%;transform:translateX(-50%);background:#fff;border:1px solid #e2e8f0;border-radius:16px;overflow:hidden;box-shadow:0 4px 20px rgba(0,0,0,.06)}
+    .viewer-frame{display:block;width:100%;height:78vh;min-height:520px;border:0}
   </style>
 </head>
 <body>
   <div class="wrap">
     <div class="card" id="root"><p class="center muted"><span class="spinner"></span>Chargement...</p></div>
+    <div id="viewer"></div>
     <p class="center"><a class="back" href="/">← Retour au site</a></p>
   </div>
 
@@ -92,13 +96,36 @@ import { supabaseConfig } from '../../../lib/supabase';
             '<a href="' + dlUrl + '" class="btn-secondary">Telecharger (fichier a ouvrir dans ton navigateur)</a>' +
             '<p class="muted" style="margin-top:16px;text-align:center">Le lien reste actif — tu peux y revenir a tout moment. Astuce : depuis le dossier ouvert, Ctrl+P / Imprimer pour en faire un PDF.</p>';
           document.getElementById('view-btn').addEventListener('click', function(){
+            // Lecture INLINE : window.open() apres un fetch async est bloque par
+            // les popup blockers (Safari/iOS surtout) — le client cliquait sans
+            // rien voir. On rend le dossier dans un iframe de la page courante.
+            var btn = this;
+            var host = document.getElementById('viewer');
+            if (host.getAttribute('data-loaded') === '1') {
+              host.scrollIntoView({ behavior: 'smooth' });
+              return;
+            }
+            btn.disabled = true;
+            btn.textContent = 'Ouverture...';
             fetch(d.pdf_url)
               .then(function(r){ return r.text(); })
               .then(function(htmlContent){
-                var blob = new Blob([htmlContent], { type: 'text/html' });
-                window.open(URL.createObjectURL(blob), '_blank');
+                var frame = document.createElement('iframe');
+                frame.className = 'viewer-frame';
+                frame.setAttribute('title', 'Mon dossier GLP-1');
+                frame.srcdoc = htmlContent;
+                host.innerHTML = '';
+                host.appendChild(frame);
+                host.setAttribute('data-loaded', '1');
+                btn.disabled = false;
+                btn.textContent = 'Revenir a mon dossier';
+                host.scrollIntoView({ behavior: 'smooth' });
               })
-              .catch(function(){ window.location.href = dlUrl; });
+              .catch(function(){
+                btn.disabled = false;
+                btn.textContent = 'Lire mon dossier';
+                window.location.href = dlUrl;
+              });
           });
         } else if (d.status === 'paid' && attempts < maxAttempts) {
           setTimeout(checkDossier, 2000);

--- a/src/pages/pharmacies/[ville]/prix-mounjaro.astro
+++ b/src/pages/pharmacies/[ville]/prix-mounjaro.astro
@@ -71,6 +71,16 @@ const faqJsonLd = JSON.stringify({
       <p class="text-sm text-gray-500 mb-6">* Si éligible au remboursement (IMC ≥ 35 avec comorbidité ou ≥ 40) ; votre mutuelle peut couvrir ce reste à charge.
         <a href="/outils/test-eligibilite/" style="color:#16a34a; font-weight:600;">Vérifiez votre éligibilité en 2 minutes →</a></p>
 
+      {/* Anti-cannibalisation : cette page cible "prix Mounjaro {city}". Sur la requete
+          generique "mounjaro prix", la page canonique est le guide national — on le dit
+          explicitement avec une ancre exacte pour reconcentrer l'autorite du cluster. */}
+      <p class="text-gray-700 mb-6" style="border-left:3px solid #16a34a; padding-left:12px;">
+        Ces tarifs sont réglementés et <strong>identiques dans toute la France</strong> : il n'existe pas de prix
+        propre à {city}. Pour le détail national (dosages, remboursement, reste à charge), consultez le guide de
+        référence <a href="/collections/glp1-cout/prix-mounjaro-france/" style="color:#16a34a; font-weight:600;">prix Mounjaro</a>.
+        Cette page sert à trouver <strong>où retirer votre traitement à {city}</strong>.
+      </p>
+
       <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Trouver Mounjaro en stock à {city}</h2>
       <p class="text-gray-700 mb-4">
         Toutes les pharmacies peuvent délivrer Mounjaro sur ordonnance, et commander sous 24-48 h si besoin.

--- a/src/pages/pharmacies/[ville]/prix-ozempic.astro
+++ b/src/pages/pharmacies/[ville]/prix-ozempic.astro
@@ -74,6 +74,15 @@ const faqJsonLd = JSON.stringify({
         <a href={`/pharmacies/${Astro.params.ville}/prix-mounjaro/`} style="color:#16a34a; font-weight:600;">Mounjaro</a>, remboursés à 65 % depuis le 15 juin 2026 —
         <a href="/outils/test-eligibilite/" style="color:#16a34a; font-weight:600;">testez votre éligibilité en 2 minutes →</a></p>
 
+      {/* Anti-cannibalisation : sur la requete generique "ozempic prix", la page
+          canonique est le guide national — ancre exacte pour reconcentrer l'autorite. */}
+      <p class="text-gray-700 mb-6" style="border-left:3px solid #16a34a; padding-left:12px;">
+        Ce tarif est réglementé et <strong>identique dans toute la France</strong> : il n'existe pas de prix
+        propre à {city}. Pour le détail national (remboursement 30 %, 100 % en ALD, reste à charge), consultez le
+        guide de référence <a href="/collections/glp1-cout/prix-ozempic-france/" style="color:#16a34a; font-weight:600;">prix Ozempic</a>.
+        Cette page sert à trouver <strong>où retirer votre traitement à {city}</strong>.
+      </p>
+
       <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Trouver Ozempic en stock à {city}</h2>
       <p class="text-gray-700 mb-4">
         La pénurie est terminée : l'ANSM a levé toutes les restrictions en juin 2025 et aucun GLP-1 ne figure sur la

--- a/src/pages/pharmacies/[ville]/prix-wegovy.astro
+++ b/src/pages/pharmacies/[ville]/prix-wegovy.astro
@@ -70,6 +70,15 @@ const faqJsonLd = JSON.stringify({
       <p class="text-sm text-gray-500 mb-6">* Si éligible au remboursement (IMC ≥ 35 avec comorbidité ou ≥ 40) ; votre mutuelle peut couvrir ce reste à charge.
         <a href="/outils/test-eligibilite/" style="color:#16a34a; font-weight:600;">Vérifiez votre éligibilité en 2 minutes →</a></p>
 
+      {/* Anti-cannibalisation : sur la requete generique "wegovy prix", la page
+          canonique est le guide national — ancre exacte pour reconcentrer l'autorite. */}
+      <p class="text-gray-700 mb-6" style="border-left:3px solid #16a34a; padding-left:12px;">
+        Ces tarifs sont réglementés et <strong>identiques dans toute la France</strong> : il n'existe pas de prix
+        propre à {city}. Pour le détail national (dosages, remboursement, reste à charge), consultez le guide de
+        référence <a href="/collections/glp1-cout/prix-wegovy-france/" style="color:#16a34a; font-weight:600;">prix Wegovy</a>.
+        Cette page sert à trouver <strong>où retirer votre traitement à {city}</strong>.
+      </p>
+
       <h2 class="text-2xl font-bold mb-3" style="color:#1a3c34;">Trouver Wegovy en stock à {city}</h2>
       <p class="text-gray-700 mb-4">
         Toutes les pharmacies peuvent délivrer Wegovy sur ordonnance, et commander sous 24-48 h si besoin.

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -349,6 +349,32 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Headers": "Authorization, Content-Type, apikey, x-client-info",
 };
 
+// --- Garde-fou prix (ceinture de sécurité déterministe) ---
+// La consigne de prompt suffit sur Groq 70B mais PAS sur le fallback
+// mistral-small-latest, qui recopie les fourchettes périmées du contexte RAG
+// (constaté en prod le 07/08/2026 : « 169 € à 360 € » pour Wegovy).
+// Les chunks déjà vectorisés portent encore ces valeurs jusqu'à réindexation,
+// donc on corrige la RÉPONSE, quel que soit le modèle qui l'a produite.
+const STALE_PRICE_RULES: Array<{ pattern: RegExp; replacement: string }> = [
+  // Wegovy : ancienne fourchette libre 169-360 € → prix réglementé juin 2026
+  { pattern: /\b169\s*(?:€|euros?)?\s*(?:à|a|-|–|—|et)\s*360\s*(?:€|euros?)/gi, replacement: "146,91 € à 195,10 €" },
+  // Mounjaro : ancienne fourchette 230-440 €
+  { pattern: /\b230\s*(?:€|euros?)?\s*(?:à|a|-|–|—|et)\s*440\s*(?:€|euros?)/gi, replacement: "176,10 € à 433,80 €" },
+];
+
+function sanitizePrices(text: string): { text: string; corrected: boolean } {
+  let corrected = false;
+  let out = text;
+  for (const { pattern, replacement } of STALE_PRICE_RULES) {
+    if (pattern.test(out)) {
+      corrected = true;
+      out = out.replace(pattern, replacement);
+    }
+    pattern.lastIndex = 0;
+  }
+  return { text: out, corrected };
+}
+
 function jsonResponse(body: object, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
@@ -904,6 +930,14 @@ Reste factuel, ne pose pas de diagnostic médical définitif, rappelle que la d�
             dossierData = null;
           }
         }
+      }
+
+      // Garde-fou prix : corrige les fourchettes périmées avant sauvegarde ET renvoi,
+      // y compris quand la réponse vient d'un modèle de secours.
+      const priceCheck = sanitizePrices(cleanResponse);
+      if (priceCheck.corrected) {
+        console.warn(`[price-guard] fourchette périmée corrigée (modèle: ${usedModel})`);
+        cleanResponse = priceCheck.text;
       }
 
       // Moment chaud → on propose la capture email (le funnel convertit à 0 sans capture).


### PR DESCRIPTION
Second run du 07/08. Le run du matin avait déjà couvert le quota (article FFJR + 2 fact-checks) ; ce run traite les 3 décisions laissées en attente et les bugs qui ont coûté un remboursement client.

## 1. Viewer du dossier livré — rendu inline (`src/pages/mon-espace/dossier/`)

**Cause racine du litige du 04/08 identifiée.** Supabase Storage sert les fichiers `.html` avec `content-type: text/plain` (protection anti-XSS côté storage), vérifié sur le lien réellement livré au client :

```
$ curl -D - <lien signé du dossier>
HTTP/2 200
content-type: text/plain
```

Le client voyait donc le code source brut — ce n'était pas un défaut de génération. Un contournement existait déjà (`fetch` → blob retypé `text/html` → `window.open`), mais `window.open()` appelé **après** une promesse `fetch` perd le geste utilisateur et se fait bloquer par les popup blockers (Safari/iOS en particulier) : le client clique, rien ne se passe.

Le dossier est désormais rendu dans un `iframe srcdoc` **dans la page courante** — pas de popup, pas de blocage, l'utilisateur reste sur le site. Le lien de téléchargement reste disponible en secours.

## 2. Garde-fou prix côté serveur (`supabase/functions/ai-coach/`)

Le smoke test du matin a montré `mistral-small-latest` (2ᵉ maillon de la chaîne LLM) servant « 169 € à 360 € » pour Wegovy — une fourchette d'avant juin 2026 que le prompt interdit explicitement. Le modèle de secours recopie les chunks RAG au lieu d'appliquer la consigne.

Les 13 articles porteurs de ces prix ont été corrigés ce matin, mais **les chunks déjà vectorisés gardent les anciennes valeurs jusqu'à réindexation**. Ajout d'un `sanitizePrices()` déterministe appliqué à la réponse avant sauvegarde et renvoi, quel que soit le modèle qui l'a produite :

- Wegovy `169-360 €` → `146,91 € à 195,10 €`
- Mounjaro `230-440 €` → `176,10 € à 433,80 €`

Une consigne de prompt ne peut pas être une garantie sur un modèle de secours ; un remplacement déterministe, si.

## 3. Anti-cannibalisation des pages prix ville

Application de l'option **(b)** proposée dans le rapport du matin (renforcer le maillage vers les pages nationales), après le décrochage de « mounjaro prix » (position 7,4 → 51,7, `prix-mounjaro-france` −53 % d'impressions).

Les liens vers les guides nationaux existaient déjà mais en bas de page, avec des ancres vagues (« Pour aller plus loin », « Guide national → »). Ajout d'un paragraphe contextuel **juste après le tableau de prix** sur les 3 pages prix ville, avec ancre exacte (`prix Mounjaro` / `prix Wegovy` / `prix Ozempic`) vers la page nationale.

Le texte est aussi honnête pour le lecteur qu'utile pour le SEO : les prix étant réglementés, il n'existe pas de prix propre à une ville — la page locale sert à trouver **où retirer** le traitement.

Option (c) (canonicals) écartée : elle désindexerait de fait une partie du cluster, c'est irréversible à court terme et le palier 2 n'a que 3 jours de recul.

## Hors diff (appliqué directement en base)

Table `email_suppression` créée (migration `create_email_suppression`) — ajout purement additif, aucune table existante touchée. Normalisation Gmail (points + sous-adressage `+tag`) via trigger, helper `is_email_suppressed()`, RLS activée sans policy publique.

Elle a immédiatement révélé que **5 personnes s'étaient désinscrites, pas 1** : `soraya.vous.m@`, `inezforbes2@`, `balbouy@` (27/07) et `charleneberaud.diet@` (26/04) n'avaient jamais été tracées. Vérification faite : **aucun envoi ne suit un STOP** (le plus serré est `balbouy@`, désinscrit 4 minutes après réception). Conformité intacte, et désormais garantie techniquement plutôt que par relecture manuelle.

## Vérifications

- `astro build` vert — 25 327 pages
- Rendu confirmé dans `dist/` : lien d'ancre exacte présent sur les pages prix ville, `srcdoc` présent sur la page dossier
- **0 occurrence Zepbound** dans le build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01766VF3Wj2DTepWPMjB4hd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01766VF3Wj2DTepWPMjB4hd3)_