### PR TITLE
Routine 09/08 : garde-fou primo-prescription Coach (v66), fact-check cancer/cholestérol, rapport quotidien

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Le diagnostic de fuite (point 5) se fait en comparant chaque K a sa baseline : l
 1. **[ACTION ROBIN]** Soumettre `/outils/test-eligibilite/` en GSC (0 impression en 30j alors que la page est indexable — jamais indexee par Google depuis sa creation le 14/07). Ajoutee en tete de la file gsc-submission-queue.md.
 2. **[FAIT 06/08/2026 — go Robin « go CTA »]** Encart eligibilite sur `/outils/carte-prix-pharmacies/` (page n°1 du site, 1 872 sessions/30j). Suivre le trafic referral vers /outils/test-eligibilite/ dans les rapports A0.
 3. **[FAIT 06/08/2026 — go Robin « go CTA »]** Encart apres le tableau de prix des 3 pages prix nationales (angle Ozempic adapte : rembourse diabete seulement → renvoi Wegovy/Mounjaro 65 %).
-4. **[AUTONOME — A FAIRE au prochain run]** Coach IA : quand intent price/eligibility detecte, proposer le LIEN direct vers /outils/test-eligibilite/ au lieu de collecter poids/taille en chat (0 DOSSIER_READY en 7j, personne ne finit la collecte). Modif prompt systeme + deploy MCP.
+4. **[FAIT 07/08/2026 — v65]** Coach IA : lien direct vers /outils/test-eligibilite/ sur intent price/eligibility (regle prioritaire prompt + garde-fou deterministe post-reponse). Complete le 09/08 (v66) par un garde-fou primo-prescription (mistral-small affirmait que le generaliste peut initier la prescription remboursee).
 5. **[APRES 2-3]** Meme encart sur les pages prix ville/dept du cluster pharmacies.
 6. **[AUTONOME — backlog]** Email de livraison J0 automatique post-achat Dossier (« votre dossier est pret » + lien /mon-espace/dossier/) — actuellement l'acheteur qui ferme l'onglet de retour Stripe n'a aucun moyen de retrouver son dossier.
 Estimation actions 2+3 a 3 % de clic : K1 0,69 % → ~1,4 %, soit ~6 ventes/mois a K2-K4 constants.

--- a/content-plan.md
+++ b/content-plan.md
@@ -40,7 +40,7 @@ Ce fichier est la **source de vérité** de la création de contenu. La routine 
 
 ## Backlog candidat (ajouts de la routine — publiables au run suivant leur ajout, veto Robin 24h)
 
-_(vide — la routine ajoute ici : sujet, requête cible, preuve de demande chiffrée, collection proposée)_
+- [ ] **B1. Vita GLP : avis, arnaque, comment se faire rembourser ? (ajouté 09/08/2026, publiable à partir du 10/08 — veto Robin 24h)** — Preuve GSC : « vita glp service client » 257 imp/28j pos 7,8 + « vita glp contact téléphone » 128 imp/28j pos 8,8 (385 imp cumulées, on ranke top 10 SANS page dédiée). Preuve terrain : plaintes récurrentes dans `contacts` de victimes ayant commandé des gélules « GLP-1 » en ligne (débits doublés, produit jamais reçu, impossible de joindre le service client). Angle : page protection consommateur — ce qu'est Vita GLP, pourquoi les gélules « GLP-1 » vendues en ligne ne sont pas des agonistes GLP-1, démarches concrètes (opposition bancaire, signal.conso.gouv.fr, pré-plainte), renvoi vers les vrais traitements et le parcours remboursé. Collection : traitements-glp1. Cohérent avec l'intent scam déjà géré par le Coach.
 
 ## Publiés
 

