### PR TITLE
Rapport 14/08 + alerte : SUPABASE_ACCESS_TOKEN manquant bloque tout deploy edge

### DIFF
--- a/reports/daily-2026-08-14.md
+++ b/reports/daily-2026-08-14.md
@@ -7,6 +7,12 @@
 
 ## ALERTES
 
+0. **BLOQUANT — le déploiement des edge functions n'a JAMAIS fonctionné : le secret `SUPABASE_ACCESS_TOKEN` est absent.** Le workflow `deploy-edge-functions.yml` a échoué à **chacune de ses exécutions** depuis sa création : 07/08, 08/08, 09/08, 13/08 et 14/08 (aujourd'hui), toujours sur `::error::SUPABASE_ACCESS_TOKEN manquant`. Conséquence directe : **les garde-fous Coach corrigeant l'erreur médicale (ce run) ne sont pas en production.** La fonction tourne toujours en v67.
+   **Action Robin (2 min, au choix)** :
+   - créer un token sur https://supabase.com/dashboard/account/tokens puis l'ajouter dans *Settings → Secrets → Actions* sous le nom `SUPABASE_ACCESS_TOKEN`, et relancer le workflow (« Deploy Supabase Edge Functions » → Run workflow) ;
+   - ou en local : `supabase functions deploy ai-coach --project-ref ywekaivgjzsmdocchvum`.
+   Je n'ai pas déployé via l'outil MCP : il impose de réémettre les 85 Ko du fichier à la main, et une faute de frappe dans une regex casserait le Coach pour 100 % des conversations — un risque plus grave que le défaut corrigé, qui est apparu une fois sur ~9 conversations en 48 h. C'est d'ailleurs la raison pour laquelle ce workflow avait été créé. Une fois le secret en place, le problème disparaît définitivement.
+
 1. **GSC en décrochage net** — 19 clics le 09/08 = **17,9 % de la baseline** (106). Moyenne 7 j : 26,4 clics/j contre 45 la semaine précédente = **−41 % WoW**. Le seuil d'alerte du prompt (« recovery GSC < 50 % au 20 juillet ou après ») est franchi depuis plusieurs semaines et la pente est redevenue négative.
 2. **Cannibalisation « ozempic prix »** — la requête est passée de **position 13,2 (20/07) à 50,4** (30 j), avec **21 pages du site en concurrence** sur le même terme. 2 024 impressions pour 15 clics. C'est la première cause identifiée du décrochage GSC. Ticket `duplicate_content` urgent créé — **arbitrage Robin requis** (action structurelle hors matrice autonome).
 3. **Erreur médicale du Coach en production (13/08)** — corrigée ce run, voir C2.
@@ -163,7 +169,7 @@ Bonne gestion d'un cas sensible le 14/08 (conv `87177eea`, femme de 69 ans, IMC 
 - Garde-fou **téléconsultation** : détecte « oui, ordonnance possible par téléconsultation » sans nuance → ajoute que c'est hors remboursement et que la primo-prescription se fait en CSO/CHU.
 - Prompt : interdiction d'attribuer un prix précis à un dosage non confirmé (seuls Mounjaro 2,5 mg = 176,10 € et 15 mg = 433,80 € le sont), et interdiction des formulations « prix libre » / « varie selon la pharmacie ».
 - Les deux regex ont été **testées contre les réponses réelles fautives et contre des réponses correctes** (déclenchement sur les fautes, silence sur les bonnes) avant commit.
-- Déploiement : via le workflow `deploy-edge-functions.yml` au merge sur `main` — plus sûr que l'outil MCP, qui impose de réémettre 85 Ko à la main. Version attendue : **v68**.
+- Déploiement : **ÉCHOUÉ — non déployé en production** (voir alerte 0). Le code est mergé sur `main` ; il partira dès que `SUPABASE_ACCESS_TOKEN` sera ajouté aux secrets. La fonction reste en v67.
 
 **C6 — Fact-check rotatif (2 articles les plus anciens)**
 - `acupuncture-glp1` → **corrigé** : le tarif d'un médecin acupuncteur conventionné était donné à « 23-30 € », valeur périmée. Le tarif secteur 1 est de **30 € depuis le 22/12/2024** ; le remboursement à 70 % passe donc de « environ 16-21 € » à **21 €, soit 19 € effectifs** après la participation forfaitaire de 2 €. `updatedAt` → 14/08.
