### PR TITLE
Run 2 07/08 : article Ozempic 2 mg, garde-fou éligibilité Coach, fact-check

### DIFF
--- a/content-plan.md
+++ b/content-plan.md
@@ -34,9 +34,9 @@ Ce fichier est la **source de vérité** de la création de contenu. La routine 
 
 ### P4 — Fond de roadmap
 
-- [ ] **10. Camp / séjour perte de poids pour adulte en France ("fat camp")** — `retraites-bien-etre`. Preuve : "camp perte de poids france" + "fat camp france" (pos 7 !) en imp sur le cluster. Suivi : —
-- [ ] **11. Peau relâchée après perte de poids GLP-1 : solutions (sport, nutrition, médecine esthétique)** — `effets-secondaires-glp1`. Pont vers retraites/Morpheus8 SANS promesse commerciale. Suivi : —
-- [ ] **12. Ozempic 2 mg : pourquoi il n'est pas disponible en France** — `traitements-glp1`. FAQ récurrente de la page prix, format court. Suivi : —
+- [x] **10. Camp / séjour perte de poids pour adulte en France ("fat camp")** — DÉJÀ COUVERT (constat routine 07/08 run 2) : article `camp-perte-de-poids-adulte-france-prix-avis` publié le 14/07/2026, live 200. L'item était resté non coché par erreur. Suivi : —
+- [x] **11. Peau relâchée après perte de poids GLP-1** — DÉJÀ COUVERT partiellement (constat routine 07/08 run 2) : article `glp1-relachement-cutane-peau-corps-perte-poids-solutions` (effets-secondaires-glp1) publié le 17/03/2026, live 200. ⚠️ MAIS : byline fictive "Dr. Sophie Dubois", thumbnail réutilisé (`effets-secondaires-ozempic-illus.jpg`), pas mis à jour depuis mars, pas de pont vers /retraites/. Refonte > 30 % = décision Robin (signalé au rapport du 07/08 run 2).
+- [x] **12. Ozempic 2 mg : pourquoi il n'est pas disponible en France** — publié le 07/08/2026 (run 2) → https://glp1-france.fr/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/ — sources : Vidal gamme Ozempic 86313 (3 dosages commercialisés FR, 2 mg absent), communiqués Novo Nordisk (CHMP 12/11/2021, SUSTAIN FORTE 17/11/2020 : HbA1c −2,2 vs −1,9 pts, objectif <7 % 68 % vs 58 %), Lancet Diabetes Endo (SUSTAIN FORTE, 961 patients, 40 sem), ANSM (encadrement Ozempic diabète T2), ameli/ANSM CP 01/03/2023 (surveillance mésusage). Maillage entrant : prix-ozempic-france (tableau dosages) + nouveau-stylo-ozempic-3ml (FAQ) + glp1-syndrome-metabolique (correction dosages). Suivi : imp J+7 (~14/08) : — ; imp J+30 (~06/09) : —
 
 ## Backlog candidat (ajouts de la routine — publiables au run suivant leur ajout, veto Robin 24h)
 

--- a/public/images/thumbnails/ozempic-2-mg-pourquoi-pas-disponible-france.svg
+++ b/public/images/thumbnails/ozempic-2-mg-pourquoi-pas-disponible-france.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Ozempic 2 mg : dosage non commercialisé en France">
+  <defs>
+    <linearGradient id="bgoz2mg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1a3c34"/>
+      <stop offset="1" stop-color="#0f2620"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bgoz2mg)"/>
+
+  <!-- echelle de dosage : 4 paliers, le dernier barre -->
+  <g font-family="Arial, Helvetica, sans-serif" font-weight="bold" text-anchor="middle">
+    <!-- barres croissantes -->
+    <rect x="120" y="290" width="90" height="70" rx="10" fill="#16a34a" opacity="0.45"/>
+    <rect x="250" y="250" width="90" height="110" rx="10" fill="#16a34a" opacity="0.65"/>
+    <rect x="380" y="200" width="90" height="160" rx="10" fill="#16a34a"/>
+    <rect x="510" y="130" width="90" height="230" rx="10" fill="#e8f5ee" opacity="0.16" stroke="#e8f5ee" stroke-width="3" stroke-dasharray="10 8"/>
+
+    <text x="165" y="332" fill="#e8f5ee" font-size="26">0,25</text>
+    <text x="295" y="312" fill="#e8f5ee" font-size="26">0,5</text>
+    <text x="425" y="288" fill="#0f2620" font-size="30">1</text>
+    <text x="555" y="252" fill="#e8f5ee" font-size="30" opacity="0.85">2</text>
+    <text x="360" y="402" fill="#e8f5ee" font-size="24" opacity="0.8">mg / semaine</text>
+  </g>
+
+  <!-- interdit sur le palier 2 mg -->
+  <g transform="translate(555 195)">
+    <circle r="46" fill="none" stroke="#e8f5ee" stroke-width="9"/>
+    <line x1="-30" y1="-30" x2="30" y2="30" stroke="#e8f5ee" stroke-width="9" stroke-linecap="round"/>
+  </g>
+
+  <!-- stylo injecteur stylise -->
+  <g transform="translate(688 96) rotate(35)">
+    <rect x="-14" y="-70" width="28" height="150" rx="12" fill="#16a34a"/>
+    <rect x="-14" y="-70" width="28" height="34" rx="12" fill="#e8f5ee"/>
+    <rect x="-4" y="80" width="8" height="26" fill="#e8f5ee"/>
+  </g>
+
+  <!-- titre -->
+  <g font-family="Arial, Helvetica, sans-serif">
+    <text x="60" y="84" fill="#e8f5ee" font-size="44" font-weight="bold">Ozempic 2 mg</text>
+    <text x="60" y="126" fill="#16a34a" font-size="28" font-weight="bold">indisponible en France</text>
+  </g>
+</svg>

