### PR TITLE
Contextual anchors to national price pages from the prices map

### DIFF
--- a/src/pages/outils/carte-prix-pharmacies.astro
+++ b/src/pages/outils/carte-prix-pharmacies.astro
@@ -118,7 +118,7 @@ const updatedFr = stats.updated_at
       <div style="max-width:960px;margin:0 auto;display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:16px;">
         <div style="flex:1 1 480px;">
           <h2 style="margin:0 0 6px;color:#1a3c34;font-size:1.25rem;">Les prix sont identiques partout — votre reste à charge, non</h2>
-          <p style="margin:0;color:#374151;">Wegovy et Mounjaro sont remboursés à 65&nbsp;% depuis juin 2026, sous conditions (IMC, comorbidités, suivi). La vraie question n'est pas où acheter, mais si vous êtes éligible.</p>
+          <p style="margin:0;color:#374151;"><a href="/collections/glp1-cout/prix-wegovy-france/" style="color:#15803d;font-weight:600;">Wegovy (146,91–195,10&nbsp;€)</a> et <a href="/collections/glp1-cout/prix-mounjaro-france/" style="color:#15803d;font-weight:600;">Mounjaro (176,10–433,80&nbsp;€)</a> sont remboursés à 65&nbsp;% depuis juin 2026, sous conditions (IMC, comorbidités, suivi). La vraie question n'est pas où acheter, mais si vous êtes éligible.</p>
         </div>
         <a href="/outils/test-eligibilite/" style="display:inline-block;background:#16a34a;color:#fff;padding:12px 22px;border-radius:8px;text-decoration:none;font-weight:600;white-space:nowrap;">Vérifier mon éligibilité → 2 min</a>
       </div>


### PR DESCRIPTION
`prix-mounjaro-france` is at position 27 on "mounjaro prix" (192 imp/28d) and `prix-wegovy-france` never recovered either — the June suspension demoted both canonical pages. The prices map (top traffic page, 90 clicks/week) only linked them from a bottom-of-page list.

This adds in-content, exact-anchor links with the official price ranges inside the eligibility CTA banner text — the strongest internal-link placement available without structural changes.

Part of the position-recovery plan for the collapsed canonical pages (internal links → freshness → manual reindex requests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181FvYp9JgDTaKWjr3GzLYa

---
_Generated by [Claude Code](https://claude.ai/code/session_0181FvYp9JgDTaKWjr3GzLYa)_