### PR TITLE
chore: file GSC — 14 URLs soumises par Robin (24/08)

### DIFF
--- a/reports/gsc-submission-queue.md
+++ b/reports/gsc-submission-queue.md
@@ -5,20 +5,6 @@ La routine AJOUTE ici a chaque publication — elle ne relance jamais dans le ch
 
 ## En attente de soumission
 
-- [ ] https://glp1-france.fr/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/ (article 01/08, prioritaire)
-- [ ] https://glp1-france.fr/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/ (article 01/08 run 2, prioritaire)
-- [ ] https://glp1-france.fr/collections/glp1-cout/prix-glp1-pharmacie-tableau-2026/ (article 02/08, prioritaire — cible « glp-1 en pharmacie prix »)
-- [ ] https://glp1-france.fr/collections/retraites-bien-etre/vittel-capvern-contrexeville-cure-thermale-minceur-comparatif/ (article 05/08, prioritaire — cible « cure thermale vittel/capvern/contrexeville minceur »)
-- [ ] https://glp1-france.fr/collections/glp1-cout/acheter-wegovy-mounjaro-espagne-prix-legalite/ (article 03/08, prioritaire — cible « wegovy prix pharmacie espagne »)
-- [ ] https://glp1-france.fr/collections/retraites-bien-etre/cure-thermale-obesite-stations-agreees-remboursement/ (article 04/08, prioritaire — cible « cure thermale minceur remboursé »)
-- [ ] https://glp1-france.fr/collections/glp1-cout/wegovy-remboursement-mutuelle/ (60 clics baseline → 0)
-- [ ] https://glp1-france.fr/collections/regime-glp1/regime-mounjaro-optimal/
-- [ ] https://glp1-france.fr/collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/
-- [ ] https://glp1-france.fr/collections/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation/
-- [ ] https://glp1-france.fr/guides/suivi-medical-glp1/
-- [ ] https://glp1-france.fr/collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/
-- [ ] https://glp1-france.fr/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/
-- [ ] https://glp1-france.fr/collections/retraites-bien-etre/jeune-randonnee-organisateurs-ffjr-comparatif-prix/ (article 07/08)
 - [ ] https://glp1-france.fr/collections/traitements-glp1/ozempic-2-mg-pourquoi-pas-disponible-france/ (article 07/08 run 2)
 - [ ] https://glp1-france.fr/collections/medecins-glp1-france/delai-rendez-vous-cso-chu-obesite-glp1-2026/ (article 10/08, prioritaire — contenu funnel parcours de soins)
 - [ ] https://glp1-france.fr/collections/medecins-glp1-france/suivi-nutritionnel-6-mois-remboursement-glp1-documenter/ (article 10/08 run 2, prioritaire — contenu funnel parcours de soins)
@@ -29,8 +15,23 @@ La routine AJOUTE ici a chaque publication — elle ne relance jamais dans le ch
 - [ ] https://glp1-france.fr/collections/medecins-glp1-france/glp1-apres-sleeve-bypass-reprise-poids-remboursement/ (article 19/08 — cible « glp1 après sleeve », aucune page du site sur ce cluster)
 - [ ] https://glp1-france.fr/collections/glp1-cout/pas-eligible-remboursement-glp1-options-2026/ (article B8 21/08 — cible « glp1 non remboursé / pas éligible », renforce le cluster éligibilité où le site est absent)
 
+- [ ] https://glp1-france.fr/collections/retraites-bien-etre/cure-thermale-vichy-minceur-avis-prix/ (article 24/08 — station AD majeure, cible « cure thermale vichy minceur »)
+- [ ] https://glp1-france.fr/en/glp1-in-france/ (page pilier EN 24/08 — cible « glp-1 in france », « mounjaro price france »)
+
 ## Soumises
 
 - [x] https://glp1-france.fr/outils/test-eligibilite/ — soumise par Robin le 09/08/2026 (confirme en chat « fait »). Surveiller premieres impressions ; re-signaler une fois si 0 imp au 16/08.
-- [ ] https://glp1-france.fr/collections/retraites-bien-etre/cure-thermale-vichy-minceur-avis-prix/ (ajouté 24/08/2026)
-- [ ] https://glp1-france.fr/en/glp1-in-france/ (ajouté 24/08/2026)
+- [x] https://glp1-france.fr/collections/medecins-glp1-france/qui-peut-prescrire-mounjaro-wegovy-rembourse/ (article 01/08, prioritaire) — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/traitements-glp1/pharmacie-refuse-delivrer-mounjaro-wegovy-que-faire/ (article 01/08 run 2, prioritaire) — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/glp1-cout/prix-glp1-pharmacie-tableau-2026/ (article 02/08, prioritaire — cible « glp-1 en pharmacie prix ») — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/retraites-bien-etre/vittel-capvern-contrexeville-cure-thermale-minceur-comparatif/ (article 05/08, prioritaire — cible « cure thermale vittel/capvern/contrexeville minceur ») — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/glp1-cout/acheter-wegovy-mounjaro-espagne-prix-legalite/ (article 03/08, prioritaire — cible « wegovy prix pharmacie espagne ») — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/retraites-bien-etre/cure-thermale-obesite-stations-agreees-remboursement/ (article 04/08, prioritaire — cible « cure thermale minceur remboursé ») — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/glp1-cout/wegovy-remboursement-mutuelle/ (60 clics baseline → 0) — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/regime-glp1/regime-mounjaro-optimal/ — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/glp1-cout/baisse-prix-ozempic-wegovy-2027-france/ — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/traitements-glp1/nouveau-stylo-ozempic-3ml-2026-changement-utilisation/ — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/guides/suivi-medical-glp1/ — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/traitements-glp1/glp1-sopk-syndrome-ovaires-polykystiques-ozempic-wegovy/ — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/effets-secondaires-glp1/effets-secondaires-mounjaro/ — soumise par Robin le 24/08/2026
+- [x] https://glp1-france.fr/collections/retraites-bien-etre/jeune-randonnee-organisateurs-ffjr-comparatif-prix/ (article 07/08) — soumise par Robin le 24/08/2026

--- a/reports/gsc-submission-queue.md
+++ b/reports/gsc-submission-queue.md
@@ -33,3 +33,4 @@ La routine AJOUTE ici a chaque publication — elle ne relance jamais dans le ch
 
 - [x] https://glp1-france.fr/outils/test-eligibilite/ — soumise par Robin le 09/08/2026 (confirme en chat « fait »). Surveiller premieres impressions ; re-signaler une fois si 0 imp au 16/08.
 - [ ] https://glp1-france.fr/collections/retraites-bien-etre/cure-thermale-vichy-minceur-avis-prix/ (ajouté 24/08/2026)
+- [ ] https://glp1-france.fr/en/glp1-in-france/ (ajouté 24/08/2026)


### PR DESCRIPTION
Mise à jour de la file de soumission GSC : 14 URLs cochées « soumises par Robin le 24/08 » (quota atteint sur ozempic-2-mg, qui reste en tête de file), et reclassement de 2 entrées (Vichy, page EN) tombées par erreur dans la section « Soumises ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YRfAvMW4Sz12kbPuHaTL2

---
_Generated by [Claude Code](https://claude.ai/code/session_018YRfAvMW4Sz12kbPuHaTL2)_