--- a/reports/daily-2026-08-07-run2.md
+++ b/reports/daily-2026-08-07-run2.md
@@ -1,0 +1,52 @@
+# Rapport quotidien — 7 août 2026 (run 2, soir)
+
+**Alertes** : aucune alerte critique. Site live OK (home 200, redirect zepbound → guide-complet-mounjaro 301, sitemap-0.xml 200). Fraîcheur : GA à jour (07/08), GSC 04/08 (3 j de retard — normal, seuil d'alerte à 5 j). Aucune donnée GSC nouvelle depuis le run 1 du matin.
+
+Ce run 2 est un run d'**exécution** : le volet analyse complet (KPIs K1-K6, WoW pages, audit du jour) a été couvert par le run 1 du matin (`daily-2026-08-07.md`) et les données GSC n'ont pas bougé depuis. Ce rapport se concentre sur ce qui a changé en cours de journée et sur les actions exécutées.
+
+---
+
+## A0. MONÉTISATION
+
+1. **Ventes Dossier** : 0 payé sur 24 h (total cumulé 3 payés, net 2 après le remboursement Mazzella du 04/08).
+2. **Événement du jour : 1 dossier créé aujourd'hui** (philippepayrastre2107@gmail.com, formulaire, `stripe_session_id` présent = checkout Stripe tenté, non payé). C'est la **2e tentative de checkout de la semaine** — le funnel produit à nouveau des intentions d'achat. Relance : le cron quotidien `relance-dossiers-daily` (08 h UTC) le relancera automatiquement demain matin — aucune action manuelle nécessaire, à vérifier au prochain run (`relance_sent_at`).
+3. **Funnel (7 j)** : `/outils/test-eligibilite/` 43 sessions (dont 13 la veille — la dynamique post-encarts du 06/08 se confirme), `/dossier-glp1/` 12 sessions (8 organic, 3 email, 1 direct). La séquence email J+3/J+7 génère des visites landing (source `email`).
+4. **Leads test d'éligibilité** : 0 nouveau sur 24 h (dernier : 06/08, J0 déjà envoyé au run 1). Échéances : J+3 pour nssmnr22@gmail.com demain 08/08, J+3 pour hiba.pg89@gmail.com le 09/08 — à envoyer au prochain run.
+5. **Coach (7 j)** : 29 conversations, 5 réponses proposant le Dossier (17 %), 0 `[[DOSSIER_READY]]` — attendu : depuis v63 le Coach envoie vers le test au lieu de collecter en chat ; le KPI à suivre devient le referral chat → `/outils/test-eligibilite/`.
+6. **Suivi post-achat** : KYM (22/07) et Françoise Cardon (24/07) toujours sans réponse aux emails de satisfaction. Marion Mazzella : dossier clos (remboursée le 04/08, aucun email entrant depuis). Aucune réponse client nouvelle dans `incoming_emails` sur 24 h (uniquement du spam « sophia*@163.com »).
+
+## A. SEO RECOVERY WATCH (delta depuis run 1)
+
+- **Recovery GA** : 49 % (451 sessions le 06/08 ; 12 sessions comptabilisées pour le 07/08 en cours). Moyenne 7 j ≈ 52 % — plateau confirmé.
+- **Recovery GSC** : 25 % (26 clics le 04/08, dernière date dispo — inchangé depuis run 1).
+- Le recul GSC des 03-04/08 (27 puis 26 clics vs 50-57 fin juillet) reste porté par le décrochage de la page prix Ozempic analysé au run 1 (requête « ozempic prix » : 2 363 imp/7 j pour 21 clics, CTR 0,9 %). Rien de nouveau à analyser sans données GSC fraîches — prochaine analyse WoW dès que la date 05/08+ arrive.
+- Pages Mounjaro (redirections Zepbound) : prix-mounjaro-france 4 clics/668 imp 7 j ; les pages prix ville/dept du cluster pharmacies continuent de prendre des clics (Aix, dept 64, Toulon).
+
+## B. MONITORING COACH IA (24 h)
+
+**KPIs** : 10 messages, 3 conversations (veille : 24 messages) ; modèles : llama-3.3-70b x4, mistral-small (fallback) x1 ; intents : price x3, scam:high x1, general x1. **0 mention Zepbound** (conformité OK). Dossiers : 3 `generated` / 4 `pending` ; 1 créé sur 24 h (voir A0).
+
+**Analyse des 3 conversations** :
+1. `2b4fbdb9` (08 h 04 UTC) : 1re réponse correcte (prix Wegovy 147-195 €, proposition de vérif) ; **2e réponse fautive : « 169 € et 360 € par mois »** (fourchette libre périmée, servie par le fallback mistral). Horodatage : 32 secondes après le déploiement v63 (08 h 03 min 45) — réponse servie par une instance v62 encore chaude. **Pas un bug actif** : le garde-fou `sanitizePrices` de v63 couvre exactement cette fourchette (169-360 → 146,91-195,10). À surveiller : plus aucune occurrence ne doit apparaître.
+2. `473f77d6` (16 h 54 UTC, **post-v63**) : « Suis-je éligible au remboursement de Mounjaro ? » → le Coach a listé les critères en bloc puis demandé comorbidité + poids + taille d'un coup, **sans donner le lien du test** — violation de la règle v63 (« lien direct EN PREMIER, jamais les critères en bloc »). Le LLM ne suit pas la consigne de façon fiable → **fix déterministe déployé ce run (v64)**, voir C.
+3. `ebef802b` (18 h 16 UTC) : prix Wegovy et Mounjaro corrects, calcul du reste à charge à 65 % correct (~51-68 € Wegovy), proposition de vérif d'éligibilité. Bon comportement. Nota : arrondis à ±0,30 € près sur le reste à charge (calcul 35 % fait par le LLM) — acceptable.
+
+**Divers** : l'intent `scam:high` sur « Combien coûte Wegovy et est-ce que je peux être remboursé ? » (conv 1) est un faux positif de classification (pattern prix+achat) — sans effet visible sur la réponse, non corrigé ce run (surveillance).
+
+## C. ACTIONS EXÉCUTÉES
+
+1. **C5 — Article du plan publié (#12)** : « Ozempic 2 mg : pourquoi ce dosage n'est pas disponible en France » → `/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/`. Chaque chiffre sourcé (Vidal gamme 86313, communiqués Novo Nordisk CHMP 12/11/2021 + SUSTAIN FORTE, Lancet Diabetes Endo, ANSM, CP ameli/ANSM 01/03/2023). FAQ schema 4 questions, thumbnail SVG unique (DA verte), 7 liens sortants dont funnel (test d'éligibilité), 3 liens entrants ajoutés dans le même commit (prix-ozempic-france, nouveau-stylo-ozempic-3ml, glp1-syndrome-metabolique). 1 URL ajoutée à la file GSC.
+2. **C5 bis — Constat plan** : items #10 (fat camp) et #11 (peau relâchée) déjà couverts par des articles existants (14/07 et 17/03) restés non cochés — plan mis à jour. #11 a des défauts (voir « EN ATTENTE »).
+3. **C6 — Fact-check rotatif (2 plus anciens)** :
+   - `reprise-poids-glp1-4-fois-plus-rapide-etude-2026` : **OK** — le « 4x plus rapide » et le retour au poids initial sous ~18 mois sont confirmés (revue Oxford, BMJ 07/01/2026, 37 études, ~9 300 participants). Amélioration : lien source BMJ/Oxford ajouté (l'article n'avait aucune source externe). `last_fact_checked` mis à jour.
+   - `glp1-syndrome-metabolique-traitement-composantes` : **corrigé x2** — (a) « Ozempic 0,5, 1 ou 2 mg » → dosages français réels 0,25/0,5/1 mg + lien vers le nouvel article 2 mg ; (b) FAQ prescription : ajout de la nuance primo-prescription CSO/CHU obligatoire pour le remboursement obésité 65 % (depuis 15/06/2026). `last_fact_checked` mis à jour.
+4. **C2 — Fix Coach IA (v64)** : garde-fou déterministe « éligibilité → lien du test » dans `ai-coach/index.ts` — si la réponse demande le poids/la taille sans que le lien `/outils/test-eligibilite/` ait été donné dans la conversation, le lien est ajouté automatiquement en fin de réponse (même mécanique que le garde-fou prix). Corrige la non-adhérence LLM constatée en conv `473f77d6`. Déploiement via le workflow CI edge functions (push main, mis en place au run 1 — PR #105) ; version attendue v64, vérifiée après merge.
+5. **Build check local avant merge** : `astro build` vert — 25 328 pages, article présent dans dist + sitemap-0.xml.
+
+## D. AUDIT DU JOUR
+
+Couvert au run 1 du matin (dimension du jour + analyse WoW). Pas de second audit ce run — les findings du run 1 restent la référence du jour.
+
+## EN ATTENTE DE DÉCISION ROBIN
+
+1. **Refonte de l'article « peau relâchée » (`glp1-relachement-cutane-peau-corps-perte-poids-solutions`)** : l'item #11 du plan est couvert par un article de mars qui a une **byline fictive « Dr. Sophie Dubois »** (risque E-E-A-T déjà signalé le 14/07), un **thumbnail réutilisé** d'un autre article, aucune mise à jour depuis mars et aucun pont vers /retraites/ (l'angle du plan). Une remise à niveau dépasserait 30 % de réécriture → décision nécessaire. Proposition : réécriture complète byline « Rédaction GLP-1 France » + thumbnail dédié + section pont retraites, au prochain run si accord.

--- a/reports/gsc-submission-queue.md
+++ b/reports/gsc-submission-queue.md
@@ -21,6 +21,7 @@ La routine AJOUTE ici a chaque publication — elle ne relance jamais dans le ch
 - [ ] https://glp1-france.fr/collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/
 - [ ] https://glp1-france.fr/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/
 - [ ] https://glp1-france.fr/collections/retraites-bien-etre/jeune-randonnee-organisateurs-ffjr-comparatif-prix/ (article 07/08)
+- [ ] https://glp1-france.fr/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/ (article 07/08 run 2)
 
 ## Soumises
 

--- a/src/content/glp1-cout/prix-ozempic-france.md
+++ b/src/content/glp1-cout/prix-ozempic-france.md
@@ -104,7 +104,7 @@ Le **prix Ozempic en pharmacie** en France est fixé à **77,60€ TTC par stylo
 | 1 mg | 77,60 € | 77,60 € (1 stylo = 4 doses) |
 | 2 mg | AMM européenne, non commercialisé en France | — |
 
-**Prix mensuel** : 77,60 € quel que soit le dosage (chaque stylo contient 4 doses, soit 1 stylo/mois)
+**Prix mensuel** : 77,60 € quel que soit le dosage (chaque stylo contient 4 doses, soit 1 stylo/mois). Pourquoi le dosage 2 mg n'est-il jamais arrivé en pharmacie française ? Explications complètes dans notre article [Ozempic 2 mg : pourquoi ce dosage n'est pas disponible en France](/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/).
 
 <div style="background:#f0fdf4;border:2px solid #16a34a;border-radius:12px;padding:20px 24px;margin:24px 0;">
   <p style="margin:0 0 8px;font-weight:700;color:#1a3c34;font-size:1.05em;">Ozempic n'est remboursé que pour le diabète — pour la perte de poids, c'est Wegovy ou Mounjaro (65 %)</p>

--- a/src/content/glp1-perte-de-poids/glp1-syndrome-metabolique-traitement-composantes.md
+++ b/src/content/glp1-perte-de-poids/glp1-syndrome-metabolique-traitement-composantes.md
@@ -3,7 +3,7 @@ title: "GLP-1 et Syndrome Métabolique : Traitement des Composantes"
 description: "GLP-1 et syndrome métabolique : Ozempic, Wegovy et Mounjaro agissent sur l'obésité abdominale, l'HTA, la dyslipidémie et la glycémie."
 pubDate: 2026-03-18
 date: 2026-06-22
-updatedAt: 2026-06-22
+updatedAt: 2026-08-07
 author: "Dr. Sophie Dubois"
 category: "Perte de poids GLP-1"
 tags: ["glp1", "syndrome métabolique", "obésité abdominale", "HTA", "dyslipidémie", "glycémie", "ozempic", "wegovy", "mounjaro"]
@@ -123,7 +123,7 @@ Il est important de noter que ces effets sont maintenus tant que le traitement e
 
 ### Ozempic (sémaglutide injectable) : si diabète de type 2 associé
 
-[Ozempic](/collections/traitements-glp1/guide-complet-ozempic/) (sémaglutide 0,5 mg, 1 mg ou 2 mg) est indiqué pour le **diabète de type 2** et remboursé à 30 % en bithérapie metformine (100 % en ALD diabète) en France pour cette indication. C'est le choix de référence quand le syndrome métabolique est associé à un diabète de type 2 avéré. Son bénéfice cardiovasculaire est prouvé par les études SUSTAIN-6 et SELECT.
+[Ozempic](/collections/traitements-glp1/guide-complet-ozempic/) (sémaglutide 0,25 mg, 0,5 mg ou 1 mg — le [dosage 2 mg n'est pas commercialisé en France](/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/)) est indiqué pour le **diabète de type 2** et remboursé à 30 % en bithérapie metformine (100 % en ALD diabète) en France pour cette indication. C'est le choix de référence quand le syndrome métabolique est associé à un diabète de type 2 avéré. Son bénéfice cardiovasculaire est prouvé par les études SUSTAIN-6 et SELECT.
 
 ### Wegovy (sémaglutide 2,4 mg) : si obésité sans diabète
 
@@ -150,7 +150,7 @@ Le remboursement dépend de l'indication. Pour le diabète de type 2, Ozempic es
 
 ### Mon médecin traitant peut-il prescrire un GLP-1 pour syndrome métabolique ?
 
-Oui. Depuis 2025, la prescription de GLP-1 peut être initiée par tout médecin (généraliste ou spécialiste) pour les indications reconnues. Si votre médecin estime que vous remplissez les critères d'indication, il peut prescrire. Il peut aussi vous orienter vers un spécialiste (endocrinologue, diabétologue, nutritionniste) pour un avis.
+Oui pour la prescription simple : tout médecin (généraliste ou spécialiste) peut prescrire un GLP-1 dans les indications reconnues. Attention toutefois : pour bénéficier du **remboursement à 65 % dans l'obésité** (Wegovy, Mounjaro), la primo-prescription doit être faite dans un centre spécialisé de l'obésité (CSO) ou un CHU depuis le 15 juin 2026 — le généraliste prend ensuite le relais pour les renouvellements. Pour Ozempic dans le diabète de type 2, le généraliste peut initier directement.
 
 ### Combien de temps faut-il pour que les GLP-1 agissent sur le syndrome métabolique ?
 

--- a/src/content/glp1-perte-de-poids/reprise-poids-glp1-4-fois-plus-rapide-etude-2026.md
+++ b/src/content/glp1-perte-de-poids/reprise-poids-glp1-4-fois-plus-rapide-etude-2026.md
@@ -3,7 +3,7 @@ title: "Reprise de Poids après GLP-1 : 4× Plus Rapide"
 description: "Reprise de poids après arrêt GLP-1 : 4 fois plus rapide qu'après un régime classique. Causes biologiques et stratégies anti-effet rebond."
 pubDate: 2026-03-18
 date: 2026-03-18
-updatedAt: 2026-03-18
+updatedAt: 2026-08-07
 author: "Dr. Marie Dubois"
 category: "Perte de poids"
 tags: ["glp1", "reprise de poids", "arrêt traitement", "ozempic", "wegovy", "mounjaro", "effet yoyo", "données 2026"]
@@ -36,7 +36,7 @@ Une nouvelle étude publiée début 2026 vient chiffrer avec précision ce que l
 
 ### La reprise de poids : 4 fois plus rapide
 
-Jusqu'ici, les études STEP et SCALE avaient déjà montré que l'arrêt du sémaglutide ou du liraglutide entraînait une reprise significative du poids perdu. Mais les nouvelles analyses de 2026 affinent ce constat avec un chiffre marquant : la vitesse de reprise pondérale après arrêt des GLP-1 est environ **quatre fois supérieure** à celle observée après la fin d'un régime hypocalorique classique de même efficacité.
+Jusqu'ici, les études STEP et SCALE avaient déjà montré que l'arrêt du sémaglutide ou du liraglutide entraînait une reprise significative du poids perdu. Mais les nouvelles analyses de 2026 affinent ce constat avec un chiffre marquant : la vitesse de reprise pondérale après arrêt des GLP-1 est environ **quatre fois supérieure** à celle observée après la fin d'un régime hypocalorique classique de même efficacité. C'est la conclusion d'une revue systématique menée par l'[Université d'Oxford, publiée dans le BMJ le 7 janvier 2026](https://www.ox.ac.uk/news/2026-01-08-new-study-finds-stopping-weight-loss-drugs-linked-faster-regain-ending-diet), portant sur 37 études et environ 9 300 participants.
 
 En termes concrets, cela se traduit souvent par :
 

--- a/src/content/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation.md
+++ b/src/content/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation.md
@@ -144,7 +144,7 @@ Non. Le prix reste identique à celui de l'ancienne présentation : 76,58 € pl
 Non, les règles de conservation sont identiques : réfrigérateur avant ouverture, et 6 semaines maximum à température ambiante après la première utilisation. Notez simplement la date de première utilisation pour ne pas dépasser la limite de 6 semaines.
 
 **Novo Nordisk va-t-il aussi changer le conditionnement d'Ozempic 1 mg ?**
-Les informations disponibles en mars 2026 concernent spécifiquement le changement du conditionnement d'Ozempic 0,5 mg. Pour le 1 mg, renseignez-vous auprès de votre pharmacien ou consultez les communications officielles de l'ANSM.
+Les informations disponibles en mars 2026 concernent spécifiquement le changement du conditionnement d'Ozempic 0,5 mg. Pour le 1 mg, renseignez-vous auprès de votre pharmacien ou consultez les communications officielles de l'ANSM. À noter : la gamme française s'arrête à 1 mg — le dosage supérieur existe ailleurs mais [Ozempic 2 mg n'est pas commercialisé en France](/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/).
 
 **J'ai des difficultés à manipuler le nouveau stylo. Qui consulter ?**
 Votre pharmacien peut vous montrer le fonctionnement du nouveau stylo lors du retrait. Pour un guide détaillé, consultez notre article sur [comment s'injecter Ozempic](/collections/traitements-glp1/comment-s-injecter-glp1-guide-pratique-ozempic-wegovy-mounjaro/). Votre médecin traitant ou une infirmière peut également vous accompagner lors des premières injections si nécessaire.

--- a/src/content/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france.md
+++ b/src/content/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france.md
@@ -1,0 +1,72 @@
+---
+title: "Ozempic 2 mg : pourquoi ce dosage n'est pas disponible en France"
+description: "Le dosage Ozempic 2 mg est autorisé en Europe depuis 2022, mais introuvable en pharmacie française. Dosages réellement commercialisés, raisons de l'absence, alternatives remboursées et pièges à éviter."
+pubDate: 2026-08-07
+author: "Rédaction GLP-1 France"
+category: "Traitements GLP-1"
+tags: ["ozempic", "sémaglutide", "2 mg", "dosage", "diabète type 2", "france"]
+collection: "traitements-glp1"
+thumbnail: "/images/thumbnails/ozempic-2-mg-pourquoi-pas-disponible-france.svg"
+thumbnailAlt: "Ozempic 2 mg : dosage non commercialisé en France, explications"
+featured: false
+published: true
+schema: "Article"
+faqSchema:
+  - question: "Ozempic 2 mg existe-t-il vraiment ?"
+    answer: "Oui. Le dosage 2 mg d'Ozempic (sémaglutide) a reçu un avis favorable du comité européen CHMP en novembre 2021 pour le traitement du diabète de type 2, sur la base de l'essai SUSTAIN FORTE. Il est commercialisé dans plusieurs pays, mais pas en France : ni le Vidal ni la Base de données publique des médicaments ne référencent de présentation 2 mg sur le marché français."
+  - question: "Quels dosages d'Ozempic sont disponibles en France en 2026 ?"
+    answer: "Trois dosages sont commercialisés en France : 0,25 mg (dose d'initiation), 0,5 mg et 1 mg par injection hebdomadaire. Le prix public est identique quel que soit le dosage (77,60 € TTC le stylo, remboursé à 30 % dans le diabète de type 2, 100 % en ALD). La dose maximale atteignable avec les présentations françaises est donc 1 mg par semaine."
+  - question: "Que faire si 1 mg d'Ozempic ne suffit plus ?"
+    answer: "C'est une décision qui appartient au médecin, jamais au patient. Les options documentées : réévaluer le traitement global du diabète, ou discuter d'un autre GLP-1 disponible en France à doses supérieures — Mounjaro (tirzépatide) va jusqu'à 15 mg par semaine dans le diabète de type 2. Ne doublez jamais vous-même les injections de 1 mg pour « faire » 2 mg : la titration et la sécurité n'ont été évaluées que dans le cadre des essais cliniques."
+  - question: "Peut-on acheter Ozempic 2 mg sur internet ?"
+    answer: "Non. En France, un médicament à prescription obligatoire ne peut jamais être vendu en ligne légalement. Les sites qui proposent « Ozempic 2 mg » à la vente directe — souvent des boutiques de « peptides » — opèrent illégalement et exposent à des contrefaçons dangereuses. Le circuit légal reste : ordonnance, puis pharmacie physique."
+mainKeyword: "ozempic 2 mg france"
+secondaryKeywords: ["ozempic 2 mg disponible france", "ozempic dosage maximum", "ozempic 2 mg prix", "sustain forte semaglutide 2 mg", "ozempic 1 mg ne suffit plus"]
+---
+
+C'est une question qui revient régulièrement de la part de patients diabétiques bien informés : Ozempic existe en dosage 2 mg dans d'autres pays, alors pourquoi votre pharmacien ne peut-il pas le commander en France ? La réponse courte : le dosage est bien **autorisé en Europe depuis 2022, mais il n'a jamais été commercialisé sur le marché français**. Voici ce qui est vérifiable — et ce qu'il ne faut surtout pas faire en attendant.
+
+## Ozempic 2 mg existe : ce que disent les essais
+
+Le dosage 2 mg de sémaglutide n'est pas une rumeur. Novo Nordisk l'a développé pour les patients diabétiques de type 2 dont la glycémie reste insuffisamment contrôlée à 1 mg, et l'a testé dans l'essai de phase 3b **SUSTAIN FORTE** (961 patients, 40 semaines, publié dans [The Lancet Diabetes & Endocrinology](https://www.thelancet.com/journals/landia/article/PIIS2213-8587(21)00174-1/abstract)) : la dose de 2 mg a réduit l'hémoglobine glyquée (HbA1c) de **2,2 points**, contre 1,9 point pour la dose de 1 mg, et **68 %** des patients sous 2 mg ont atteint l'objectif d'HbA1c < 7 %, contre 58 % sous 1 mg ([communiqué Novo Nordisk](https://www.globenewswire.com/news-release/2020/11/17/2128457/0/en/Once-weekly-semaglutide-2-0-mg-demonstrates-superior-reduction-in-HbA1c-vs-once-weekly-semaglutide-1-0-mg-in-people-with-type-2-diabetes-in-the-SUSTAIN-FORTE-trial.html)).
+
+Sur cette base, le comité européen des médicaments (CHMP) a rendu un **avis favorable le 12 novembre 2021** pour étendre l'autorisation d'Ozempic au dosage 2 mg dans le diabète de type 2, avec un lancement européen annoncé pour le premier semestre 2022 ([communiqué Novo Nordisk](https://www.globenewswire.com/news-release/2021/11/12/2333189/0/en/Ozempic-2-0-mg-recommended-for-approval-for-the-treatment-of-type-2-diabetes-by-the-European-Medicines-Agency.html)).
+
+## En France : trois dosages, et c'est tout
+
+Quatre ans plus tard, le constat est sans ambiguïté. La [gamme Ozempic référencée par le Vidal](https://www.vidal.fr/medicaments/gammes/ozempic-86313.html) pour le marché français comprend exactement trois dosages commercialisés :
+
+| Dosage | Statut en France | Prix public | Remboursement |
+|---|---|---|---|
+| 0,25 mg (initiation) | Commercialisé | 77,60 € TTC | 30 % (diabète T2), 100 % en ALD |
+| 0,5 mg | Commercialisé (nouveau stylo 3 ml) | 77,60 € TTC | 30 % (diabète T2), 100 % en ALD |
+| 1 mg | Commercialisé | 77,60 € TTC | 30 % (diabète T2), 100 % en ALD |
+| **2 mg** | **Non commercialisé** | — | — |
+
+Aucune présentation « Ozempic 2 mg » n'apparaît ni au Vidal ni dans la Base de données publique des médicaments : en France, **la dose hebdomadaire maximale atteignable avec les stylos disponibles est 1 mg**. Le détail des prix et du parcours de remboursement est dans notre [guide des prix Ozempic en France](/collections/glp1-cout/prix-ozempic-france/).
+
+## Pourquoi ce dosage n'est-il pas arrivé en France ?
+
+Novo Nordisk n'a jamais communiqué officiellement de raison spécifique à la France. En revanche, le contexte dans lequel ce lancement aurait dû se faire est documenté, et il explique beaucoup :
+
+- **Des tensions d'approvisionnement majeures dès 2022-2023.** La demande mondiale de GLP-1 a dépassé les capacités de production, au point que l'[ANSM a encadré la délivrance d'Ozempic](https://ansm.sante.fr/actualites/ozempic-semaglutide-un-medicament-a-utiliser-uniquement-dans-le-traitement-du-diabete-de-type-2) en rappelant qu'il devait être réservé aux diabétiques de type 2, avec priorité aux patients déjà traités. Lancer un nouveau dosage qui consomme deux fois plus de principe actif par stylo, sur un marché déjà en rupture, n'avait guère de sens industriel.
+- **Le mésusage surveillé en France.** L'ANSM et l'Assurance Maladie ont mis en place dès mars 2023 une surveillance renforcée des prescriptions d'Ozempic hors diabète ([communiqué commun](https://www.assurance-maladie.ameli.fr/presse/2023-03-01-cp-ansm-cnam-semaglutide)). Un dosage doublé aurait mécaniquement aggravé l'enjeu.
+- **La stratégie de gamme a évolué.** Pour la perte de poids, Novo Nordisk pousse [Wegovy, le sémaglutide dosé jusqu'à 2,4 mg](/collections/glp1-cout/prix-wegovy-france/), remboursé à 65 % dans l'obésité depuis le 15 juin 2026. Et en 2026, l'effort industriel français s'est porté sur le [remplacement des stylos 1,5 ml par le nouveau format 3 ml](/collections/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation/) — pas sur l'introduction du 2 mg.
+
+Résultat : le 2 mg est resté un produit d'export (il est vendu notamment aux États-Unis), sans inscription au remboursement français ni circuit de distribution en officine.
+
+## Mon médecin dit que 1 mg ne suffit plus : quelles options ?
+
+Si votre glycémie reste mal contrôlée à 1 mg, la réponse n'est **jamais** d'improviser. Trois points à retenir pour la consultation :
+
+1. **N'augmentez jamais la dose vous-même.** Faire deux injections de 1 mg pour simuler du 2 mg n'a été validé dans aucun cadre de soins français : la sécurité du 2 mg a été évaluée avec une titration précise, un stylo dédié et un suivi d'essai clinique.
+2. **Des alternatives à doses supérieures existent en France.** [Mounjaro (tirzépatide)](/collections/traitements-glp1/guide-complet-mounjaro/) monte jusqu'à 15 mg par semaine dans le diabète de type 2, avec des paliers progressifs. C'est au prescripteur d'évaluer si un changement de molécule est pertinent.
+3. **Si l'enjeu est le poids plus que la glycémie**, le cadre a changé : Wegovy et Mounjaro sont remboursés à 65 % dans l'obésité depuis juin 2026, sous conditions strictes. Notre [test d'éligibilité](/outils/test-eligibilite/) vous dit en une minute si vous entrez dans les critères avant d'en parler à votre médecin.
+
+## Le piège : les sites qui « vendent » Ozempic 2 mg
+
+Tapez « Ozempic 2 mg France » dans un moteur de recherche et vous trouverez des boutiques en ligne — souvent des sites de « peptides » — qui prétendent le vendre en direct. Rappel simple : en France, **un médicament à prescription obligatoire ne peut jamais être vendu en ligne**, même par une pharmacie agréée. Un site qui expédie de l'« Ozempic 2 mg » sans ordonnance vend au mieux un produit détourné, au pire une contrefaçon. Les précautions détaillées sont dans notre article sur [l'achat d'Ozempic sans ordonnance et ses risques](/collections/traitements-glp1/ozempic-sans-ordonnance-legal-risques/).
+
+## Ce qu'il faut retenir
+
+Ozempic 2 mg est un vrai médicament, autorisé en Europe, efficace dans les essais — et absent du marché français, où la gamme s'arrête à 1 mg. Ce n'est ni un oubli de votre pharmacien ni un produit « bientôt disponible » annoncé officiellement : aucune commercialisation française n'est à ce jour programmée publiquement. Si votre traitement actuel ne suffit plus, la discussion se joue avec votre médecin, autour des alternatives réellement disponibles et remboursées en France.

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -940,6 +940,18 @@ Reste factuel, ne pose pas de diagnostic médical définitif, rappelle que la d�
         cleanResponse = priceCheck.text;
       }
 
+      // Garde-fou éligibilité → lien du test : la règle du prompt (« lien direct
+      // avant toute collecte poids/taille ») n'est pas toujours suivie par le LLM.
+      // Si la réponse demande le poids/la taille sans que le lien du test ait été
+      // donné dans la conversation, on l'ajoute en fin de réponse.
+      const asksBodyData = /\b(ton|votre)\s+poids\b|poids\s+et\s+(ta|votre)\s+taille/i.test(cleanResponse);
+      const testLinkAlreadyGiven = cleanResponse.includes("/outils/test-eligibilite/")
+        || historyMessages.some((m: any) => m.role === "assistant" && typeof m.content === "string" && m.content.includes("/outils/test-eligibilite/"));
+      if (asksBodyData && !testLinkAlreadyGiven && !dossierData) {
+        console.warn(`[eligibility-guard] lien du test ajouté (modèle: ${usedModel})`);
+        cleanResponse += "\n\nLe plus rapide si tu préfères : notre [test d'éligibilité](/outils/test-eligibilite/) te donne le verdict en 1 minute (3 questions).";
+      }
+
       // Moment chaud → on propose la capture email (le funnel convertit à 0 sans capture).
       const saysEligible = /\béligibl/i.test(cleanResponse);
       const saysNotEligible = /\b(pas|plus)\b[^.]{0,25}éligibl|éligibl[^.]{0,25}\bsi\b/i.test(cleanResponse);


### PR DESCRIPTION
Routine quotidienne — run 2 du 07/08/2026.

## Contenu (C5 — plan de contenu, item #12)
- **Nouvel article** : « Ozempic 2 mg : pourquoi ce dosage n'est pas disponible en France » (`/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/`). Sources : Vidal (gamme 86313), communiqués Novo Nordisk (CHMP 12/11/2021, SUSTAIN FORTE), Lancet Diabetes Endo, ANSM, CP ameli/ANSM 01/03/2023. FAQ schema 4 questions, thumbnail SVG unique, 3 liens entrants ajoutés (prix-ozempic-france, nouveau-stylo-ozempic-3ml, glp1-syndrome-metabolique).
- content-plan.md : items #10 et #11 constatés déjà couverts, #12 coché ; file GSC +1 URL.

## Coach IA (C2)
- `ai-coach/index.ts` : garde-fou déterministe « éligibilité → lien du test » — si la réponse demande poids/taille sans que `/outils/test-eligibilite/` ait été donné dans la conversation, le lien est ajouté (non-adhérence LLM constatée en prod post-v63, conv du 07/08 16h54). Déploiement via le workflow CI edge functions au merge (v64 attendue).

## Fact-check (C6)
- `glp1-syndrome-metabolique-traitement-composantes` : dosages Ozempic corrigés (0,25/0,5/1 mg — pas de 2 mg en France) + nuance primo-prescription CSO/CHU pour le remboursement obésité.
- `reprise-poids-glp1-4-fois-plus-rapide-etude-2026` : chiffre « 4x » confirmé (revue Oxford/BMJ 07/01/2026) + lien source ajouté.

## Vérifications
- Build local vert : 25 328 pages, article présent dans dist + sitemap-0.xml.
- Rapport : `reports/daily-2026-08-07-run2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158yWn4upCXaXHfx6iTLJAd

---
_Generated by [Claude Code](https://claude.ai/code/session_0158yWn4upCXaXHfx6iTLJAd)_