### PR TITLE
report: deploy #512 green + keep-list full-sync gap finding (daily 23/08)

### DIFF
--- a/reports/daily-2026-08-23.md
+++ b/reports/daily-2026-08-23.md
@@ -104,3 +104,10 @@ Home/sitemap/redirects 200/301 OK ; robots.txt sain ; aucun meta noindex ni X-Ro
 
 ---
 *Généré par la routine du 23/08/2026. GA au 23/08 (partiel), GSC au 20/08 (retard 3j). 0 article publié (plan épuisé — cause structurelle signalée). 2 fact-checks corrigés, keep-list 40, 1 enrichissement C1, cannibalisation en pause (20/42). Aucune URL ajoutée à la file GSC.*
+
+---
+
+## POST-SCRIPTUM — Bilan deploy (ajouté après merge PR #136)
+
+- **Deploy #512 : VERT en 3m35** (sync incrémental). Vérifié live : section Rybelsus sur prix-ozempic-france ✓, 77,60 € sur ozempic-ordonnance ✓, LIVERAGE sur article NASH ✓, home 200 ✓. Les changements du 22/08 (annulés avec #511) sont embarqués.
+- **⚠️ Découverte process** : `config/pharmacy-index-keeplist.json` n'est PAS dans les patterns SHARED du workflow deploy (ligne ~74 de deploy-hostinger.yml) → un refresh de keep-list seul ne déclenche jamais le full sync et **ne se déploie donc jamais** sur les pages pharmacies. Les 2 pages réintégrées ce run (dunkerque/la-pharmacie-du-lycee, marseille/pharmacie-djaoui) servent encore leur noindex live ; elles basculeront au prochain full sync. Fix = 1 ligne dans le workflow (ajout du fichier aux SHARED_PATTERNS) — modification CI/CD → validation Robin requise, à traiter avec la décision keep-list n°1 (l'élargissement nécessitera de toute façon un full sync).


### PR DESCRIPTION
Post-scriptum au rapport du 23/08 :
- Deploy #512 vert (3m35, sync incrémental), toutes les pages de contenu modifiées vérifiées live.
- Découverte : `config/pharmacy-index-keeplist.json` absent des SHARED_PATTERNS du workflow deploy → un refresh keep-list seul ne se déploie jamais sur les pages pharmacies (les 2 pages réintégrées servent encore leur noindex). Fix 1 ligne proposé, validation Robin requise (CI/CD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YRfAvMW4Sz12kbPuHaTL2

---
_Generated by [Claude Code](https://claude.ai/code/session_018YRfAvMW4Sz12kbPuHaTL2)_