### PR TITLE
Run 2 14/08 : fact-check alternatives-bio (réf. JAMA, coumarine EFSA/ANSES) + addendum rapport

### DIFF
--- a/reports/daily-2026-08-14.md
+++ b/reports/daily-2026-08-14.md
@@ -238,3 +238,35 @@ Dimension auditée : **couverture par requête et concurrence interne**. Finding
 5. **Consolidation des 6 pages « remboursement Mounjaro »** aux intitulés très proches (voir section D) : fusion/redirection = décision produit. Pas d'urgence, à arbitrer après le point 1.
 
 **File GSC** : aucune URL ajoutée ce run (pas de publication).
+
+---
+
+## RUN 2 — second déclenchement planifié du jour (18h+, addendum)
+
+Le run complet du jour s'est terminé à 16h13 (PR #118 + #119). Ce second passage est un run incrémental : vérifications, fact-check supplémentaire, aucune duplication d'action (pas de 2ᵉ relance email, pas de nouveau ticket).
+
+### Ce qui a bougé depuis 16h13 : rien
+
+- 0 dossier créé/payé, 0 lead test d'éligibilité, 0 message Coach, 0 email entrant depuis le run 1.
+- GSC toujours arrêté au 09/08 (5 j). La sync de 6h24 UTC a réussi et GA est à jour ⇒ le retard est côté API Google, pas côté token. Tentative de relance manuelle du workflow `sync-analytics.yml` : **échec 403** (l'intégration GitHub de la routine n'a pas la permission `actions:write` en dispatch). La sync planifiée de demain 8h rattrapera si l'API a publié les jours manquants ; si le 15/08 le retard atteint 6 j, escalade.
+- Secret `SUPABASE_ACCESS_TOKEN` toujours absent : le déploiement des garde-fous Coach (alerte 0 du run 1) reste bloqué, fonction en v67.
+- Aucune décision Robin reçue sur les points 0-5 « EN ATTENTE » — tous toujours ouverts.
+
+### Vérifications post-deploy du run 1 (faites)
+
+- Deploy Hostinger du merge #118 : **vert** (success, 14h09 UTC).
+- Correction C1 vérifiée **live** : la nouvelle meta description de l'article pénurie est bien servie en production (le champ actif est `seoDescription`, la modification est effective).
+- Site : home 200, redirect zepbound→mounjaro 301 conforme, sitemap 200.
+
+### C6 — Fact-check rotatif (2 articles suivants les plus anciens, `last_fact_checked` 14/06)
+
+- `alternatives-bio-glp1` → **corrigé (2 corrections sourcées)** :
+  1. La réf « jusqu'à −1 % d'HbA1c à 2 000 mg/j (JAMA 2025) » était imprécise : l'essai JAMA Network Open 2025 porte sur un **dérivé** (berbérine ursodésoxycholate, HTD1801), pas sur la berbérine simple des compléments — reformulé avec lien vers l'étude et mise en garde de non-transposabilité.
+  2. Le seuil coumarine « 0,1 mg/kg/j » était attribué à un « avis ANSES 2014 » : c'est la DJT **EFSA** ; la recommandation ANSES réelle est < 4,8 mg/j pour 60 kg via compléments (avis 2018-SA-0180) — corrigé avec lien source + précision ~3 000 mg/kg de coumarine dans la Cassia.
+  `updatedAt` → 14/08.
+- `alternatives-naturelles-ozempic` → **OK factuellement** : Ozempic 77,60 € / remb. 30 % (BDPM), justificatif de prescription obligatoire depuis le 01/02/2025 (confirmé Vidal/FFD — s'applique à Ozempic, Trulicity, Victoza, Byetta), chiffres berbérine cohérents. **MAIS qualité éditoriale médiocre** : sections template vides (« Cette section est en cours de mise à jour »), phrase tronquée (« Selon les endocrinologues français... »), titre de section cassé (« ##  recommandés »), double FAQ. Une refonte dépasserait 30 % → décision Robin (ajouté aux candidats de consolidation, sans urgence).
+- `last_fact_checked` mis à jour pour les deux.
+
+### File GSC
+
+Aucune URL ajoutée (pas de publication ce run — backlog toujours vide, décision « a/b » du run 1 en attente).

--- a/src/content/alternatives-glp1/alternatives-bio-glp1.md
+++ b/src/content/alternatives-glp1/alternatives-bio-glp1.md
@@ -3,6 +3,7 @@ title: "Alternatives Bio GLP-1 : Guide Complet et Conseils 2026"
 description: "Alternatives bio aux GLP-1 — berbérine, cannelle, inositol — ce que la science dit sur les substituts naturels à Ozempic et Wegovy. Guide 2025."
 pubDate: 2025-08-20
 date: 2025-08-20
+updatedAt: 2026-08-14
 author: "Rédaction GLP-1 France"
 category: "Alternatives thérapeutiques"
 tags: ["glp1", "alternatives", "traitements"]
@@ -49,7 +50,7 @@ La berbérine active l'**AMPK** (AMP-activated protein kinase), la même voie m�
 
 ### Ce que disent les études
 - Réduction de l'HbA1c : **-0,3 à -0,7 %** avec 1 500 mg/j (doses standard)
-- Jusqu'à **-1 % d'HbA1c** à 2 000 mg/j dans des études récentes (JAMA 2025)
+- Jusqu'à **-1 % d'HbA1c** pour un dérivé de la berbérine (berbérine ursodésoxycholate, HTD1801) dans un essai randomisé publié dans [JAMA Network Open en 2025](https://jamanetwork.com/journals/jamanetworkopen/articlepdf/2830825/mathioudakis_2025_ic_240386_1740068777.90761.pdf) — résultat non transposable tel quel à la berbérine simple vendue en complément alimentaire
 - Réduction modeste du poids corporel : 1 à 3 kg en moyenne sur 12 semaines
 - Effet sur la glycémie à jeun comparable à certains antidiabétiques de 2e ligne dans certaines études, mais avec des biais méthodologiques importants
 
@@ -80,7 +81,7 @@ La cannelle est populaire dans la communauté des personnes atteintes de diabèt
 | **Cannelle Ceylon** (*Cinnamomum verum*) | Très faible | ✅ Sûre pour usage quotidien | Plus chère |
 | **Cannelle Cassia** (*Cinnamomum cassia*) | Élevée | ⚠️ Risque hépatotoxique à doses élevées | Courante en supermarché |
 
-L'**ANSES** recommande de ne pas dépasser **0,1 mg/kg/j de coumarine** (avis 2014). La cannelle Cassia — la plus vendue en grande surface — peut facilement dépasser ce seuil à usage thérapeutique. **Pour tout usage médical, utiliser exclusivement la cannelle Ceylon.**
+La dose journalière tolérable fixée par l'**EFSA** est de **0,1 mg/kg/j de coumarine** ; l'**ANSES** recommande de son côté de rester sous **4,8 mg/j** pour un adulte de 60 kg via les compléments alimentaires ([avis 2018-SA-0180](https://www.anses.fr/fr/system/files/NUT2018SA0180.pdf)). La cannelle Cassia — la plus vendue en grande surface, ~3 000 mg de coumarine/kg — dépasse ce seuil dès une cuillère à café par jour. **Pour tout usage médical, utiliser exclusivement la cannelle Ceylon.**
 
 ### Efficacité sur la glycémie
 Les études sont contradictoires. Certaines méta-analyses montrent une légère réduction de la glycémie à jeun (-0,5 à -1 mmol/L), mais sans résultats robustes sur l'HbA1c. La cannelle ne se substitue pas à un antidiabétique médicamenteux.


### PR DESCRIPTION
Second déclenchement planifié du 14/08 (run incrémental, le run complet #118/#119 s'est terminé à 16h13).

## Contenu

- **C6 fact-check rotatif** (2 articles les plus anciens, `last_fact_checked` 14/06) :
  - `alternatives-bio-glp1` — 2 corrections sourcées : la réf « JAMA 2025 » portait en réalité sur un dérivé de la berbérine (HTD1801, JAMA Network Open 2025) — reformulée avec lien et mise en garde ; le seuil coumarine 0,1 mg/kg/j est la DJT EFSA, pas un « avis ANSES 2014 » — corrigé avec la vraie reco ANSES (< 4,8 mg/j / 60 kg, avis 2018-SA-0180). `updatedAt` → 14/08.
  - `alternatives-naturelles-ozempic` — OK factuellement (77,60 € / 30 %, justificatif 01/02/2025 confirmé Vidal/FFD) ; qualité éditoriale signalée au rapport (refonte > 30 % = décision Robin).
- **Addendum au rapport** `reports/daily-2026-08-14.md` : vérifications post-deploy du run 1 (deploy vert, correction C1 vérifiée live), rien de neuf en base depuis 16h13, secret `SUPABASE_ACCESS_TOKEN` toujours absent, relance manuelle sync-analytics impossible (403 dispatch).

Aucune action de la liste « DEMANDER » n'est touchée (pas de suppression/redirection, pas de prix/Stripe, pas de schéma DB, < 30 % de chaque article).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaLTvUVFe2bKmMbXjqBqpM)_