### PR TITLE
Run 11/08 : article Ozempic pour maigrir (P2a), fact-check, rapport

### DIFF
--- a/content-plan.md
+++ b/content-plan.md
@@ -26,7 +26,7 @@ Ce fichier est la **source de vérité** de la création de contenu. La routine 
 
 ### P2 — Quick wins sur demande GSC mesurée
 
-- [ ] **P2a. Ozempic pour maigrir : prix réel 2026 et pourquoi il n'est pas remboursé pour l'obésité** — ajouté 09/08 (plan croissance, veto 24h ou « go plan »). Preuve GSC : « ozempic pour maigrir prix » 144 imp/14j pos 14,6, 0 clic ; aucune page dédiée à l'intent « maigrir » (prix-ozempic-france = intent diabète). Angle : hors AMM/non remboursé pour l'obésité seule → alternatives remboursées 65 % (Wegovy/Mounjaro) + test d'éligibilité. Collection : glp1-cout. Attention cannibalisation : lier prix-ozempic-france en canonique de l'intent prix.
+- [x] **P2a. Ozempic pour maigrir : prix réel 2026 et pourquoi il n'est pas remboursé pour l'obésité** — publié le 11/08/2026 (fenêtre veto 24h passée, plan croissance) → https://glp1-france.fr/collections/glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite/ — sources : BDPM fiche Ozempic 63210923 (77,60 € TTC, remboursement 30 %), ANSM/CNAM CP 01/03/2023 (usage réservé diabète type 2, surveillance mésusage), Vidal 37850 (Wegovy 146,91-195,10 € / Mounjaro 176,10-433,80 €, remb 65 % 15/06/2026, critères IMC ≥ 40 ou ≥ 35 + comorbidité + 6 mois), STEP 2 PubMed 33667417 (sémaglutide 2,4 mg −9,6 % vs 1 mg −7 %). Angle : hors AMM = 0 % remboursé + moins efficace que Wegovy → renvoi test d'éligibilité. Maillage entrant : prix-ozempic-france + ozempic-2-mg-pourquoi-pas-disponible + medicament-pour-maigrir-guide (lien canonique prix vers prix-ozempic-france). Suivi : imp J+7 (~18/08) : — ; imp J+30 (~10/09) : —
 
 ### P3 — Cluster retraites (leadership : déjà position 8 sur "retraite perte de poids" à J+14)
 

--- a/public/images/thumbnails/ozempic-pour-maigrir-prix-remboursement-obesite.svg
+++ b/public/images/thumbnails/ozempic-pour-maigrir-prix-remboursement-obesite.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Ozempic pour maigrir : prix et remboursement 2026">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1a3c34"/>
+      <stop offset="1" stop-color="#0f2721"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <circle cx="710" cy="70" r="120" fill="#16a34a" opacity="0.12"/>
+  <circle cx="70" cy="390" r="95" fill="#16a34a" opacity="0.10"/>
+  <!-- Carte prix barrée : Ozempic hors AMM -->
+  <g transform="translate(80,130)">
+    <rect x="0" y="0" width="300" height="180" rx="14" fill="#ffffff" opacity="0.97"/>
+    <text x="24" y="44" font-family="Segoe UI, Arial, sans-serif" font-size="22" font-weight="700" fill="#1a3c34">Ozempic « pour maigrir »</text>
+    <text x="24" y="92" font-family="Segoe UI, Arial, sans-serif" font-size="34" font-weight="800" fill="#b91c1c">77,60 €/mois</text>
+    <text x="24" y="128" font-family="Segoe UI, Arial, sans-serif" font-size="18" fill="#b91c1c">Remboursement : 0 %</text>
+    <line x1="20" y1="82" x2="280" y2="100" stroke="#b91c1c" stroke-width="4" opacity="0.55"/>
+    <text x="24" y="160" font-family="Segoe UI, Arial, sans-serif" font-size="15" fill="#6b7280">Hors AMM — 100 % à votre charge</text>
+  </g>
+  <!-- Carte alternative remboursée -->
+  <g transform="translate(430,130)">
+    <rect x="0" y="0" width="290" height="180" rx="14" fill="#16a34a"/>
+    <text x="24" y="44" font-family="Segoe UI, Arial, sans-serif" font-size="22" font-weight="700" fill="#ffffff">Wegovy / Mounjaro</text>
+    <text x="24" y="92" font-family="Segoe UI, Arial, sans-serif" font-size="34" font-weight="800" fill="#ffffff">65 %</text>
+    <text x="24" y="126" font-family="Segoe UI, Arial, sans-serif" font-size="18" fill="#dcfce7">remboursés depuis le 15/06/2026</text>
+    <text x="24" y="158" font-family="Segoe UI, Arial, sans-serif" font-size="15" fill="#dcfce7">Sous conditions (IMC, 6 mois de suivi)</text>
+  </g>
+  <text x="400" y="80" text-anchor="middle" font-family="Segoe UI, Arial, sans-serif" font-size="34" font-weight="800" fill="#ffffff">Ozempic pour maigrir : le vrai prix 2026</text>
+  <text x="400" y="380" text-anchor="middle" font-family="Segoe UI, Arial, sans-serif" font-size="19" fill="#a7f3d0">glp1-france.fr — chiffres officiels BDPM / ANSM</text>
+</svg>