@@ -224,6 +230,7 @@ Dimension auditée : **couverture par requête et concurrence interne**. Finding
 
 ## EN ATTENTE DE DÉCISION ROBIN
 
+0. **`SUPABASE_ACCESS_TOKEN` à ajouter aux secrets GitHub** (voir alerte 0) — bloque tout déploiement du Coach depuis le 07/08, y compris la correction de l'erreur médicale de ce run. C'est la seule action de la liste que je ne peux pas faire moi-même.
 1. **Cannibalisation « ozempic prix » (le plus rentable).** 21 pages se disputent la requête ; la position est passée de 13 à 50 en 3 semaines, ce qui explique l'essentiel du décrochage GSC. La correction consiste à désigner `prix-ozempic-france` comme canonique et à désoptimiser les 20 autres (retrait du terme de leurs `seoTitle`/keywords, remplacement par des liens internes). Cela touche ~20 fichiers existants → hors matrice autonome. **Réponds « go ozempic » et je le fais au prochain run**, sinon je laisse en l'état et la position continuera probablement de se dégrader.
 2. **Nouveaux sujets de contenu.** Le backlog est vide après l'annulation de B2/B3, et l'audit ne trouve aucun trou de contenu sur le cluster prix. Deux options : (a) je passe le prochain run à consolider l'existant plutôt qu'à publier (ma recommandation, tant que la cannibalisation n'est pas réglée) ; (b) je cherche des sujets hors cluster prix (retraites, parcours de soins) avec preuve GSC. **Réponds « a » ou « b »** — sans réponse, je pars sur (a) et je le signalerai.
 3. **Mesure de la fuite K6.** Pour savoir où les visiteurs abandonnent le test d'éligibilité, il faut un événement GA4 à chaque étape (IMC → comorbidités → verdict → email). C'est une modification de page front, ~15 lignes. **Réponds « go tracking test »** et je l'ajoute au prochain run.


### PR DESCRIPTION
## Rapport quotidien 14/08

`reports/daily-2026-08-14.md`.

## Alerte bloquante découverte en fin de run

Le workflow `deploy-edge-functions.yml` a échoué à **chacune de ses exécutions depuis sa création** — 07/08, 08/08, 09/08, 13/08 et 14/08 — toujours sur la même erreur :

```
::error::SUPABASE_ACCESS_TOKEN manquant. Ajoute-le dans Settings > Secrets > Actions.
```

Conséquence : les garde-fous Coach de la PR #118, qui corrigent une erreur médicale constatée en production le 13/08 (seuils IMC 27/30 présentés comme critères du remboursement français), **ne sont pas déployés**. `ai-coach` tourne toujours en v67.

**Fix, au choix :**
- créer un token sur https://supabase.com/dashboard/account/tokens, l'ajouter dans *Settings → Secrets → Actions* sous `SUPABASE_ACCESS_TOKEN`, puis relancer le workflow ;
- ou en local : `supabase functions deploy ai-coach --project-ref ywekaivgjzsmdocchvum`.

Je n'ai pas contourné via l'outil MCP : il impose de réémettre les 85 Ko du fichier à la main, et une faute de frappe dans une regex casserait le Coach pour 100 % des conversations — risque plus grave que le défaut corrigé, qui est apparu une fois sur ~9 conversations en 48 h. C'est exactement le motif pour lequel ce workflow avait été écrit.

Cette PR ne touche que `reports/`, hors des `paths` du deploy Hostinger : elle n'annule pas le déploiement FTP en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYXzPqqYrEYB4T7VL1soLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYXzPqqYrEYB4T7VL1soLa)_