### PR TITLE
Rapport 08/08 + fix Coach : garde-fou IMC énoncé directement (v65)

### DIFF
--- a/reports/daily-2026-08-08.md
+++ b/reports/daily-2026-08-08.md
@@ -1,0 +1,120 @@
+# Rapport quotidien — 08/08/2026
+
+## 🚨 ALERTES
+
+1. **[CORRIGÉE CE RUN] Erreur médicale du Coach IA en prod** : le 08/08 à 06h23, le Coach a affirmé à un utilisateur avec **IMC 33,2** (+ 5 comorbidités) qu'il était « éligible au remboursement à 65% » — FAUX (seuils officiels : IMC ≥ 35 + comorbidité, ou ≥ 40). Cause : le garde-fou serveur ne calculait l'IMC que depuis poids+taille ; un IMC énoncé directement (« imc de 33,2 ») passait sans verdict injecté. **Fix déployé : ai-coach v65** (extraction de l'IMC énoncé + verdict serveur), testé en prod avec le message exact → réponse désormais correcte (« vous n'êtes pas éligible »). Conversation concernée : `b9e28891-e4f4-470c-922f-6723a9edb6c3`.
+2. **Recovery GSC toujours < 50% et en érosion** : 25 clics le 05/08 = **23,6%** de la baseline (106), en baisse depuis le pic du 28/07 (57 clics). Critère d'alerte (recovery < 50% après le 20/07) toujours actif.
+3. **GA en baisse 3 jours consécutifs** (04→07/08 : 515 → 511 → 453 → 407) — à surveiller, le motif hebdo (vendredi plus faible) explique une partie mais pas tout.
+
+Aucune violation Zepbound détectée (redirect 301 OK, aucune mention dans les réponses Coach).
+
+---
+
+## A0. MONETISATION
+
+### Ventes Dossier (4,99 €)
+- **0 payé en 24h** — total cumulé : **3 payés/générés** (22/07, 24/07, 01/08).
+- **1 dossier créé en 24h** (07/08 17:54) : checkout Stripe lancé, **non payé**. Email présent → relance automatique envoyée le 08/08 08:00 (`dossier_relance` dans email_replies). À suivre au prochain run.
+- État table `dossiers` : 3 generated, 4 pending (tous les pending ont tenté le checkout et ont été relancés).
+
+### Funnel (7 derniers jours)
+- `/outils/test-eligibilite/` : **45 sessions** — en hausse depuis le déploiement des encarts CTA le 06/08 (6→9→13→9 sessions/j autour du déploiement).
+- `/dossier-glp1/` : **11 sessions**.
+- Leads `eligibility_test` : **3 en 7j, 0 en 24h**. Taux de capture ≈ 6,7% (baseline K6 : 9,3%) — légèrement sous la baseline, pas encore significatif sur 45 sessions.
+
+### KPIs vs baselines (04/08)
+- **K1 Exposition ≈ 1,9%** (56 sessions funnel / ~2 950 sessions site 7j) vs baseline 0,69% → **net progrès**, cohérent avec les encarts CTA carte-prix + pages prix déployés le 06/08. K1 reste le levier principal mais la tendance est bonne.
+- K2 Activation ≈ 18% (2 dossiers créés / 11 sessions landing) vs baseline 12% → OK.
+- K3 Paiement 7j : 1/2 = 50% = baseline.
+- K5 Coach : 5 réponses proposant le Dossier en 7j ; **0 [[DOSSIER_READY]] en 7j** — confirme que la collecte complète en chat ne se termine jamais ; le renvoi direct vers le test (règle prompt + garde-fou lien) est la bonne stratégie.
+
+### Suivi post-achat / relances
+- `dossier_satisfaction` envoyé le 04/08 (client 3, payé 01/08) — pas de réponse à ce jour.
+- Clients 1 et 2 (22/07, 24/07) : emails envoyés, toujours sans réponse.
+- Sync inbox opérationnelle (11 emails entrants sur 7j, dernier le 06/08).
+
+### Diagnostic de fuite
+Le goulot reste **le volume absolu** : 56 sessions funnel/7j ne peuvent produire que ~1-2 ventes/semaine à conversion constante. Les actions K1 (encarts) montent en charge ; prochaine étape déjà planifiée : encarts sur les pages prix ville/dept (palier 5 du plan K1) + email de livraison J0 (backlog point 6).
+
+---
+
+## A. SEO RECOVERY WATCH
+
+### Fraîcheur des données
+| Source | Dernière date | Retard |
+|---|---|---|
+| GA | 2026-08-08 | 0 j ✓ |
+| GSC | 2026-08-05 | 3 j (seuil alerte : >4 j) ✓ |
+
+### Site live
+- Home : **200** ✓ — Redirect zepbound → guide-complet-mounjaro : **301** ✓ — sitemap-0.xml : **200** ✓
+
+### Recovery Scores
+- **GA : 44,1%** (407 sessions le 07/08 vs baseline 922)
+- **GSC : 23,6%** (25 clics le 05/08 vs baseline 106) — le vrai thermomètre organique
+
+### 7 derniers jours
+| Date | GA sessions | % base | GSC clics | % base | GSC impr. |
+|---|---|---|---|---|---|
+| 01/08 | 324 | 35% | 36 | 34% | 1 981 |
+| 02/08 | 273 | 30% | 45 | 42% | 1 767 |
+| 03/08 | 467 | 51% | 27 | 25% | 1 538 |
+| 04/08 | 515 | 56% | 26 | 25% | 1 597 |
+| 05/08 | 511 | 55% | 25 | 24% | 2 086 |
+| 06/08 | 453 | 49% | — | — | — |
+| 07/08 | 407 | 44% | — | — | — |
+
+### Tendance
+- GA moyenne 7j : ~421 sessions (46%) vs ~467 (51%) la semaine précédente → **-10% WoW**, pente légèrement négative.
+- GSC clics : érosion continue depuis le 28/07 (57 → 25). Impressions stables (~1 500-2 100) mais **position moyenne dégradée** (19,6 le 27/07 → 25-28 début août), probablement diluée par l'indexation des nouvelles pages programmatiques (palier 2 déployé le 04/08) qui entrent en positions lointaines.
+- **Aucune projection de retour à 100% possible sur cette pente** — la tendance clics est négative, pas positive.
+
+### Pages : top actuel vs baseline (candidates réindexation)
+| Page | Clics 7j | Baseline (1-23/06) | État |
+|---|---|---|---|
+| /outils/carte-prix-pharmacies/ | 81 | 438 | 18% — leader mais loin de la base |
+| /collections/glp1-cout/prix-ozempic-france/ | 22 | 242 | 9% (2 515 impr., CTR 0,9% → C1 candidate) |
+| /collections/glp1-cout/prix-wegovy-france/ | 8 | 301 | 3% |
+| **/collections/glp1-cout/prix-mounjaro-france/** | **2** | **411** | **0,5% — pire écart** (606 impr., CTR 0,3%) |
+| /collections/glp1-cout/wegovy-remboursement-mutuelle/ | absent top 15 | 60 | à réindexer |
+| /collections/regime-glp1/regime-mounjaro-optimal/ | absent | 18 | à réindexer |
+
+→ Candidates à demande de réindexation GSC (déjà dans la file `gsc-submission-queue.md` pour la plupart) : prix-mounjaro-france, prix-wegovy-france, wegovy-remboursement-mutuelle, regime-mounjaro-optimal.
+
+### Pages Mounjaro (cibles 301 ex-Zepbound)
+prix-mounjaro-france : 2 clics / 606 impr. — le trafic Mounjaro passe surtout par les pages prix ville (aix, nimes, menton, st-etienne : 1-2 clics chacune). La page nationale a un problème de **position** (impressions là, clics absents), pas d'indexation.
+
+---
+
+## B. COACH IA (24h)
+
+### KPIs
+- **14 messages / 4 conversations / 7 messages user** (vs 24 messages la veille, -42%)
+- Modèles : llama-3.3-70b ×6, mistral-small ×1 — **100% LLM, 0 fallback-v1** ✓
+- Intents : price ×4, diabetes ×1, general ×1, prescription ×1
+
+### Analyse qualité (4 conversations)
+1. `b9e28891` — **ERREUR CRITIQUE (corrigée, voir alertes)** : IMC 33,2 + 5 comorbidités → le Coach a répondu « vous semblez éligible » puis « tu es éligible au remboursement à 65% » (2 réponses fausses, llama puis mistral). Le reste de la conversation était bon (orientation CSO, proposition Dossier au bon moment quand l'utilisateur a mentionné son endocrinologue à Cesson-Sévigné).
+2. `473f77d6` — « Suis-je éligible au remboursement de Mounjaro ? » : réponse correcte sur les critères mais collecte poids/taille en chat **sans donner le lien du test** (la règle prompt existait ; le garde-fou serveur v64 qui ajoute le lien a été déployé quelques heures après cette conversation).
+3. `90805798` — poches isothermes : bonne réponse, chiffres conformes aux règles de conservation, lien article pertinent. Intent mal classé (« price ») mais sans impact.
+4. `ebef802b` — prix Wegovy/Mounjaro remboursés : calculs 65% corrects, bonne relance éligibilité. Écart mineur : « 176,20 € et 434,20 € » pour Mounjaro au lieu de 176,10-433,80 € officiels (arrondi du modèle, ~0,4 € — non bloquant, à surveiller).
+- **Aucune mention Zepbound** ✓ — aucun fallback inutile — longueurs OK sauf réponse poches isothermes (un peu longue).
+
+### Dossiers
+- 3 generated / 4 pending (détail en A0). 1 créé en 24h (checkout non payé, relancé automatiquement).
+
+### Actions recommandées
+- Suivre au prochain run : plus aucun verdict « éligible » à IMC < 35 dans coach_messages (requête de contrôle sur les nouvelles conversations).
+- Optionnel : ajouter une règle sanitizePrices pour les arrondis Mounjaro (176,20/434,20 → 176,10/433,80) si l'écart réapparaît.
+
+---
+
+## C. ACTIONS EXÉCUTÉES CE RUN
+
+1. **Fix Coach IA — ai-coach v65 déployée via MCP** : nouvelle fonction `extractStatedImc()` (capte « imc de 33,2 », « mon IMC est 36.5 », exclut les citations de seuils « il faut un IMC de 35 ? ») + verdict serveur injecté même sans poids/taille. Regex validée sur 9 cas, déploiement testé en prod avec le message exact de la conversation fautive → verdict correct. Diff : `supabase/functions/ai-coach/index.ts` (+27 lignes). Conversation de test en base : session `routine-test-imc-guard-0808` (à exclure des stats).
+2. Rapport quotidien (ce fichier).
+
+Note périmètre : cette tâche planifiée est le **monitoring quotidien** (rapport A+B) — la publication d'article du content-plan (C5) relève de la tâche « GLP1 SEO ROUTINE », non déclenchée ici.
+
+## EN ATTENTE DE DÉCISION ROBIN
+- Rien de nouveau ce run. (Rappel file GSC : soumission manuelle des URLs dans `reports/gsc-submission-queue.md` quand tu veux — les pages prix nationales qui s'effondrent y figurent.)

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -294,7 +294,24 @@ function extractImc(userTexts: string[]): { imc: number; poids: number; taille: 
   return { imc, poids, taille };
 }
 
-function buildImcVerdictContext(imcData: { imc: number; poids: number; taille: number }): string {
+// IMC énoncé directement ("mon IMC est de 33,2", "avec un imc de 33.2") :
+// le calcul poids/taille ne capte pas ce cas et le LLM a rendu un verdict
+// "éligible" à un IMC de 33,2 le 08/08 — on injecte donc aussi le verdict
+// quand l'utilisateur donne son IMC sans poids ni taille.
+function extractStatedImc(userTexts: string[]): number | null {
+  for (const t of userTexts) {
+    const m = t.match(/\bimc\b\s*(?:est|était|etait|=|:|de|d'environ|autour de|a|à)?\s*(?:de\s*)?(\d{2}(?:[.,]\d{1,2})?)\b/i);
+    if (!m) continue;
+    // Exclure les citations de seuils réglementaires ("il faut un IMC de 35", "IMC ≥ 40")
+    const before = t.slice(Math.max(0, (m.index ?? 0) - 30), m.index ?? 0);
+    if (/(≥|>=|>|<|≤|<=|seuil|faut|minimum|au moins|inf[eé]rieur|sup[eé]rieur|dessous|dessus)/i.test(before)) continue;
+    const value = parseFloat(m[1].replace(',', '.'));
+    if (value >= 12 && value <= 80) return value;
+  }
+  return null;
+}
+
+function buildImcVerdictContext(imcData: { imc: number; poids: number | null; taille: number | null }): string {
   const { imc, poids, taille } = imcData;
   let verdict: string;
   if (imc >= 40) {
@@ -304,7 +321,10 @@ function buildImcVerdictContext(imcData: { imc: number; poids: number; taille: n
   } else {
     verdict = "NON ÉLIGIBLE au remboursement (IMC < 35, seuils : IMC ≥ 35 avec comorbidité ou IMC ≥ 40). INTERDICTION ABSOLUE de dire \"tu es éligible\" ou \"vous êtes éligible\". Dis-le avec tact et oriente vers le médecin pour évaluer d'autres options.";
   }
-  return `\n\n⚠️ VERDICT CALCULÉ PAR LE SYSTÈME (fiable, PRIORITAIRE sur tout autre calcul) : poids ${poids} kg, taille ${taille} cm → IMC = ${imc.toFixed(1)}. Verdict remboursement : ${verdict} Ta réponse DOIT être cohérente avec ce verdict — ne recalcule pas toi-même.`;
+  const source = poids !== null && taille !== null
+    ? `poids ${poids} kg, taille ${taille} cm → IMC = ${imc.toFixed(1)}`
+    : `IMC annoncé par l'utilisateur = ${imc.toFixed(1)}`;
+  return `\n\n⚠️ VERDICT CALCULÉ PAR LE SYSTÈME (fiable, PRIORITAIRE sur tout autre calcul) : ${source}. Verdict remboursement : ${verdict} Ta réponse DOIT être cohérente avec ce verdict — ne recalcule pas toi-même.`;
 }
 
 // --- Scam signal detection ---
@@ -805,7 +825,12 @@ serve(async (req) => {
       // Garde-fou éligibilité : IMC calculé côté serveur, verdict injecté
       const userTexts = [cleanMessage, ...historyMessages.filter((m: any) => m.role === 'user').map((m: any) => m.content).reverse()];
       const imcData = extractImc(userTexts);
-      const imcContext = imcData ? buildImcVerdictContext(imcData) : '';
+      const statedImc = imcData === null ? extractStatedImc(userTexts) : null;
+      const imcContext = imcData
+        ? buildImcVerdictContext(imcData)
+        : statedImc !== null
+          ? buildImcVerdictContext({ imc: statedImc, poids: null, taille: null })
+          : '';
 
       const userMessageWithContext = ragContext
         ? `Contexte factuel (utilise ces informations pour répondre sans mentionner leur source) :\n\n${ragContext}${linksHint}${scamContext}${doctorContext}${imcContext}\n\nQuestion de l'utilisateur : ${cleanMessage}`


### PR DESCRIPTION
## Contenu

- **Rapport quotidien** `reports/daily-2026-08-08.md` : SEO recovery (GA 44%, GSC 24% et en érosion), monétisation (0 vente 24h, 1 checkout abandonné relancé auto, K1 en net progrès à ~1,9% après les encarts CTA du 06/08), Coach IA (14 msgs / 4 conv, 100% LLM).
- **Fix Coach IA (erreur médicale détectée en prod le 08/08)** : le Coach a déclaré « éligible au remboursement à 65% » un utilisateur avec IMC 33,2 — les seuils officiels sont IMC ≥ 35 + comorbidité ou ≥ 40. Le garde-fou serveur ne calculait l'IMC que depuis poids+taille ; un IMC énoncé directement (« imc de 33,2 ») passait sans verdict injecté.
  - Nouvelle fonction `extractStatedImc()` dans `supabase/functions/ai-coach/index.ts` (capte l'IMC énoncé, exclut les citations de seuils type « il faut un IMC de 35 ? »).
  - `buildImcVerdictContext()` accepte désormais un IMC sans poids/taille.
  - **Déployé en prod : ai-coach v65** (via MCP). Testé avec le message exact de la conversation fautive → le Coach répond désormais correctement « non éligible ».

## Vérifications

- Regex validée sur 9 cas (IMC énoncé, seuils cités, poids/taille classiques).
- `tsc --noEmit` : aucune erreur de syntaxe introduite.
- Test end-to-end prod concluant (session de test `routine-test-imc-guard-0808`, à exclure des stats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACfy6iKy961qNpz932DqKd

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACfy6iKy961qNpz932DqKd)_