### PR TITLE
report: résolution du taux Ozempic + CI edge functions

### DIFF
--- a/reports/daily-2026-08-07.md
+++ b/reports/daily-2026-08-07.md
@@ -364,3 +364,53 @@ Toujours en tête de `gsc-submission-queue.md`. C'est la dernière action manuel
 - **Réindexation RAG propre** : les chunks ont été corrigés par `regexp_replace` sur le texte ; leurs embeddings restent calculés sur l'ancien texte. Sans effet sur ce que lit le Coach (c'est le contenu qui est injecté), impact marginal sur la pertinence de récupération. Une réindexation complète reste souhaitable.
 - **Email de livraison J0 post-achat** (action 6 du plan K1) — toujours en attente. L'acheteur qui ferme l'onglet de retour Stripe n'a aucun moyen de retrouver son dossier.
 - **Jonction test d'éligibilité → Dossier** : à traiter au prochain run, après les 7 jours de mesure des encarts du 06/08.
+
+---
+
+## RÉSOLUTION — Taux de remboursement Ozempic (même jour, après retour de Robin)
+
+Robin a demandé de trancher et corriger. Fait.
+
+### La source
+
+| Fiche BDPM | Taux | Prix |
+|---|---|---|
+| [OZEMPIC 0,5 mg](https://base-donnees-publique.medicaments.gouv.fr/medicament/61400703/extrait) | **30 %** | 77,60 € |
+| [OZEMPIC 1 mg](https://base-donnees-publique.medicaments.gouv.fr/medicament/63210923/extrait) | **30 %** | 77,60 € |
+
+Mécanisme cohérent : l'avis HAS du 27/08/2025 juge le SMR « modéré » → taux 30 %. Le 65 % est le chiffre d'avant 2025. La HAS ne publiant que le SMR, il fallait remonter à la BDPM — d'où le blocage du run précédent.
+
+**Le `CLAUDE.md` et le prompt du Coach avaient raison.** C'étaient le site (46 fichiers) et les chunks RAG (67) qui étaient périmés. Le prompt n'a donc PAS été modifié.
+
+### Le piège évité
+
+**Trulicity et Victoza sont bien à 65 %** ([Trulicity](https://base-donnees-publique.medicaments.gouv.fr/medicament/63787647/extrait), [Victoza](https://base-donnees-publique.medicaments.gouv.fr/medicament/62645506/extrait)). Un remplacement global aurait introduit une erreur là où il n'y en avait pas.
+
+Règle appliquée : ne corriger que si Ozempic est le **dernier médicament cité** avant le taux, sans autre médicament intercalé, et hors contexte perte de poids/obésité. Le dry-run a effectivement attrapé un faux positif (`prix-glp1-pharmacie-tableau-2026.md:79`, où le 65 % portait sur Wegovy/Mounjaro malgré Ozempic cité avant) — exclu.
+
+Les phrases groupant les trois médicaments ont été **réécrites**, pas substituées : « remboursés à 30 % (Ozempic) ou 65 % (Trulicity, Victoza) ».
+
+### Périmètre corrigé
+
+- **46 fichiers source** (41 `.md` + 5 `.astro`) — PR #104
+- **Chunks RAG** : 0 occurrence « Ozempic … 65 % » restante, **132 chunks Wegovy/Mounjaro à 65 % intacts**, 41 chunks Ozempic désormais à 30 %. Deux titres de section `80,18 €` alignés sur `77,60 €`.
+- La distinction « 65 % bithérapie / 30 % trithérapie » devient sans objet (taux unique) : formulations aplaties dans 8 fichiers.
+
+### Trouvaille annexe (sérieuse)
+
+La recherche a mis au jour des pages `.astro` — **dont la home** — affirmant encore que « Wegovy, Mounjaro et Saxenda ne sont **pas** remboursés », faux depuis le 15/06/2026 pour les deux premiers. Le comparateur mutuelle annonçait même une prise en charge « attendue au 2ᵉ semestre 2026 ». Corrigé : `index.astro`, `comparateur-mutuelle-glp1.astro`, `calculateur-cout.astro`, `nouveaux-medicaments-perdre-poids.astro`.
+
+**Leçon** : les audits de contenu ne couvraient que `src/content/`. Les pages `.astro` (outils, guides, home) portent aussi des affirmations factuelles et échappaient au fact-check. À intégrer au protocole C6.
+
+### Vérifié en production
+
+- `/collections/traitements-glp1/guide-complet-ozempic/` → « remboursé à **30 %** en bithérapie metformine »
+- Home → « Depuis le 15 juin 2026, Wegovy et Mounjaro sont remboursés à 65 % » + « Ozempic … 30 % »
+- `/collections/glp1-cout/prix-wegovy-france/` → 45 mentions de 65 % préservées
+- 0 occurrence « Ozempic … 65 % » sur les pages clés
+
+### Déploiement des edge functions — PR #105 mergée
+
+Découper un déploiement d'edge function est impossible : l'API remplace la fonction entière, chaque envoi porte tous les fichiers. Le vrai « petit à petit » est de déployer **à chaque merge**. Workflow `deploy-edge-functions.yml` créé : déclenché sur `supabase/functions/**`, il ne déploie que les fonctions réellement modifiées (diff du commit précédent).
+
+**Action Robin restante** : ajouter le secret `SUPABASE_ACCESS_TOKEN` (https://supabase.com/dashboard/account/tokens). Les secrets existants donnent accès à la base, pas au déploiement. Tant qu'il manque, le workflow échoue proprement sans rien casser. Une fois ajouté, le garde-fou prix `sanitizePrices()` partira automatiquement.


### PR DESCRIPTION
Ajoute au rapport du 07/08 la section de résolution du taux de remboursement Ozempic. Le code correspondant est déjà parti dans #104 et #105 ; cette PR ne contient que le rapport.

Points consignés :

- **Le taux est 30 %**, source BDPM sur les deux dosages. Le `CLAUDE.md` et le prompt du Coach avaient raison — c'étaient le site et les chunks RAG qui étaient périmés. Le prompt n'a donc pas été touché.
- **Trulicity et Victoza restent à 65 %** : la règle de correction exigeait qu'Ozempic soit le dernier médicament cité avant le taux, hors contexte obésité. Un faux positif a été attrapé au dry-run et exclu.
- **Leçon de méthode** : les audits de contenu ne couvraient que `src/content/`. Les pages `.astro` (home, outils, guides) portent aussi des affirmations factuelles et échappaient au fact-check — c'est là qu'on a trouvé « Wegovy, Mounjaro et Saxenda ne sont pas remboursés », faux depuis le 15/06/2026. À intégrer au protocole C6.
- **Action restante pour Robin** : ajouter le secret `SUPABASE_ACCESS_TOKEN` pour activer le déploiement automatique des edge functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01766VF3Wj2DTepWPMjB4hd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01766VF3Wj2DTepWPMjB4hd3)_