--- a/reports/daily-2026-08-09.md
+++ b/reports/daily-2026-08-09.md
@@ -1,0 +1,101 @@
+# Rapport quotidien — 09/08/2026
+
+## ALERTES
+
+- **(d) Recovery GSC 39 %** (41 clics le 07/08 vs baseline 106) — toujours < 50 % après le 20/07. Situation connue, tendance clics en baisse WoW (-26 %) alors que les impressions montent (+~10 %, portées par le cluster pharmacies à positions basses).
+- **(c) Sessions GA en baisse 4 jours consécutifs** (511 → 453 → 408 → 256 du 05 au 08/08). Le 08/08 est un samedi (creux hebdomadaire récurrent), mais la semaine entière est molle : à surveiller lundi/mardi — si pas de rebond > 450, diagnostic requête par requête.
+- Aucune alerte critique : site live OK (home 200, redirect zepbound → mounjaro 301, sitemap 200), pas de mention Zepbound dans les réponses Coach, données fraîches (GA J-0, GSC J-2).
+
+---
+
+## A0. MONÉTISATION (Dossier GLP-1 4,99 €)
+
+### Ventes & dossiers
+- **0 dossier créé / 0 payé en 24 h.** Cumul : 7 dossiers, 3 payés (22/07, 24/07, 01/08), **dont 1 remboursé** → **2 ventes nettes**.
+- **Cas Mazzella (payé 01/08) clos** : réponse client 04/08 10:14 maintenant la demande de remboursement (déçue du contenu « réponse ChatGPT ») → email « Votre remboursement est fait » parti le 04/08 14:24. Aucun message d'elle depuis. À retenir produit : la valeur perçue du dossier généré est le point faible (1 remboursement sur 3 ventes).
+- 4 dossiers pending avec tentative de checkout : tous relancés (dernier : philippepayrastre, relance 08/08 08:00). Aucune conversion post-relance à ce jour.
+- Suivi satisfaction : client 1 (22/07, email 23/07) et client 2 (24/07, email 27/07) — toujours aucune réponse.
+
+### Funnel (30 j glissants) — KPIs vs baseline 04/08
+| KPI | Valeur | Baseline | Verdict |
+|---|---|---|---|
+| K1 Exposition | **0,99 %** (144/14 515) | 0,69 % | ↗ +43 % (effet encarts 06/08) |
+| K2 Activation | 12,5 % (6/48) | 12 % | stable |
+| K3 Paiement | 50 % (3/6) | 50 % | stable |
+| K4 Conversion funnel | 2,1 % (3/144) | 2,9 % | ↘ (trafic test monte plus vite que les ventes) |
+| K5 Coach | **22 %** (7 propositions/32 conv 7j) | 11 % | ↗ x2 |
+| K6 Capture test | 7,3 % (7/96) | 9,3 % | ↘ léger |
+
+- **Goulot toujours K1**, mais en amélioration (0,69 → 0,99 %). Le levier n°1 restant : **soumission GSC de /outils/test-eligibilite/** (toujours **0 impression en 30 j** ; audit du jour : page 200, indexable, canonical propre, dans le sitemap, 3 liens depuis carte-prix — le blocage est uniquement le crawl → action Robin).
+- Encarts du 06/08 : sessions test-eligibilite 13 (06/08) / 9 (07/08) / 4 (08/08, samedi) vs ~5-6/j avant. Effet positif modeste ; le trafic interne ne se mesure pas en « referral » GA (navigation interne), on suit la tendance brute.
+- Coach : 0 [[DOSSIER_READY]] en 7 j — attendu et voulu depuis v65 (le Coach envoie vers le test au lieu de collecter en chat).
+
+### Leads & emails
+- Leads eligibility_test 7 j : 3 (03/08, 05/08, 06/08) — tous ont reçu leur récap J0. **Relance J+3 envoyée ce run à nssmnr22@... (lead 05/08, IMC 45,4)** via send-feedback-email, tracée (category eligibility_j3). J+7 Lamia due demain 10/08.
+- Règle STOP vérifiée avant envoi : aucune désinscription des leads concernés dans incoming_emails (seuls spams peptides chinois + le fil Mazzella).
+
+---
+
+## A. SEO RECOVERY WATCH
+
+**Recovery GA : 28 %** (256 sessions le 08/08, samedi ; 44 % le 07/08 avec 408) — **Recovery GSC : 39 %** (41 clics le 07/08).
+
+### 7 derniers jours
+| Date | GA sessions | % base 922 | GSC clics | % base 106 | GSC impressions |
+|---|---|---|---|---|---|
+| 02/08 | 273 | 30 % | 45 | 42 % | 1 767 |
+| 03/08 | 467 | 51 % | 27 | 25 % | 1 538 |
+| 04/08 | 515 | 56 % | 26 | 25 % | 1 597 |
+| 05/08 | 511 | 55 % | 25 | 24 % | 2 086 |
+| 06/08 | 453 | 49 % | 23 | 22 % | **2 317** (record post-suspension) |
+| 07/08 | 408 | 44 % | 41 | 39 % | 1 733 |
+| 08/08 | 256 | 28 % | — | — | — |
+
+**Tendance** : clics -26 % WoW (223 vs 302), impressions +~10 % WoW. La position moyenne se dégrade (20 → 26-30) : c'est un artefact du cluster pharmacies (palier 2 du 04/08) qui injecte des centaines de pages neuves à positions basses — 851 pages pharmacies actives GSC sur 7 j, 3 638 imp, 26 clics. La recovery des pages historiques, elle, **recule** : pas de retour à 100 % estimable sur la pente actuelle.
+
+### Pages : top 7 j vs top baseline (candidates réindexation/renforcement)
+- `/outils/carte-prix-pharmacies/` : 93 clics/7j (baseline 438/23j) — leader stable, mais la requête « carte prix mounjaro france » s'effondre : **346 → 124 imp WoW, 57 → 15 clics**. Cause probable : glissement de position + saisonnalité août. À suivre au prochain run ; si la chute continue, analyse SERP.
+- `/collections/glp1-cout/prix-mounjaro-france/` : **2 clics/7j vs 411 baseline** (766 imp — indexée mais reléguée). Pire perte du site.
+- `/collections/glp1-cout/prix-wegovy-france/` : 8 clics/7j vs 301 baseline.
+- Absentes du top actuel (baseline 10-60 clics) : `wegovy-remboursement-mutuelle`, `/collections/glp1-cout/` (hub), `regime-mounjaro-optimal`, `baisse-prix-ozempic-wegovy-2027-france` → déjà dans la file gsc-submission-queue.
+- « ozempic prix » : 707 imp/7j (vs 866), 5 clics, pos ~13 — stagne sous le pli page 1.
+- Pages Mounjaro (cibles 301 Zepbound) : espagne 7 clics, pénurie 3 clics, prix-mounjaro-france 2 clics — faibles.
+
+## B. DÉCISIONS
+1. **Constat** : mistral-small (fallback) a affirmé le 08/08 à une utilisatrice cherchant le remboursement que « le médecin traitant peut prescrire directement Mounjaro depuis juin 2025 » — faux dans un contexte remboursement (primo-prescription = CSO/CHU/SMR, arrêtés du 12/06/2026), et déjà interdit par le prompt (consigne ignorée, même pathologie que les prix périmés du 07/08). **Décision** : garde-fou déterministe post-réponse (même patron que le price-guard). **Action : fait, v66 déployée.**
+2. **Constat** : content-plan épuisé (tous sujets cochés, backlog vide) → pas d'article publiable ce run (publier hors plan = décision Robin). **Décision** : alimenter le backlog avec le meilleur sujet mesuré. **Action : sujet « Vita GLP arnaque » ajouté (385 imp/28j top 10 sans page dédiée + plaintes victimes dans contacts), publiable au run du 10/08 sauf veto.**
+3. **Constat** : « carte prix mounjaro france » -64 % d'impressions WoW sur la page n°1 du site. **Décision** : observation 1 run de plus (août + volatilité) avant de toucher au title — la page reste leader.
+4. **Constat** : intent « scam:high » attribué à tort à la question prescripteur Lille (faux positif de la détection par mots-clés). Sans impact utilisateur (la réponse reste adaptée). **Décision** : pas de fix ce run, à regrouper avec une revue des patterns d'intent si les faux positifs se répètent.
+
+## C. ACTIONS EXÉCUTÉES
+1. **Coach IA v66 déployée** (MCP) : garde-fou primo-prescription — si la réponse prétend que le généraliste prescrit « directement / sans spécialiste » sans préciser « hors remboursement », une clarification sourcée + lien vers l'article « qui peut prescrire » est ajoutée. Regex validée sur le cas réel de prod (fire) et 2 réponses correctes (no fire). Diff : +17 lignes dans index.ts.
+2. **Fact-check C6** (2 plus anciens, last_fact_checked 10/06) :
+   - `glp1-cancer-risque-protection-bilan-etudes-2026` : **corrigé** — SURPASS-CVOT 13 884 → **13 299 patients** (NEJM 17/12/2025) ; étude JAMA Oncology déc. 2023 réécrite : classe GLP-1 (pas sémaglutide seul), **-44 % vs insuline (HR 0,56) / -25 % vs metformine (HR 0,75)** au lieu du « -17 % sur 10 ans » erroné ; lien source ajouté ; updatedAt 09/08. L'étude thyroïde multisite (98 147 vs 2,5 M, HR 0,81) : vérifiée exacte.
+   - `glp1-cholesterol-triglycerides-profil-lipidique-benefices` : **OK** — LEADER (9 340 pts, -13 % MACE, -22 % mortalité CV), SUSTAIN-6 (AVC -39 %), SURMOUNT-1 (-22,5 % poids), SURMOUNT-5 (-20,2 % vs -13,7 %) conformes aux publications.
+   - `last_fact_checked` mis à jour en base pour les deux.
+3. **Relance J+3 lead eligibility** envoyée (nssmnr22@, IMC 45,4, lead du 05/08) via send-feedback-email, tracée en email_replies.
+4. **Backlog content-plan** : sujet Vita GLP ajouté avec preuves chiffrées (veto 24 h).
+5. **CLAUDE.md** : statut plan K1 action 4 passé à FAIT (v65 07/08 + complément v66 09/08).
+
+## D. AUDIT DU JOUR (J1 Technique, ciblé)
+- Home 200, redirect Zepbound 301 → mounjaro OK, sitemap-0.xml 200, robots.txt sain.
+- `/outils/test-eligibilite/` : 200, **pas de noindex**, canonical self, présent dans le sitemap, 3 liens entrants depuis carte-prix-pharmacies (encart 06/08 vérifié en prod). → Les 0 impressions GSC en 30 j ne sont PAS un problème technique : jamais crawlée. Seul levier : soumission manuelle GSC (Robin).
+- Cluster pharmacies : 851 pages actives GSC/7j, 3 638 imp — l'indexation du palier 2 progresse.
+
+## B (volet). MONITORING COACH IA (24 h)
+- **16 messages / 5 conversations / 8 messages user** (veille : 14 msgs → +14 %). 100 % LLM (llama-70B x6, mistral-small x2), 0 fallback statique.
+- Intents : general 6, price 1, scam:high 1 (faux positif, cf. Décision 4).
+- Dossiers : 0 créé en 24 h ; stock : 3 generated / 4 pending.
+- Qualité par conversation :
+  - Lille/prescripteur (2f0f39e3) : 2 premières réponses correctes (CSO/CHU + annuaire), 3e réponse (mistral) **erronée** sur le généraliste → corrigée structurellement par v66. C'était LE problème du jour.
+  - Recettes sans fromage : OK, concis, pertinent.
+  - « Éligible IMC 33,2 + 5 comorbidités ? » : verdict correct (non éligible, seuils 35+comorbidité/40 rappelés), bon réflexe médecin.
+  - Arrêt Trulicity : prudent et correct (renvoi médecin), propose une checklist — OK.
+  - « Surpoids simple, dangereux ? » : réponse équilibrée, OK.
+  - **Aucune mention Zepbound** ✓
+- Action recommandée (faite) : v66. Rien d'autre à signaler.
+
+## EN ATTENTE DE DÉCISION ROBIN
+1. **Soumission GSC de `/outils/test-eligibilite/`** (plan K1 action 1, en attente depuis le 04/08) — page saine techniquement, jamais crawlée : c'est le déblocage K1 le moins cher du site.
+2. **Bylines médecins fictives : 124 articles** (Dr. Marie Dubois x42, Dr. Sophie Dubois x29, Dr. Émilie Martin x24, Dr. Julien Lefèvre x17, autres x12). Risque E-E-A-T/légal signalé le 14/07 ; un swap global vers « Rédaction GLP-1 France » est un lot mécanique d'1 commit — j'attends le go (ou un vrai relecteur crédité).
+3. **Backlog Vita GLP** : veto avant demain 10/08, sinon je publie au prochain run.

--- a/src/content/recherche-glp1/glp1-cancer-risque-protection-bilan-etudes-2026.md
+++ b/src/content/recherche-glp1/glp1-cancer-risque-protection-bilan-etudes-2026.md
@@ -3,7 +3,7 @@ title: "GLP-1 et Cancer : Risques et Protections — Bilan 2026"
 description: "GLP-1 et cancer : risques et protections pour thyroïde, colorectal et pancréas. Bilan 2026 sur sémaglutide, tirzépatide et risque oncologique."
 pubDate: 2026-03-18
 date: 2026-03-18
-updatedAt: 2026-03-18
+updatedAt: 2026-08-09
 author: "Dr. Julien Lefèvre"
 category: "Recherche médicale"
 tags: ["glp1", "cancer", "risque", "protection", "thyroïde", "colorectal", "pancréatique", "sémaglutide", "recherche", "oncologie"]
@@ -74,7 +74,7 @@ Trois grandes études de sécurité cardiovasculaire ont fourni des données ras
 
 - **LEADER** (liraglutide, 9 340 patients, 3,8 ans de suivi) : aucune augmentation significative du cancer du pancréas
 - **SUSTAIN-6** (sémaglutide, 3 297 patients) : pas de signal pancréatique
-- **SURPASS-CVOT** (tirzépatide, 13 884 patients) : pas d'augmentation du risque de cancer pancréatique
+- **SURPASS-CVOT** (tirzépatide vs dulaglutide, 13 299 patients, résultats publiés dans le NEJM en décembre 2025) : pas d'augmentation du risque de cancer pancréatique
 
 Une méta-analyse publiée dans *The Lancet Diabetes & Endocrinology* en 2024 regroupant plus de 80 000 patients de ces essais a conclu à **l'absence d'augmentation du risque de cancer du pancréas** sous GLP-1, comparativement aux autres traitements antidiabétiques ou à un placebo.
 
@@ -88,7 +88,7 @@ Des données observationnelles récentes suggèrent que les GLP-1 pourraient ré
 
 ### L'étude de la Clinique Cleveland (2023-2024)
 
-Une grande étude rétrospective de Wang et al. (Case Western Reserve University) publiée dans *JAMA Oncology* en décembre 2023 a analysé plus de 1,2 million de dossiers médicaux avec des cohortes appariées de 22 572 patients ou en surpoids avec diabète de type 2 traités par sémaglutide à des patients traités par d'autres médicaments contre le diabète. Les patients sous sémaglutide présentaient une réduction du risque de cancer colorectal de **17 %** sur 10 ans de suivi, après ajustement pour les facteurs confondants.
+Une grande étude rétrospective de Wang et al. (Case Western Reserve University) publiée dans [*JAMA Oncology* en décembre 2023](https://jamanetwork.com/journals/jamaoncology/fullarticle/2812769) a analysé plus de 1,2 million de dossiers de patients diabétiques de type 2 débutant un premier antidiabétique, avec des cohortes appariées de 22 572 patients. Résultat : les patients débutant un agoniste GLP-1 (la classe entière, pas seulement le sémaglutide) présentaient un risque de cancer colorectal réduit de **44 %** par rapport à ceux débutant une insuline (HR 0,56) et de **25 %** par rapport à ceux débutant la metformine (HR 0,75), sur une fenêtre de suivi allant jusqu'à 15 ans, après appariement sur les facteurs confondants. L'effet était plus marqué chez les patients en surpoids ou obèses.
 
 ### Mécanismes biologiques proposés
 

--- a/supabase/functions/ai-coach/index.ts
+++ b/supabase/functions/ai-coach/index.ts
@@ -977,6 +977,21 @@ Reste factuel, ne pose pas de diagnostic médical définitif, rappelle que la d�
         cleanResponse += "\n\nLe plus rapide si tu préfères : notre [test d'éligibilité](/outils/test-eligibilite/) te donne le verdict en 1 minute (3 questions).";
       }
 
+      // Garde-fou primo-prescription : la consigne du prompt (« ne jamais dire que le
+      // médecin traitant peut initier la prescription remboursée ») n'est pas toujours
+      // suivie par les modèles de secours (constaté en prod le 08/08/2026, mistral-small :
+      // « ton médecin traitant peut te prescrire directement Mounjaro depuis juin 2025 »
+      // à une utilisatrice qui demandait explicitement le remboursement). Comme pour les
+      // prix, on corrige la RÉPONSE quel que soit le modèle : si elle affirme que le
+      // généraliste prescrit « directement / sans spécialiste » sans préciser que c'est
+      // hors remboursement, on ajoute la clarification.
+      const gpInitiationClaim = /(médecin traitant|généraliste)[^.!?]{0,140}(prescrire\s+directement|prescrire[^.!?]{0,60}sans (passer par un |)spécialiste|sans passer par un spécialiste)/i;
+      const gpClaimClarified = /hors remboursement|non remboursé|plein tarif|n'ouvre pas (le |droit au )?remboursement|à (ta |votre |sa )?charge/i;
+      if (gpInitiationClaim.test(cleanResponse) && !gpClaimClarified.test(cleanResponse)) {
+        console.warn(`[prescriber-guard] claim généraliste sans nuance remboursement corrigé (modèle: ${usedModel})`);
+        cleanResponse += "\n\nPrécision importante : le médecin traitant peut prescrire Wegovy ou Mounjaro, mais HORS remboursement (traitement à ta charge). Pour ouvrir le remboursement à 65 %, la première prescription doit être faite par un spécialiste en CSO/CHU — ton généraliste pourra ensuite renouveler. Détails : [qui peut prescrire pour être remboursé ?](/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/)";
+      }
+
       // Moment chaud → on propose la capture email (le funnel convertit à 0 sans capture).
       const saysEligible = /\béligibl/i.test(cleanResponse);
       const saysNotEligible = /\b(pas|plus)\b[^.]{0,25}éligibl|éligibl[^.]{0,25}\bsi\b/i.test(cleanResponse);


### PR DESCRIPTION
## Contenu du run quotidien 09/08/2026

### Coach IA — garde-fou primo-prescription (v66 déployée via MCP)
Le 08/08, le fallback mistral-small a affirmé à une utilisatrice cherchant le remboursement que « le médecin traitant peut prescrire directement Mounjaro depuis juin 2025 » — faux dans un contexte remboursement (primo-prescription réservée CSO/CHU/SMR, arrêtés du 12/06/2026), alors que le prompt l'interdit déjà. Même patron que le price-guard : garde-fou déterministe post-réponse qui ajoute la clarification sourcée si la réponse revendique une prescription « directe / sans spécialiste » sans nuance remboursement. Regex validée sur le cas réel de prod (fire) et sur 2 réponses correctes (no fire). **Déjà déployé en prod (v66, ACTIVE)** — ce commit versionne la source.

### Fact-check C6 (2 articles les plus anciens)
- `glp1-cancer-risque-protection-bilan-etudes-2026` : SURPASS-CVOT corrigé (13 884 → 13 299 patients, NEJM 17/12/2025) ; l'étude JAMA Oncology déc. 2023 réécrite (classe GLP-1 et non sémaglutide seul ; −44 % vs insuline HR 0,56 / −25 % vs metformine HR 0,75, au lieu du « −17 % sur 10 ans » erroné) ; lien source ajouté.
- `glp1-cholesterol-triglycerides-profil-lipidique-benefices` : chiffres vérifiés conformes, aucun changement.

### Divers
- `content-plan.md` : sujet backlog « Vita GLP arnaque » (385 imp/28j top 10 sans page dédiée, veto 24 h).
- `CLAUDE.md` : statut plan K1 action 4 → FAIT (v65/v66).
- `reports/daily-2026-08-09.md` : rapport complet (monétisation, recovery, décisions, audit J1).

Aucun changement de prix, d'offre, de schéma DB ni de layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUHJSwevMHDLuni1omdmQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUHJSwevMHDLuni1omdmQY)_