### PR TITLE
Run 24/08 (2e run) : rapport quotidien, fact-checks ANSM + avant/après, 2 seoTitles C1, emails leads

### DIFF
--- a/reports/daily-2026-08-24.md
+++ b/reports/daily-2026-08-24.md
@@ -1,0 +1,89 @@
+# Rapport quotidien — 24/08/2026
+
+## ALERTES
+
+1. **Trafic toujours au plancher post-noindex** : 127 sessions sam 22/08, 159 dim 23/08 (14-17 % de la baseline 922). Décision Robin du 24/08 : **ON TIENT** la keep-list jusqu'au verdict J+30 (~17/09) — pas de ré-élargissement, le crash est documenté (rapport 23/08), pas de nouvelle action.
+2. Retard GSC 3 jours (dernier jour complet : 20/08 ; le 21/08 est partiel — 145 imp vs ~1 650/j). Sous le seuil d'alerte (4 j), à re-vérifier demain.
+3. `/outils/test-eligibilite/` : toujours **0 impression GSC** au 21/08 (J+12 post-soumission). Jalon du 25/08 atteint demain → si toujours 0 : ping sitemap + audit crawl (prévu au prochain run).
+4. Aucune violation Zepbound, site live OK (home 200, redirect zepbound→mounjaro 301, sitemap 200).
+
+---
+
+## A0. MONÉTISATION
+
+### Ventes & funnel
+- **Dossiers payés : 0 en 24h, 0 sur 7j** (cumul : 3 payés/générés, 4 pending anciens). 0 dossier créé, 0 tentative de checkout sur 7j → aucune relance checkout due.
+- **Visites funnel 7j** : ~54 sessions test-eligibilité + 6 landing Dossier. Volume divisé par 2 avec le crash trafic général.
+- **Leads du jour : 2 nouveaux via la prospection v2 du matin** (~95 emails envoyés par le run du matin, catégorie dossier_prospection_2) :
+  - olivier.ecrepont : test complété à 10h03, **verdict ÉLIGIBLE** (IMC 37,1 + HTA + apnée + cardio + suivi nutritionnel en cours) → **récap J0 envoyé ce run avec CTA Dossier** (eligibility_recap).
+  - sab.rauzy : test complété, non éligible (IMC 26,4, sous l'AMM) → récap J0 honnête envoyé, sans upsell, lien article « pas éligible : vos options ».
+  - **Signal fort : la prospection v2 convertit en engagement en quelques heures** (2 tests complétés / ~95 envois le jour même).
+- **Relances J+3 dues aujourd'hui : envoyées** (leads du 21/08) — mlaure.francois et aureliacottin (éligibles : conseils accélération CSO + lien article délais), nadine.cabanel (non éligible IMC 32 : version adaptée sans upsell, dépistage comorbidités + suivi nutritionnel + options hors remboursement). Catégorie eligibility_j3, tracées.
+- **Coach IA : 0 message en 24h** (vs 2 la veille) — plancher historique, cohérent avec le trafic. Aucun [[DOSSIer_READY]], aucun coach_recap, aucun lead_magnet_parcours nouveau.
+- **Suivi post-achat** : aucune réponse clients 1-3 (incoming_emails : uniquement spam B2B peptides). Philippe : relance_2 envoyée ce matin (run du matin), à surveiller.
+- **Emails hebdo Robin (lundi)** : envoyés ce matin par le run du matin (robin_weekly_funnel + robin_weekly_retraites + robin_funnel_solutions). Obligation remplie pour la semaine.
+
+### KPIs (fenêtre 30j — inchangés vs 23/08, pas de nouvelle donnée significative)
+K1 ~2,1 % (vs 0,69 base) ✓ ; K2 ~12 % = ; K3 40-50 % = ; K4 en dilution ; K5 25 % ✓ ; K6 ~5 % ⚠️ à suivre. **Fuite du moment = volume absolu de trafic** (cause SEO, pas funnel) + K6 capture en baisse.
+
+---
+
+## A. SEO RECOVERY WATCH
+
+- **Recovery GA : 17 %** (159 sessions le 23/08 / 922). Sam 22/08 : 14 %.
+- **Recovery GSC : 31 %** (33 clics le 20/08 / 106 — dernier jour complet).
+
+### 14 derniers jours (extraits clés)
+| Date | GA sessions | % base | GSC clics | GSC imp |
+|---|---|---|---|---|
+| 18/08 | 412 | 45 % | 20 | 1 821 |
+| 19/08 | 332 | 36 % | 27 | 1 676 |
+| 20/08 | 418 | 45 % | 33 | 1 656 |
+| 21/08 | 213 | 23 % | (6*) | (145*) |
+| 22/08 | 127 | 14 % | — | — |
+| 23/08 | 159 | 17 % | — | — |
+\* sync partiel
+
+**Tendance** : GA cassé depuis le 21/08 (effet noindex documenté au rapport 23/08). Côté GSC (jusqu'au 20/08), les clics étaient en HAUSSE (33 = meilleur jour depuis la suspension) — le crash GA vient de la longue traîne pharmacies invisible dans GSC. Les données GSC 21-23/08 diront si les clics suivent ; verdict lisible d'ici 2 jours.
+
+### Pages money (7j, vs baseline juin)
+- prix-mounjaro-france : **0 clic**, 319 imp, pos 36,7 (baseline ~125 clics/sem)
+- prix-wegovy-france : 1 clic, 174 imp, pos 44,8 (baseline ~92)
+- wegovy-remboursement-mutuelle : 0 clic, pos 21,3 ; regime-mounjaro-optimal : 0 clic, pos 9,5 (30 imp)
+- Réindexation manuelle : déjà demandée et relancée (17 et 20/08) — pas de nouvelle relance (règle anti-harcèlement).
+
+### Plan recovery — état
+1. Money pages : voir ci-dessus, toujours écrasées. 2. Dégraissage : décision ON TIENT (24/08), verdict 17/09 ; fix workflow keep-list→full-sync mergé ce matin (#138). 3. **Cannibalisation : 20/42, pause maintenue** (GSC 21-23/08 illisible). 4. Bylines : fait. 5. C1 : 2 seoTitles raccourcis ce run. 6. Réactivation invisibles : pause (même raison que 3). 7. Backlinks : RAS. 8. Réindexation : relancée le 20/08, stop.
+
+---
+
+## B. DÉCISIONS
+
+1. **Constat** : WoW GSC (15-21/08 vs 8-14/08), les impressions MONTENT sur les pages restantes : prix-ozempic-france 711→1 254 imp et 3→13 clics (effet section Rybelsus + regain), carte-prix 37→64 clics, /retraites/ 12→164 imp (x13 confirmé), paris/prix-wegovy 118→361 imp. Aucune page en perte >20 % d'impressions dans le top. → **Décision** : le signal « qualité » des pages conservées est bon ; ne rien toucher, laisser la SERP digérer. → Action : consigné, pas d'intervention on-page de plus ce run.
+2. **Constat** : prospection v2 → 2 tests complétés le jour même, dont 1 éligible (profil client type). → **Décision** : la boucle email → test → récap J0 → J+3 est le canal le plus actif du funnel en ce moment ; la servir en priorité chaque run. → Action : 5 emails envoyés ce run (voir C).
+3. **Constat** : file V2 du content-plan ajoutée aujourd'hui = fenêtre de veto 24h (publiable à partir du 25/08) ; l'article du jour (Vichy, D10-substitution) a été publié par le run du matin (#139, vérifié live 200). → **Décision** : pas de 2e article aujourd'hui (règle max 1/jour + veto V2). Demain : A1 (refresh Foundayo/orforglipron, anti-doublon d'abord).
+
+## C. ACTIONS EXÉCUTÉES
+
+1. **5 emails leads envoyés** (send-feedback-email v3, tous tracés) : 2 récaps J0 (olivier éligible avec CTA Dossier ; sab non éligible, honnête sans upsell) + 3 relances J+3 (mlaure, aurelia éligibles ; nadine adaptée non éligible). Vérif STOP/achats faite avant envoi (aucun STOP, aucun acheteur).
+2. **C6 fact-check `ansm-regles-prescription-glp1-france` : CORRIGÉ (important)** — l'article laissait croire que le généraliste suffit pour la primo-prescription REMBOURSÉE (même erreur que le garde-fou Coach v66) : clarification AMM (généraliste OK, à charge) vs remboursement 65 % (primo-prescription CSO/CHU, arrêtés 06/2026) en 3 endroits + critère « IMC ≥ 35 remboursement HAS en cours d'évaluation » périmé supprimé. Vérifiés OK : Trulicity 65 % (HAS/Vidal), Victoza arrêt fin 2026 (Vidal/Moniteur), formulaire antidiabétiques 01/02/2025 (ameli/FFD), Ozempic 30 %.
+3. **C6 fact-check `avant-apres-glp1-resultats-reels` : CORRIGÉ** — paliers STEP 1 (≥10 % : 66→69 %, ≥15 % : 48→50 %, NEJM 2032183) ; reprise de poids réattribuée à l'extension STEP 1 (2/3 repris à 1 an) au lieu de « STEP 4 » ; « étude SUSTAIN-Extended » (introuvable) supprimée, remplacée par STEP 4 réel (+6,9 % placebo vs −7,9 %). SURMOUNT-1 32/55/63 % ≥20 % : vérifié EXACT (NEJM/Lilly).
+4. **C1 : 2 seoTitles raccourcis ≤ 65 cars** (regime-mounjaro-optimal 77→57, effets-secondaires-mounjaro 74→54) + updatedAt.
+5. `last_fact_checked` mis à jour en base pour les 2 articles.
+
+## D. AUDIT DU JOUR — J2 On-page SEO
+
+- **0 title ou seoTitle dupliqué** sur les 166+ articles (bon signal).
+- **10 seoTitles > 68 caractères** : 2 corrigés ce run (les 2 à trafic), 8 restants à traiter en C1 au fil des runs : mounjaro-long-terme-surmount, ozempic-generique-france (88 cars), prix-wegovy-france (70 — page money, mais title travaillé récemment : à arbitrer), remboursement-mounjaro-accord-prealable, remboursement-mounjaro-obesite-has-ceps, glp1-alzheimer-evoke, glp1-prescription-generaliste-ansm-2026 (80), penurie-ozempic-wegovy-mounjaro.
+
+## Volet B — Coach IA (24h)
+
+- **0 message, 0 conversation** (veille : 2). Plancher absolu — cohérent avec le trafic minimal du dimanche + crash. Aucun bug à analyser, aucune violation Zepbound possible (0 réponse). Dossiers : 3 generated / 4 pending, 0 créé en 24h.
+- Rien à corriger côté Coach ce run (v78 en prod depuis ce matin — capture email in-chat : première donnée d'usage attendue avec le retour du trafic).
+
+## EN ATTENTE DE DÉCISION ROBIN
+
+Rien de nouveau — les 3 attentes du rapport 23/08 sont soldées (keep-list : ON TIENT acté ; content-plan : V2 validée ; réindexation : relancée, stop). Aucune action sensible identifiée ce run.
+
+---
+*Généré par la routine du 24/08/2026 (2e run du jour — le run du matin a publié l'article Vichy #139, les leviers leads #140, la prospection v2 et les emails hebdo). Ce run : 5 emails leads, 2 fact-checks corrigés, 2 seoTitles C1, audit J2. GA au 24/08 (partiel), GSC au 21/08 (partiel, dernier complet 20/08). File V2 en veto jusqu'au 25/08 → article A1 demain. Aucune URL ajoutée à la file GSC.*

--- a/src/content/avant-apres-glp1/avant-apres-glp1-resultats-reels.md
+++ b/src/content/avant-apres-glp1/avant-apres-glp1-resultats-reels.md
@@ -5,6 +5,7 @@ description: "Avant après GLP1 : résultats réels Ozempic, Wegovy et Mounjaro 
 author: "Rédaction GLP-1 France"
 pubDate: 2026-03-15
 date: 2026-03-15
+updatedAt: 2026-08-24
 category: "avant-après"
 tags: ["avant après", "glp1", "résultats", "perte de poids", "témoignages", "ozempic", "wegovy", "mounjaro"]
 image: "/images/thumbnails/avant-après-glp1.jpg"
@@ -33,8 +34,8 @@ L'étude STEP 1, publiée dans le New England Journal of Medicine en 2021, reste
 |----------|--------|---------|
 | Perte de poids moyenne | **-14,9%** | -2,4% |
 | Patients ayant perdu ≥ 5% | **86%** | 31% |
-| Patients ayant perdu ≥ 10% | 66% | 12% |
-| Patients ayant perdu ≥ 15% | 48% | 5% |
+| Patients ayant perdu ≥ 10% | 69% | 12% |
+| Patients ayant perdu ≥ 15% | 50% | 5% |
 | Patients ayant perdu ≥ 20% | 32% | 2% |
 
 Ce qui signifie concrètement : pour une personne pesant 100 kg au départ, la perte de poids moyenne sous Wegovy est d'environ 15 kg sur 16 mois. Un tiers des patients en perdent 20 kg ou plus.
@@ -116,9 +117,9 @@ C'est LA question que tous les patients se posent. Les études sont claires sur 
 
 ### Les données sur la reprise de poids
 
-L'étude STEP 4 (Wegovy) a suivi des patients qui ont arrêté le traitement après 20 semaines d'efficacité. Résultat : à 1 an après l'arrêt, **les patients avaient repris les deux tiers du poids perdu**.
+L'extension de l'étude STEP 1 (Wegovy) a suivi des patients après l'arrêt du traitement à 68 semaines. Résultat : un an après l'arrêt, **les patients avaient repris environ les deux tiers du poids perdu**.
 
-Une étude similaire avec Ozempic (étude SUSTAIN-Extended) montre une reprise de 50 à 70% du poids perdu dans les 12 mois suivant l'arrêt.
+L'étude STEP 4 confirme le mécanisme : les patients passés sous placebo après 20 semaines de sémaglutide ont repris du poids (+6,9 %), tandis que ceux qui poursuivaient le traitement continuaient d'en perdre (−7,9 %).
 
 Ce phénomène s'explique par la physiologie : le GLP-1 traite une cause biologique de l'obésité (la résistance à la satiété), mais n'agit que tant que le médicament est présent. À l'arrêt, les mécanismes de faim reprennent le dessus.
 

--- a/src/content/effets-secondaires-glp1/effets-secondaires-mounjaro.md
+++ b/src/content/effets-secondaires-glp1/effets-secondaires-mounjaro.md
@@ -3,10 +3,10 @@ title: "Effets Secondaires Mounjaro Long Terme 2026 : Liste"
 thumbnail: "/images/thumbnails/effets-secondaires-ozempic-illus.jpg"
 description: "Effets secondaires Mounjaro à long terme 2026 : 12 effets fréquents + risques graves (pancréatite, gastroparésie, thyroïde). Témoignages et solutions."
 keywords: ['effets secondaires mounjaro', 'mounjaro effet secondaire long terme', 'effets secondaires mounjaro long terme', 'mounjaro effet secondaire grave', 'mounjaro nausées', 'mounjaro effets indésirables', 'risques mounjaro', 'mounjaro vomissements', 'mounjaro diarrhée', 'mounjaro danger', 'mounjaro pancréatite']
-seoTitle: "Mounjaro Effets Secondaires Long Terme 2026 : liste complète et solutions"
+seoTitle: "Mounjaro : effets secondaires 2026, liste et solutions"
 seoDescription: "Effets secondaires Mounjaro long terme : nausées (24-33%), chute de cheveux, pancréatite, gastroparésie. Données études SURMOUNT 2025-2026. Solutions concrètes et quand consulter. Mis à jour juillet 2026."
 publishedAt: '2025-08-30'
-updatedAt: '2026-07-19'
+updatedAt: 2026-08-24
 date: 2026-07-19
 featured: true
 author: "Rédaction GLP-1 France"

--- a/src/content/regime-glp1/regime-mounjaro-optimal.md
+++ b/src/content/regime-glp1/regime-mounjaro-optimal.md
@@ -12,9 +12,9 @@ thumbnailAlt: "Illustration pour l'article régime-mounjaro-optimal"
 featured: false
 priority: 5
 schema: "Article"
-seoTitle: "Régime Mounjaro Optimal 2026 : aliments, menus et protéines (guide complet)"
+seoTitle: "Régime Mounjaro 2026 : aliments, menus types et protéines"
 seoDescription: "Régime sous Mounjaro (tirzépatide) : 30-35% protéines, aliments à privilégier, menus par phase d'escalade. 7 conseils pour maximiser la perte de poids. Mis à jour juillet 2026."
-updatedAt: '2026-07-20'
+updatedAt: 2026-08-24
 mainKeyword: "régime Mounjaro alimentation optimale tirzepatide"
 
 # Configuration Affiliation

--- a/src/content/traitements-glp1/ansm-regles-prescription-glp1-france.md
+++ b/src/content/traitements-glp1/ansm-regles-prescription-glp1-france.md
@@ -2,8 +2,8 @@
 title: "ANSM Prescription GLP-1 : Règles France 2025-2026"
 description: "ANSM prescription GLP-1 règles France 2025-2026 : tout médecin peut désormais prescrire les GLP-1. Formulaire obligatoire et conditions."
 pubDate: 2026-03-16
-date: "2026-05-29"
-updatedAt: 2026-05-29
+date: "2026-08-24"
+updatedAt: 2026-08-24
 author: "Rédaction GLP-1 France"
 category: "Traitements"
 tags: ["glp1", "ANSM", "prescription", "réglementation", "France", "obésité", "diabète"]
@@ -40,10 +40,9 @@ Depuis juin 2025, **tout médecin peut initier un traitement par GLP-1 pour l'ob
 
 **Ce qui change concrètement** :
 
-- Votre médecin traitant peut vous prescrire [Wegovy](/collections/traitements-glp1/guide-complet-wegovy/) (sémaglutide 2,4 mg) ou [Mounjaro](/collections/traitements-glp1/guide-complet-mounjaro/) (tirzépatide) pour l'obésité, sous réserve d'un IMC initial >= 35 kg/m² et d'un échec préalable d'une prise en charge nutritionnelle (deuxième intention uniquement)
-- Il n'est plus nécessaire de consulter un spécialiste pour la première prescription
-- Le renouvellement peut également être assuré par le médecin traitant
-- Les conditions médicales d'éligibilité selon l'ANSM pour la prescription (AMM) : IMC >= 30 kg/m² (obésité) ou IMC >= 27 kg/m² avec au moins une comorbidité liée au poids. Les critères IMC >= 35 s'appliquent uniquement aux conditions de remboursement HAS (en cours d'évaluation).
+- Votre médecin traitant peut vous prescrire [Wegovy](/collections/traitements-glp1/guide-complet-wegovy/) (sémaglutide 2,4 mg) ou [Mounjaro](/collections/traitements-glp1/guide-complet-mounjaro/) (tirzépatide) pour l'obésité, dans le cadre de l'AMM : IMC >= 30 kg/m², ou IMC >= 27 kg/m² avec au moins une comorbidité liée au poids
+- Il n'est plus nécessaire de consulter un spécialiste pour une première prescription **dans le cadre de l'AMM** (traitement alors à votre charge)
+- **Attention, pour être remboursé c'est différent** : depuis les arrêtés de juin 2026, la prescription initiale **remboursée à 65 %** doit être faite dans un centre spécialisé de l'obésité (CSO) ou un service hospitalier spécialisé, avec des critères plus stricts (IMC >= 40, ou >= 35 avec comorbidité, après 6 mois de prise en charge nutritionnelle). Le médecin traitant assure ensuite les renouvellements.
 - Ces évolutions concernent aussi la prescription des [GLP-1 pour les adolescents obèses de 12 ans et plus](/collections/traitements-glp1/wegovy-mounjaro-adolescent-obesite-12-ans-france-guide/), un cadre spécifique encadré par l'ANSM
 
 **Ce qui ne change pas** :
@@ -103,7 +102,7 @@ Si vous êtes diabétique de type 2 et traité par un GLP-1 comme [Ozempic](/col
 
 Si vous souffrez d'obésité et souhaitez un traitement GLP-1 :
 
-- Vous pouvez désormais consulter votre médecin traitant directement, sans passer par un spécialiste — découvrez le [parcours complet pour commencer un traitement GLP-1](/collections/medecins-glp1-france/comment-commencer-traitement-glp1-france/)
+- Vous pouvez consulter votre médecin traitant directement pour une prescription dans le cadre de l'AMM ; pour une prescription **remboursée**, il vous adressera à un CSO/CHU pour la primo-prescription — découvrez le [parcours complet pour commencer un traitement GLP-1](/collections/medecins-glp1-france/comment-commencer-traitement-glp1-france/)
 - Votre médecin évaluera votre éligibilité (IMC, comorbidités, traitements antérieurs) — [vérifiez vos critères d'éligibilité GLP-1](/collections/glp1-perte-de-poids/suis-je-eligible-glp1-criteres-imc-france/)
 - Les traitements approuvés pour l'obésité sont Wegovy et Mounjaro
 - **Remboursement** : depuis le 15 juin 2026, Wegovy et Mounjaro sont remboursés à 65 % par l'Assurance Maladie pour l'obésité (IMC ≥ 35 avec comorbidité ou IMC ≥ 40, après échec nutritionnel, prescription initiale en CSO/CHU). Consultez nos guides sur le [prix Wegovy](/collections/glp1-cout/prix-wegovy-france/) et le [prix Mounjaro](/collections/glp1-cout/prix-mounjaro-france/)
@@ -177,7 +176,7 @@ Pour comparer ces traitements en détail, consultez notre [comparatif des GLP-1]
 
 ### Mon médecin généraliste peut-il me prescrire Ozempic pour maigrir ?
 
-Non. Ozempic est indiqué uniquement pour le diabète de type 2. Pour la perte de poids, les traitements approuvés sont Wegovy, Mounjaro et Saxenda. Depuis juin 2025, votre généraliste peut vous prescrire ces traitements anti-obésité si vous remplissez les critères d'éligibilité — consultez notre guide sur le [médecin généraliste et conditions de prescription](/collections/medecins-glp1-france/medecin-generaliste-prescription-wegovy-mounjaro-conditions/) pour connaître les démarches.
+Non. Ozempic est indiqué uniquement pour le diabète de type 2. Pour la perte de poids, les traitements approuvés sont Wegovy, Mounjaro et Saxenda. Depuis juin 2025, votre généraliste peut vous prescrire ces traitements anti-obésité si vous remplissez les critères d'éligibilité (mais la primo-prescription remboursée passe par un CSO/CHU) — consultez notre guide sur le [médecin généraliste et conditions de prescription](/collections/medecins-glp1-france/medecin-generaliste-prescription-wegovy-mounjaro-conditions/) pour connaître les démarches.
 
 ### Le formulaire obligatoire va-t-il ralentir ma prise en charge ?
 


### PR DESCRIPTION
## Contenu du run (routine quotidienne, 2e run du 24/08)

### Fact-checks C6 (2 articles corrigés)
- **ansm-regles-prescription-glp1-france** : clarification AMM (généraliste possible, à charge) vs remboursement 65 % (primo-prescription CSO/CHU obligatoire, arrêtés 06/2026) — l'article laissait croire que le généraliste suffisait pour la prescription remboursée. Ligne périmée « IMC ≥ 35 remboursement HAS en cours d'évaluation » supprimée. Vérifiés OK : Trulicity 65 %, Victoza arrêt fin 2026, formulaire antidiabétiques 01/02/2025.
- **avant-apres-glp1-resultats-reels** : paliers STEP 1 corrigés (≥10 % : 69 %, ≥15 % : 50 %, NEJM), reprise de poids réattribuée à l'extension STEP 1, « SUSTAIN-Extended » (introuvable) remplacé par les données réelles de STEP 4. SURMOUNT-1 vérifié exact.

### C1
- 2 seoTitles raccourcis ≤ 65 cars : regime-mounjaro-optimal, effets-secondaires-mounjaro (+ updatedAt).

### Rapport
- `reports/daily-2026-08-24.md` : monétisation (5 emails leads envoyés — 2 récaps J0 dont 1 éligible issu de la prospection v2 du matin, 3 relances J+3), recovery (GA 17 %, GSC 31 % au dernier jour complet), audit J2 on-page (0 doublon, 10 seoTitles longs), Coach 0 msg/24h.

Pas d'article ce run : file V2 en fenêtre de veto jusqu'au 25/08, article du jour (Vichy) déjà publié par le run du matin (#139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjtvq6RfDcriiHB5TidycS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bjtvq6RfDcriiHB5TidycS)_