--- a/reports/daily-2026-08-11.md
+++ b/reports/daily-2026-08-11.md
@@ -1,0 +1,97 @@
+# Rapport quotidien — 11/08/2026
+
+**Alertes** : aucune alerte critique. Site live OK (home 200, redirect zepbound→mounjaro 301, sitemap 200). GA à jour (11/08), GSC J-2 (09/08, normal). Aucune occurrence Zepbound détectée dans les conversations Coach.
+
+---
+
+## A0. MONÉTISATION (objectif principal)
+
+### Ventes Dossier GLP-1 (4,99 €)
+- **0 vente payée sur 24h et sur 7j.** Total cumulé inchangé : **3 dossiers payés/générés**, 4 pending.
+- 1 seul dossier créé sur 7j (07/08, philippepayrastre2107@…) : checkout Stripe tenté mais **non payé** — relance email déjà envoyée le 08/08, **pas de réponse ni de paiement depuis**. Pas de nouvelle relance (une seule relance par prospect).
+- Aucun dossier créé via chat sur 7j.
+
+### Funnel (7 derniers jours, ga_metrics)
+| Étape | Valeur 7j | Hier |
+|---|---|---|
+| Sessions /outils/carte-prix-pharmacies/ (source K1) | 257 | 24 |
+| Sessions /outils/test-eligibilite/ | **57** | 9 |
+| Sessions /dossier-glp1/ (landing) | **8** | 1 |
+| Dossiers créés | 1 | 0 |
+| Payés | 0 | 0 |
+
+### KPIs vs baselines (04/08)
+- **K1 exposition** : ~65 sessions funnel / ~2 600 sessions site 7j ≈ **2,5 %** (baseline 0,69 %) — **nette amélioration**, les encarts carte-prix + pages prix (actions 2-3 du plan K1) portent le trafic vers le test.
+- **K2 activation** : 1 dossier / 8 sessions landing = 12,5 % (baseline 12 %) — conforme, mais volume landing très faible.
+- **K3 paiement** : 0/1 sur la fenêtre — le checkout du 07/08 n'a pas converti malgré relance.
+- **K5 Coach** : 6 réponses proposant le Dossier / 30 conversations 7j = **20 %** (baseline 11 %) — bon. 0 `[[DOSSIER_READY]]` émis sur 7j.
+- **K6 capture test** : 2 leads / 57 sessions test = **3,5 %** (baseline 9,3 %) — **en dessous de la baseline**, à surveiller : si < 5 % la semaine prochaine, revoir le placement du formulaire email.
+- **Fuite du moment** : le goulot se déplace de K1 (en amélioration) vers **la landing /dossier-glp1/ (8 sessions/7j)** : le test capte du trafic mais le passage test → landing Dossier reste marginal.
+
+### Leads test d'éligibilité
+- 0 nouveau lead sur 24h (2 sur 7j, total 7). Rien à emailer ce run (recaps J0 des 2 leads déjà traités les runs précédents).
+
+### Suivi post-achat
+- Aucun nouveau payé. Clients 1 (payé 22/07) et 2 (payé 24/07) : emails satisfaction envoyés (23/07 et 27/07), **toujours aucune réponse** dans incoming_emails (sync pg_cron active — les seuls emails entrants récents sont des victimes d'arnaques "kit minceur" hors site + un email égaré).
+
+### Plan K1 — état
+1. `/outils/test-eligibilite/` soumise GSC par Robin le 09/08 : **toujours 0 impression GSC au 09/08** (dernière date dispo) — trop tôt pour conclure, re-point au 16/08 comme prévu.
+2-5. Encarts déployés (carte-prix, pages prix nationales, Coach v65/v66, templates ville/dept) — le trafic test-eligibilite (57 sessions/7j) confirme l'effet.
+6. Backlog : email de livraison J0 post-achat (autonome, à faire un prochain run).
+
+---
+
+## A. SEO RECOVERY WATCH
+
+### Scores de recovery
+- **Recovery GA : 46 %** — 427 sessions le 10/08 (dernier jour complet) vs baseline 922.
+- **Recovery GSC : 18 %** — 19 clics le 09/08 (dimanche, dernier jour dispo) vs baseline 106. Meilleur jour récent : 41 clics le 07/08 (39 %).
+
+### 7 derniers jours
+| Date | GA sessions | % base | GSC clics | % base |
+|---|---|---|---|---|
+| 04/08 | 515 | 56 % | 26 | 25 % |
+| 05/08 | 511 | 55 % | 25 | 24 % |
+| 06/08 | 453 | 49 % | 23 | 22 % |
+| 07/08 | 408 | 44 % | 41 | 39 % |
+| 08/08 (sam) | 256 | 28 % | 24 | 23 % |
+| 09/08 (dim) | 236 | 26 % | 19 | 18 % |
+| 10/08 | 427 | 46 % | — | — |
+
+### Tendance
+Plateau autour de 45-55 % GA en semaine depuis fin juillet, clics GSC entre 19 et 41/jour sans pente franche. **La baisse WoW de cette semaine est expliquée par la demande (saisonnalité août), pas par un déclassement** — voir Phase B : sur toutes les grosses requêtes, les positions sont stables ou en amélioration alors que les impressions chutent. Pas de date de retour à 100 % estimable sur cette pente ; le vrai test sera la rentrée (fin août).
+
+### Pages baseline vs actuelles (candidates réindexation)
+Toujours les mêmes absentes du top actuel vs top baseline : `wegovy-remboursement-mutuelle` (60 clics baseline → 0), `regime-mounjaro-optimal` (18 → 1), `nouveau-stylo-ozempic-3ml` (9 → 0), `effets-secondaires-mounjaro` (8 → 0), `guides/suivi-medical-glp1` (8 → 0). Toutes déjà dans `reports/gsc-submission-queue.md` — pas de relance à Robin (règle 3bis).
+
+### Pages Mounjaro (cibles 301 Zepbound)
+`acheter-wegovy-mounjaro-espagne` 9 clics/188 imp (meilleure page mounjaro du moment), `penurie-…` 3/453, `prix-mounjaro-france` 2/666 (impressions élevées, clics faibles — title à retravailler si ça persiste).
+
+---
+
+## B. DÉCISIONS (analyse WoW 7j vs 7j précédents)
+
+1. **Constat** : top baisses impressions = prix-ozempic-france (-1 310, 3 683→2 373), prix-mounjaro-france (-501), carte-prix (-373), hub glp1-cout (-236), prix-wegovy-france (-196). Analyse requête par requête sur les 2 plus grosses : « ozempic prix » 993→387 imp mais position **8,8→7,9** (améliorée) ; « carte prix mounjaro france » 179→90 imp, pos 2,9→3,8 ; « prix mounjaro autour de moi » pos 4,5→**3,3** (améliorée). **Cause nommée : chute de la demande de recherche (vacances d'août), pas de glissement de position.** → Décision : ne rien toucher aux pages prix cette semaine, re-vérifier au retour des volumes (~25/08).
+2. **Constat** : « ozempic pour maigrir prix »/« ozempic perte de poids prix » (~140 imp/7j cumulées, pos 10-11) sans page dédiée → **Action faite ce run** : article P2a publié + maillage.
+3. **Constat** : montées = prix-glp1-tableau (+256 imp, article 02/08 qui décolle), ozempic-sans-ordonnance (+217, 7 clics), espagne (+169, 9 clics), camp-perte-de-poids (+119 imp, première apparition GSC de la verticale retraites sur ce cluster). → Rien à faire, ça valide les publications récentes.
+4. **Constat** : K6 capture test 3,5 % vs baseline 9,3 % (2 leads/57 sessions). → Décision : observation 1 semaine de plus (petit volume, 2 leads) avant de toucher au formulaire.
+5. **Constat Coach** : une réponse « étapes pour commencer » (conv e7aa1c08) donne les critères AMM (IMC ≥ 30/≥ 27) sans préciser que le **remboursement** exige IMC ≥ 40/≥ 35 + comorbidité + 6 mois, et la réponse est **tronquée en plein « 5. »** (limite de tokens). → Décision : à corriger dans un prochain run C2 (durcir la consigne « critères AMM ≠ critères remboursement » + vérifier max_tokens) — pas déployé ce run pour ne pas empiler deux déploiements le même jour que l'article.
+
+---
+
+## C. ACTIONS EXÉCUTÉES
+
+1. **C5 — Article du plan publié** : « Ozempic pour maigrir : prix réel 2026 et pourquoi il n'est pas remboursé » (`glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite`). Chaque chiffre sourcé : BDPM (77,60 €, taux 30 %), ANSM/CNAM 01/03/2023 (mésusage), Vidal 37850 (remb 65 % Wegovy/Mounjaro + critères), STEP 2 PubMed 33667417 (−9,6 % vs −7 %). Thumbnail SVG unique DA verte. Maillage entrant : prix-ozempic-france, ozempic-2-mg, medicament-pour-maigrir-guide. CTA test d'éligibilité. 1 URL ajoutée à la file GSC.
+2. **C6 — Fact-check** : `medicament-pour-maigrir-guide-complet-france-2026` → **2 erreurs corrigées** : Ozempic annoncé « remboursé 65 % en bithérapie » → 30 % (BDPM), Rybelsus annoncé « 80-110 €/mois remboursé 65 % » → non remboursé (avis HAS défavorable, prix libre). `glp1-microbiote-intestinal-flore-impact-probiotiques` → **OK** (claims correctement nuancés, aucun chiffre faux). `last_fact_checked` mis à jour pour les deux.
+3. Maillage : 3 liens entrants ajoutés vers le nouvel article (dans le même commit).
+
+## D. AUDIT DU JOUR (rotation : J4 Contenu)
+
+Fact-check approfondi ci-dessus (C6) + revue qualité des 4 conversations Coach des 24h :
+- 16 messages / 4 conversations (vs 6 messages la veille). 6 réponses llama-3.3-70b, 2 fallback mistral-small (25 %).
+- Conversations correctes : redirection carte-prix OK, prix officiels exacts (77/147-195/176-434 €), proposition de vérification d'éligibilité présente.
+- 2 défauts relevés (voir B.5) : critères AMM vs remboursement ambigus dans « les étapes », réponse tronquée mi-liste. Pas d'erreur médicale dangereuse, pas de mention Zepbound.
+
+## EN ATTENTE DE DÉCISION ROBIN
+
+Rien de bloquant ce run — tout est dans la matrice d'autonomie.

--- a/reports/gsc-submission-queue.md
+++ b/reports/gsc-submission-queue.md
@@ -23,6 +23,8 @@ La routine AJOUTE ici a chaque publication — elle ne relance jamais dans le ch
 - [ ] https://glp1-france.fr/collections/medecins-glp1-france/delai-rendez-vous-cso-chu-obesite-glp1-2026/ (article 10/08, prioritaire — contenu funnel parcours de soins)
 - [ ] https://glp1-france.fr/collections/medecins-glp1-france/suivi-nutritionnel-6-mois-remboursement-glp1-documenter/ (article 10/08 run 2, prioritaire — contenu funnel parcours de soins)
 
+- [ ] https://glp1-france.fr/collections/glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite/ (article 11/08, prioritaire — cible « ozempic pour maigrir prix », 144 imp/14j pos ~10)
+
 ## Soumises
 
 - [x] https://glp1-france.fr/outils/test-eligibilite/ — soumise par Robin le 09/08/2026 (confirme en chat « fait »). Surveiller premieres impressions ; re-signaler une fois si 0 imp au 16/08.

--- a/src/content/glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite.md
+++ b/src/content/glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite.md
@@ -1,0 +1,96 @@
+---
+title: "Ozempic pour maigrir : prix réel 2026 et pourquoi il n'est pas remboursé"
+thumbnail: "/images/thumbnails/ozempic-pour-maigrir-prix-remboursement-obesite.svg"
+thumbnailAlt: "Ozempic pour maigrir : prix et remboursement en France 2026"
+description: "Ozempic pour maigrir en 2026 : 77,60 € par mois, jamais remboursé pour la perte de poids seule. Pourquoi, ce que dit l'ANSM, et les alternatives remboursées à 65 %."
+keywords: ['ozempic pour maigrir prix', 'ozempic maigrir', 'ozempic perte de poids prix', 'ozempic pour maigrir remboursement', 'ozempic obésité', 'prix ozempic maigrir', 'ozempic sans diabète', 'ozempic hors amm']
+seoTitle: "Ozempic pour maigrir : prix 2026 et remboursement (la vérité)"
+seoDescription: "Ozempic pour maigrir coûte 77,60 €/mois, 100 % à votre charge : jamais remboursé hors diabète. Les alternatives remboursées à 65 % et le test d'éligibilité."
+mainKeyword: "ozempic pour maigrir prix"
+publishedAt: '2026-08-11'
+updatedAt: '2026-08-11'
+date: 2026-08-11
+featured: false
+author: 'Rédaction GLP-1 France'
+readingTime: 7
+collection: "glp1-cout"
+image: "/images/thumbnails/ozempic-pour-maigrir-prix-remboursement-obesite.svg"
+secondaryKeywords: ["ozempic prix perte de poids", "ozempic pour maigrir avis prix", "ozempic non remboursé", "semaglutide pour maigrir prix", "wegovy ou ozempic pour maigrir"]
+faqSchema:
+  - question: "Quel est le prix d'Ozempic pour maigrir en 2026 ?"
+    answer: "Le prix d'Ozempic est réglementé : 77,60 € TTC le stylo, soit environ un mois de traitement, identique dans toutes les pharmacies françaises. Mais utilisé pour maigrir sans diabète de type 2, il est prescrit hors AMM : l'Assurance Maladie ne rembourse rien, la totalité reste à votre charge et la mention « non remboursable » doit figurer sur l'ordonnance."
+  - question: "Ozempic peut-il être remboursé pour la perte de poids ?"
+    answer: "Non, dans aucun cas. Ozempic n'est remboursé (à 30 %, ou 100 % en ALD) que pour le diabète de type 2, son indication officielle. Pour la perte de poids, ce sont Wegovy et Mounjaro qui sont remboursés à 65 % depuis le 15 juin 2026, sous conditions strictes : IMC ≥ 40, ou IMC ≥ 35 avec comorbidité, après au moins 6 mois de prise en charge nutritionnelle."
+  - question: "Un médecin peut-il prescrire Ozempic pour maigrir sans diabète ?"
+    answer: "L'ANSM et l'Assurance Maladie rappellent qu'Ozempic doit être réservé au traitement du diabète de type 2 et surveillent activement son mésusage depuis 2023. Une prescription hors AMM reste juridiquement possible dans des cas très encadrés, mais elle engage la responsabilité du médecin, n'est jamais remboursée et prive des patients diabétiques d'un médicament essentiel en période de tension d'approvisionnement."
+  - question: "Ozempic ou Wegovy : lequel fait le plus maigrir ?"
+    answer: "Wegovy. Les deux contiennent du sémaglutide, mais Ozempic plafonne à 1 mg par semaine contre 2,4 mg pour Wegovy. Dans l'essai comparatif STEP 2, la dose 2,4 mg a fait perdre en moyenne 9,6 % du poids initial contre 7 % pour la dose 1 mg. Wegovy est en plus le seul des deux à être remboursé pour l'obésité."
+  - question: "Comment savoir si j'ai droit au remboursement d'un traitement pour maigrir ?"
+    answer: "Les critères officiels 2026 sont : IMC ≥ 40, ou IMC ≥ 35 avec au moins une comorbidité (hypertension, apnée du sommeil, prédiabète...), après échec d'une prise en charge nutritionnelle d'au moins 6 mois, avec une primo-prescription par un médecin spécialiste ou une structure spécialisée dans l'obésité. Notre test d'éligibilité gratuit vous donne un verdict en 2 minutes."
+schema: "Article"
+published: true
+---
+
+**Ozempic pour maigrir, combien ça coûte vraiment ?** La réponse courte : **77,60 € par mois, entièrement à votre charge** — car utilisé pour la perte de poids sans diabète, Ozempic n'est **jamais remboursé**, et ce n'est de toute façon ni le médicament prévu pour ça, ni le plus efficace. Voici les chiffres officiels 2026, ce que dit la réglementation, et surtout les alternatives qui, elles, sont remboursées à 65 %.
+
+## Le prix réel d'Ozempic en 2026
+
+Le prix d'Ozempic est fixé par le Comité économique des produits de santé et publié dans la [Base de données publique des médicaments](https://base-donnees-publique.medicaments.gouv.fr/) : **77,60 € TTC le stylo**, quel que soit le dosage (0,25 mg, 0,5 mg ou 1 mg). Un stylo contient 4 doses hebdomadaires, soit **environ un mois de traitement**.
+
+Ce prix est identique dans toutes les pharmacies de France — inutile de comparer les officines, seule la disponibilité varie. Le détail complet (dosages, honoraires de dispensation, reste à charge en diabète) est dans notre [guide du prix d'Ozempic en France](/collections/glp1-cout/prix-ozempic-france/).
+
+La vraie question n'est donc pas le prix facial, mais **qui paie** :
+
+| Situation | Remboursement | Coût réel pour vous |
+|---|---|---|
+| Diabète de type 2 (indication officielle) | 30 %, **100 % en ALD** | ~54 €/mois, 0 € en ALD |
+| **Perte de poids sans diabète (hors AMM)** | **0 %** | **77,60 €/mois, 100 % à votre charge** |
+
+## Pourquoi Ozempic n'est pas remboursé pour maigrir
+
+Ozempic (sémaglutide) ne dispose d'une autorisation de mise sur le marché que pour **le diabète de type 2 insuffisamment contrôlé**. Prescrit pour la perte de poids chez une personne non diabétique, il est utilisé « hors AMM » : le médecin doit porter la mention « non remboursable » sur l'ordonnance, et l'Assurance Maladie ne prend rien en charge.
+
+Ce n'est pas un vide juridique, c'est une position officielle. Depuis mars 2023, [l'ANSM et l'Assurance Maladie rappellent qu'Ozempic doit être utilisé uniquement dans le traitement du diabète de type 2](https://ansm.sante.fr/actualites/ozempic-semaglutide-un-medicament-a-utiliser-uniquement-dans-le-traitement-du-diabete-de-type-2) et ont mis en place une surveillance active du mésusage (données de remboursement, signalements des professionnels, pharmacovigilance). Leur argument principal : chaque boîte détournée vers la perte de poids **prive un patient diabétique** d'un traitement essentiel, dans un contexte de tensions d'approvisionnement récurrentes.
+
+Concrètement, en 2026 :
+
+- Un médecin qui prescrit Ozempic pour maigrir hors AMM **engage sa responsabilité** ;
+- Le pharmacien peut refuser la délivrance si la situation lui paraît non conforme — c'est le même mécanisme que pour [les refus de délivrance de Mounjaro et Wegovy](/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/) ;
+- Vous paierez **plein tarif, tous les mois, sans aucune perspective de remboursement**.
+
+## Ozempic n'est même pas le bon outil pour maigrir
+
+Au-delà de la réglementation, il y a un argument médical simple : **le dosage**. Ozempic plafonne à 1 mg de sémaglutide par semaine (le dosage 2 mg [n'est pas commercialisé en France](/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/)). Wegovy, développé spécifiquement pour l'obésité avec la même molécule, monte à 2,4 mg.
+
+La différence a été mesurée dans un essai comparatif direct : dans [l'étude STEP 2](https://pubmed.ncbi.nlm.nih.gov/33667417/) (The Lancet, 2021), le sémaglutide 2,4 mg a entraîné une perte de poids moyenne de **9,6 %** du poids initial, contre **7 %** pour la dose 1 mg d'Ozempic. Payer Ozempic de sa poche pour maigrir, c'est donc payer plein tarif pour l'option la moins efficace.
+
+## Les vraies alternatives : remboursées à 65 % depuis juin 2026
+
+Depuis le 15 juin 2026, deux traitements GLP-1 disposant de l'AMM obésité sont [remboursés à 65 % par l'Assurance Maladie](https://www.vidal.fr/actualites/37850) :
+
+| Traitement | Prix officiel/mois | Après remboursement 65 % |
+|---|---|---|
+| [Wegovy](/collections/glp1-cout/prix-wegovy-france/) (sémaglutide 2,4 mg) | 146,91 à 195,10 € | ~51 à 68 €/mois |
+| [Mounjaro](/collections/glp1-cout/prix-mounjaro-france/) (tirzépatide) | 176,10 à 433,80 € | ~62 à 152 €/mois |
+
+Avec une mutuelle qui complète le ticket modérateur, le reste à charge peut tomber bien en dessous du prix d'un Ozempic payé plein pot — pour un traitement **plus efficace et prescrit dans les règles**.
+
+Les conditions du remboursement sont strictes :
+
+1. **IMC ≥ 40**, ou **IMC ≥ 35 avec au moins une comorbidité** (hypertension, apnée du sommeil, prédiabète, stéatose hépatique...) ;
+2. Après **échec d'une prise en charge nutritionnelle d'au moins 6 mois** (perte de poids < 5 %) — voici [comment documenter ces 6 mois de suivi](/collections/medecins-glp1-france/suivi-nutritionnel-6-mois-remboursement-glp1-documenter/) ;
+3. **Primo-prescription par un spécialiste ou une structure spécialisée** dans l'obésité (CSO, CHU), le renouvellement pouvant ensuite être assuré par votre généraliste — le détail est dans notre guide [qui peut prescrire Mounjaro ou Wegovy](/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/).
+
+<div style="background:#f0fdf4;border:1px solid #16a34a;border-radius:12px;padding:20px 24px;margin:24px 0;">
+  <p style="margin:0 0 8px;font-weight:700;color:#1a3c34;">Êtes-vous éligible au remboursement à 65 % ?</p>
+  <p style="margin:0 0 14px;color:#374151;">IMC, comorbidités, suivi nutritionnel : vérifiez en 2 minutes si vous remplissez les critères officiels 2026 pour Wegovy ou Mounjaro remboursés.</p>
+  <a href="/outils/test-eligibilite/" style="display:inline-block;background:#16a34a;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Faire le test d'éligibilité → 2 min</a>
+</div>
+
+## En résumé : les 3 scénarios possibles en 2026
+
+- **Vous êtes diabétique de type 2** : Ozempic est votre traitement, remboursé à 30 % (100 % en ALD), sur prescription classique. Son prix pour maigrir n'est pas votre sujet.
+- **Vous voulez maigrir et remplissez les critères d'obésité** : ne payez pas Ozempic plein tarif. Faites valider votre éligibilité (IMC ≥ 40, ou ≥ 35 + comorbidité, 6 mois de suivi) et visez **Wegovy ou Mounjaro remboursés à 65 %**. Le parcours (médecin traitant → spécialiste → pharmacie) prend quelques semaines à quelques mois.
+- **Vous voulez maigrir sans remplir les critères** : aucun GLP-1 ne sera remboursé, et Ozempic hors AMM reste une impasse (coût, responsabilité du prescripteur, efficacité moindre). Parlez-en à votre médecin : perte de poids encadrée d'abord — c'est aussi le chemin qui, en cas d'échec documenté à 6 mois, peut ouvrir droit au remboursement.
+
+Attention enfin aux sites qui proposent « Ozempic sans ordonnance » ou des « gélules GLP-1 » miracle : la vente de sémaglutide sans ordonnance est illégale en France et les produits vendus en ligne sont au mieux inefficaces, au pire dangereux.

--- a/src/content/glp1-cout/prix-ozempic-france.md
+++ b/src/content/glp1-cout/prix-ozempic-france.md
@@ -7,7 +7,7 @@ seoTitle: "Prix Ozempic 2026 : 77,60 €/stylo — remboursé 30%, 100% en ALD"
 seoDescription: "Prix officiel Ozempic : 77,60 € TTC le stylo (1 mois), identique dans toutes les pharmacies. Remboursé 30% diabète type 2, 100% en ALD. Point juillet 2026."
 mainKeyword: "prix Ozempic France"
 publishedAt: '2025-01-28'
-updatedAt: '2026-08-06'
+updatedAt: '2026-08-11'
 date: 2026-06-22
 featured: true
 author: 'Rédaction GLP-1 France'
@@ -133,7 +133,7 @@ Le **prix Ozempic en pharmacie** en France est fixé à **77,60€ TTC par stylo
 ✅ **Échec des antidiabétiques oraux**
 ✅ **Formulaire de demande obligatoire** (depuis février 2025)
 
-⚠️ **Important** : Ozempic n'est remboursé que pour le **diabète de type 2**, pas pour l'obésité seule. Pour la [perte de poids](/collections/glp1-perte-de-poids/glp1-perte-de-poids/) sans diabète, [Wegovy](/collections/traitements-glp1/guide-complet-wegovy/) et [Mounjaro](/collections/traitements-glp1/guide-complet-mounjaro/) sont remboursés à 65% depuis le 15 juin 2026 pour l'obésité sous conditions (IMC ≥ 35 avec comorbidité ou IMC ≥ 40). Saxenda reste non remboursé.
+⚠️ **Important** : Ozempic n'est remboursé que pour le **diabète de type 2**, pas pour l'obésité seule. Pour la [perte de poids](/collections/glp1-perte-de-poids/glp1-perte-de-poids/) sans diabète, [Wegovy](/collections/traitements-glp1/guide-complet-wegovy/) et [Mounjaro](/collections/traitements-glp1/guide-complet-mounjaro/) sont remboursés à 65% depuis le 15 juin 2026 pour l'obésité sous conditions (IMC ≥ 35 avec comorbidité ou IMC ≥ 40). Saxenda reste non remboursé. Nous détaillons le sujet dans [Ozempic pour maigrir : prix réel et pourquoi il n'est pas remboursé](/collections/glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite/).
 
 ### Démarches pour le remboursement
 

--- a/src/content/glp1-perte-de-poids/medicament-pour-maigrir-guide-complet-france-2026.md
+++ b/src/content/glp1-perte-de-poids/medicament-pour-maigrir-guide-complet-france-2026.md
@@ -8,6 +8,7 @@ collection: "glp1-perte-de-poids"
 category: "glp1-perte-de-poids"
 tags: ["médicament pour maigrir", "perte de poids", "GLP-1", "Wegovy", "Mounjaro", "Saxenda", "Ozempic", "France 2026"]
 date: "2026-04-10"
+updatedAt: '2026-08-11'
 mainKeyword: "medicament pour maigrir france"
 featured: true
 enableAffiliation: true
@@ -124,10 +125,10 @@ L'**Ozempic** de Novo Nordisk est officiellement autorisé uniquement pour le tr
 
 **Prix et remboursement :**
 - Environ **77,60 euros par stylo** (prix fixe)
-- **Remboursé à 65 %** par la Sécurité sociale pour le diabète de type 2 en bithérapie avec metformine (30 % en trithérapie avec insuline basale). Prise en charge jusqu'à 100 % en ALD (Affection de Longue Durée).
+- **Remboursé à 30 %** par la Sécurité sociale pour le diabète de type 2 ([taux BDPM](https://base-donnees-publique.medicaments.gouv.fr/medicament/63210923/extrait)). Prise en charge à 100 % en ALD (Affection de Longue Durée).
 - Non rembourse pour la perte de poids seule
 
-**Attention :** la prescription hors AMM de l'Ozempic pour la perte de poids comporte des risques. En cas d'effet secondaire grave, la responsabilite du médecin est engagee differemment. De plus, les tensions d'approvisionnement liees a la forte demande pour la perte de poids peuvent priver les patients diabetiques de leur traitement. Privilegiez le [Wegovy](/collections/traitements-glp1/guide-complet-wegovy/) si votre objectif est la perte de poids.
+**Attention :** la prescription hors AMM de l'Ozempic pour la perte de poids comporte des risques. En cas d'effet secondaire grave, la responsabilite du médecin est engagee differemment. De plus, les tensions d'approvisionnement liees a la forte demande pour la perte de poids peuvent priver les patients diabetiques de leur traitement. Privilegiez le [Wegovy](/collections/traitements-glp1/guide-complet-wegovy/) si votre objectif est la perte de poids — nous expliquons en détail [pourquoi Ozempic pour maigrir n'est ni remboursé ni pertinent](/collections/glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite/).
 
 Pour en savoir plus : [guide complet Ozempic](/collections/traitements-glp1/guide-complet-ozempic/) | [prix Ozempic en France](/collections/glp1-cout/prix-ozempic-france/)
 
@@ -174,7 +175,7 @@ Pour en savoir plus : [guide complet Ozempic](/collections/traitements-glp1/guid
       <td>5-10 % (hors AMM)</td>
       <td>~80 euros/stylo</td>
       <td>1x/semaine</td>
-      <td>65 % (diabète, bithérapie)</td>
+      <td>30 % (diabète, 100 % en ALD)</td>
       <td>Pas d'AMM obésité</td>
     </tr>
   </tbody>
@@ -191,7 +192,7 @@ Le **Rybelsus** est le seul GLP-1 disponible sous forme de comprimé en France. 
 - **Dose :** 3 mg, 7 mg ou 14 mg, un comprimé par jour a jeun
 - **Indication officielle :** diabète de type 2
 - **Efficacité pour la perte de poids :** inferieure aux formes injectables (environ 5 a 10 % de perte de poids)
-- **Prix :** 80 a 110 euros par mois, rembourse a 65 % pour le diabète de type 2
+- **Prix :** prix libre (non remboursé) — la Haute Autorité de santé a rendu un avis défavorable à son remboursement, et il est très peu référencé dans les officines françaises
 
 Le Rybelsus doit etre pris a jeun avec un demi-verre d'eau, au moins 30 minutes avant le premier repas. Cette contrainte peut etre genante au quotidien.
 
@@ -312,7 +313,7 @@ Le cout reste le principal frein a l'acces aux medicaments pour maigrir en Franc
     <tr>
       <td><strong>Ozempic</strong></td>
       <td>~80 euros/stylo</td>
-      <td>65 % (diabète, bithérapie)</td>
+      <td>30 % (diabète, 100 % en ALD)</td>
       <td>Complement possible (diabète)</td>
     </tr>
   </tbody>

--- a/src/content/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france.md
+++ b/src/content/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france.md
@@ -61,7 +61,7 @@ Si votre glycémie reste mal contrôlée à 1 mg, la réponse n'est **jamais** d
 
 1. **N'augmentez jamais la dose vous-même.** Faire deux injections de 1 mg pour simuler du 2 mg n'a été validé dans aucun cadre de soins français : la sécurité du 2 mg a été évaluée avec une titration précise, un stylo dédié et un suivi d'essai clinique.
 2. **Des alternatives à doses supérieures existent en France.** [Mounjaro (tirzépatide)](/collections/traitements-glp1/guide-complet-mounjaro/) monte jusqu'à 15 mg par semaine dans le diabète de type 2, avec des paliers progressifs. C'est au prescripteur d'évaluer si un changement de molécule est pertinent.
-3. **Si l'enjeu est le poids plus que la glycémie**, le cadre a changé : Wegovy et Mounjaro sont remboursés à 65 % dans l'obésité depuis juin 2026, sous conditions strictes. Notre [test d'éligibilité](/outils/test-eligibilite/) vous dit en une minute si vous entrez dans les critères avant d'en parler à votre médecin.
+3. **Si l'enjeu est le poids plus que la glycémie**, le cadre a changé : Wegovy et Mounjaro sont remboursés à 65 % dans l'obésité depuis juin 2026, sous conditions strictes — utiliser [Ozempic pour maigrir n'est ni remboursé ni pertinent](/collections/glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite/). Notre [test d'éligibilité](/outils/test-eligibilite/) vous dit en une minute si vous entrez dans les critères avant d'en parler à votre médecin.
 
 ## Le piège : les sites qui « vendent » Ozempic 2 mg
 


### PR DESCRIPTION
## Contenu du run quotidien 11/08/2026

### C5 — Article du plan (P2a)
- **Nouvel article** : `glp1-cout/ozempic-pour-maigrir-prix-remboursement-obesite` — cible « ozempic pour maigrir prix » (144 imp/14j, pos ~10, 0 clic, aucune page dédiée à l'intent).
- Chiffres sourcés : BDPM (77,60 €, taux 30 %), ANSM/CNAM 01/03/2023 (mésusage), Vidal 37850 (remboursement 65 % Wegovy/Mounjaro + critères), STEP 2 / PubMed 33667417 (−9,6 % vs −7 %).
- Thumbnail SVG unique (DA #1a3c34/#16a34a), FAQ schema 5 questions, CTA test d'éligibilité.
- Maillage entrant : `prix-ozempic-france`, `ozempic-2-mg-pourquoi-pas-disponible-france`, guide `medicament-pour-maigrir`.

### C6 — Fact-check (2 articles les plus anciens)
- `medicament-pour-maigrir-guide-complet-france-2026` : **2 corrections** — Ozempic « remboursé 65 % bithérapie » → **30 %** (BDPM), Rybelsus « 80-110 €/mois remboursé 65 % » → **non remboursé** (avis HAS défavorable).
- `glp1-microbiote-intestinal-flore-impact-probiotiques` : OK, aucune correction.

### Rapport
- `reports/daily-2026-08-11.md` (A0 monétisation, SEO recovery, décisions WoW, Coach IA).
- content-plan.md : P2a coché ; file GSC : +1 URL.

Build local Astro vérifié avant merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYV3boHSMA2pYbS66mzgri

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYV3boHSMA2pYbS66mzgri)_