### PR TITLE
Diagnostic 08/09 + fix fenêtre sync GSC + rattrapage des récaps leads

### DIFF
--- a/.github/workflows/sync-analytics.yml
+++ b/.github/workflows/sync-analytics.yml
@@ -9,7 +9,7 @@ on:
       days:
         description: 'Number of days to sync'
         required: false
-        default: '3'
+        default: '10'
 
 jobs:
   sync:

--- a/reports/daily-2026-09-08.md
+++ b/reports/daily-2026-09-08.md
@@ -1,0 +1,239 @@
+# Diagnostic complet — 08/09/2026
+
+Demandé par Robin (« ça fait longtemps que j'ai pas fait un check »).
+Dernier run de routine : **25/08** — 14 jours sans run. Ce rapport couvre la période 25/08 → 08/09.
+
+---
+
+## 🚨 ALERTES
+
+### A1. Coach IA en panne totale depuis ~8 jours (INCIDENT LIVE)
+
+Le Coach ne répond plus avec un LLM : **100 % des réponses de cette semaine sont des `fallback-v1`** (réponses génériques pré-écrites).
+
+| Semaine | Réponses | % fallback |
+|---|---|---|
+| 13/07 → 10/08 | 78-115/sem | 0 % |
+| 17/08 | 39 | 3 % |
+| 24/08 | 21 | 0 % |
+| 31/08 | 22 | **36 %** |
+| 07/09 | 8 | **100 %** |
+
+**Cause racine** (logs edge function, 07/09) : les 3 maillons de la chaîne LLM échouent en cascade.
+
+1. `mistral-small-latest` → **HTTP 429** `{"message":"Rate limit exceeded","code":"1300"}` — quota Mistral épuisé.
+2. `openai/gpt-oss-120b` (Groq) → **HTTP 413** : `TPM Limit 8000, Requested 11186`.
+3. `openai/gpt-oss-20b` (Groq) → **HTTP 413** : `Limit 8000, Requested 11066`.
+4. → `fallback-v1`.
+
+**Pourquoi Groq ne peut pas prendre le relais** : le `SYSTEM_PROMPT` fait à lui seul **33 817 caractères ≈ 9 400 tokens**, déjà au-dessus du plafond free tier Groq de 8 000 TPM — avant même d'ajouter le RAG et l'historique. Élaguer le RAG et l'historique ne suffit donc PAS ; il faudrait amputer le prompt système de moitié, c'est-à-dire retirer des garde-fous médicaux, l'interdiction Zepbound et les règles funnel. **Non fait volontairement** : c'est hors matrice d'autonomie (sujet médical/légal + réécriture majeure).
+
+**Le correctif est au niveau du compte, il appartient à Robin** :
+- **Option A (recommandée)** : créditer / passer Mistral en payant. Restaure le primaire immédiatement, coût quasi nul au volume actuel (~40 réponses/semaine).
+- **Option B** : Groq Dev Tier (payant) → relève le plafond TPM, Groq redevient un vrai secours.
+- **Option C** : ajouter un 4e fournisseur avec un budget suffisant.
+
+**Impact business** : le Coach est le funnel gratuit vers le Dossier. Sur les 14 derniers jours, **0 réponse proposant le Dossier** (vs 4-7/semaine avant). Le funnel chat est mort pendant la panne.
+
+**Constat de fond** : la panne a duré 8 jours sans que personne ne le voie. Il n'existe aucune alerte sur le taux de fallback.
+
+### A2. Données GSC inexploitables depuis le 21/08 (cause racine identifiée le 25/08, jamais corrigée)
+
+Les impressions stockées s'effondrent de ~1 650/j (18-20/08) à ~60/j — mais **ce n'est pas un effondrement réel**, c'est un artefact de collecte.
+
+Preuve : GA compte **146 sessions organiques/jour** quand GSC n'enregistre que **4 clics/jour**. Le ratio, de 12x avant le 21/08, passe à 36x. Physiquement impossible.
+
+| Date | Lignes stockées | Pages distinctes |
+|---|---|---|
+| 18-20/08 | 1 135-1 194 | 330-360 |
+| 21/08 | 90 | 33 |
+| 22/08 → 05/09 | 22-72 | 16-41 |
+
+**Cause racine** : `.github/workflows/sync-analytics.yml` lance `--days 3`. GSC finalise ses données avec 2-3 jours de latence : chaque jour est donc écrit alors qu'il est encore partiel, et **jamais re-récupéré ensuite** puisque la fenêtre glissante de 3 jours l'a déjà dépassé. Tous les jours depuis le 21/08 sont figés à l'état partiel.
+
+**Correctif (1 ligne, non appliqué — modif workflow CI/CD = hors autonomie)** : passer la fenêtre à `--days 10`. L'upsert (`page_path,query,date`) écrase proprement, donc les jours partiels déjà stockés seraient réécrits complets au premier run.
+
+Backfill manuel tenté ce jour via `workflow_dispatch` (l'input `days` existe déjà) : **refusé, HTTP 403** — l'intégration GitHub de la session n'a pas le droit de déclencher un workflow. À lancer par Robin.
+
+**Conséquence** : tant que ce n'est pas corrigé, **aucun chiffre GSC postérieur au 20/08 n'est exploitable** (clics, impressions, positions, keep-list pharmacies). GA reste fiable.
+
+### A3. 37 leads sans réponse alors que le site promet un récap sous 24 h
+
+Aucun email envoyé depuis le **25/08** (dernier `eligibility_recap`).
+
+| Jour | Leads test d'éligibilité | Ont reçu un email |
+|---|---|---|
+| 07/09 | 14 | 0 |
+| 05/09 | 3 | 0 |
+| 03/09 | 4 | 0 |
+| 01/09 | 2 | 0 |
+| 31/08 | 2 | 0 |
+| 30/08 | 6 | 0 |
+| 28/08 | 2 | 0 |
+| 27/08 | 4 | 0 |
+| **Total** | **37** | **0** |
+
+Sont également en retard : les 2 emails hebdo à Robin (lundis 31/08 et 07/09 manqués) et la **newsletter « Actu GLP-1 »**, dont la première édition était due le 31/08 — jamais lancée.
+
+Un lead a **répondu** à son récap le 25/08 (`xa65noycw@mozmail.com`, « Re: Votre test d'éligibilité GLP-1 ») et n'a jamais reçu de réponse — 14 jours.
+
+### A4. Email de phishing reçu sur la boîte support
+
+`support.hostingermr40pmjtc9h0@colori-shop.com` — « Hostinger - Action required to maintain your service » (06/09). Le domaine expéditeur est `colori-shop.com`, pas Hostinger. Vu l'historique de suspension DMCA, l'appât est bien choisi. **Ne pas cliquer.** Toute action Hostinger doit passer par le panel, jamais par un lien d'email.
+
+---
+
+## A. SEO / TRAFIC
+
+### Recovery (GA seule — GSC inexploitable, voir A2)
+
+- **Recovery GA : ~22 %** — moyenne 200 sessions/jour sur 01-07/09, contre baseline 922.
+- Dernier jour complet (07/09) : 274 sessions = 30 %.
+- Tendance : **négative**. 18-20/08 tournait à ~390 sessions/jour, on est à ~200.
+
+| Jour | Sessions |
+|---|---|
+| 18/08 | 412 |
+| 20/08 | 418 |
+| 25/08 | 199 |
+| 31/08 | 252 |
+| 03/09 | 205 |
+| 05/09 | 135 |
+| 06/09 | 112 |
+| 07/09 | 274 |
+
+### Verdict anticipé du noindex pharmacies (décision du 24/08, verdict prévu 17/09)
+
+Sessions GA/jour, 9 jours avant le déploiement du noindex vs 9 derniers jours :
+
+| Cluster | Avant (08-16/08) | Maintenant (30/08-07/09) | Delta |
+|---|---|---|---|
+| `/pharmacies/*` | 120/j | 17/j | **-103/j** |
+| Reste du site | 218/j | 183/j | -35/j |
+
+**Lecture** : le pari du dégraissage d'index était que sacrifier la longue traîne pharmacies ferait remonter le reste du site. **À ce stade ça ne se produit pas** : le cluster pharmacies a perdu 86 % de son trafic et le reste du site baisse aussi légèrement. Coût net ≈ 103 sessions/jour, bénéfice ≈ 0.
+
+Ce n'est **pas** une demande de revenir en arrière : la décision de Robin du 24/08 est de tenir jusqu'au 17/09 sans élargir la keep-list, et elle est respectée. C'est la donnée à avoir en main pour trancher dans 9 jours. Réserve : la keep-list a été construite sur des données GSC déjà partielles (cause A2), donc elle a pu être aveugle à des pages qui méritaient d'être gardées.
+
+### Pages money (données complètes du 14-20/08, dernière semaine fiable)
+
+| Page | Clics 14-20/07 | Clics 14-20/08 | Position 08 |
+|---|---|---|---|
+| `/outils/carte-prix-pharmacies/` | 86 | 77 | 35,5 |
+| `/collections/glp1-cout/prix-wegovy-france/` | 37 | 2 | 41,7 |
+| `/collections/glp1-cout/prix-mounjaro-france/` | 35 | 0 | 33,7 |
+| `/collections/glp1-cout/wegovy-remboursement-mutuelle/` | 5 | 0 | 19,3 |
+| `/collections/regime-glp1/regime-mounjaro-optimal/` | 2 | 0 | 8,0 |
+
+Les deux pages prix principales sont sorties de la page 1 (positions 34 et 42) et ne rapportent plus rien en clics. La carte des prix tient (elle reste la page n°1 du site en GA avec 604 sessions/30j).
+
+### Top pages GA (30 jours)
+
+| Page | Sessions |
+|---|---|
+| `/outils/carte-prix-pharmacies/` | 604 |
+| `/collections/glp1-cout/prix-mounjaro-france/` | 418 |
+| `/guides/qu-est-ce-que-glp1/` | 414 |
+| `/` | 241 |
+| `/collections/glp1-cout/prix-wegovy-france/` | 188 |
+| `/outils/test-eligibilite/` | 179 |
+
+---
+
+## B. MONÉTISATION
+
+### Ventes
+
+**0 vente depuis le 01/08** (dernier dossier payé : mazzella.marion, 01/08). Total cumulé : **3 dossiers payés** (22/07, 24/07, 01/08) = 14,97 €.
+
+### Le funnel Dossier ne produit plus rien depuis 32 jours
+
+Dernier dossier **créé** : 07/08 (Philippe, resté `pending`). Depuis : **0 création** malgré 29 sessions sur la landing en 30 jours.
+
+**Le funnel n'est pas cassé — il est affamé.** Vérifié ce jour :
+- `src/pages/dossier-glp1.astro` : le handler de soumission est intact, le formulaire est bien servi dans le HTML de prod.
+- Edge function `stripe-payment` : ACTIVE, code inchangé depuis juin, la branche `dossier` accepte bien les invités sans compte.
+- RLS `dossiers` : policy `FOR ALL TO public` — n'a rien bloqué.
+
+Ce qui a changé, c'est l'alimentation en haut de funnel : **29 sessions/30j sur la landing** (contre 50 à la baseline du 04/08) et **0 proposition du Dossier par le Coach en 14 jours** (panne A1).
+
+### KPIs funnel (30 jours glissants)
+
+| KPI | Baseline 04/08 | Aujourd'hui | Verdict |
+|---|---|---|---|
+| K1 Exposition (sessions funnel / sessions site) | 0,69 % | **2,6 %** (208/7 876) | ✅ objectif du plan K1 dépassé |
+| K2 Activation (dossiers créés / sessions landing) | 12 % | **0 %** (0/29) | 🔴 |
+| K3 Paiement (payés / créés) | 50 % | n/a (0 créé) | — |
+| K4 Conversion funnel | 2,9 % | **0 %** | 🔴 |
+| K5 Coach (réponses proposant le Dossier) | 11 % | **0 %** | 🔴 panne A1 |
+| K6 Capture test (leads / sessions test) | 9,3 % | **33 %** (60/179) | ✅ x3,5 |
+
+**Diagnostic de fuite** : le goulot n'est plus K1. Le plan K1 a fonctionné — l'exposition a été multipliée par 3,8 et la capture email par 3,5 (60 leads en 30 jours contre 5 auparavant). **Le goulot s'est déplacé sur K2** : ces 60 leads captés ne sont jamais transformés, parce que (a) la séquence email qui devait les travailler est à l'arrêt depuis 14 jours (A3), et (b) le Coach qui devait proposer le Dossier est en panne (A1).
+
+Autrement dit : le site génère aujourd'hui **plus de prospects qualifiés que jamais**, et personne ne les traite.
+
+### Dossiers en attente
+
+| Email | Créé | Statut | Relances |
+|---|---|---|---|
+| philippepayrastre2107@gmail.com | 07/08 | pending | relance_2 le 24/08, sans réponse |
+| JONATHANVIALE1@GMAIL.COM | 27/07 | pending | 2 relances, ne plus écrire |
+| sruth83@gmail.com | 27/07 | pending | STOP le 01/08 — ne pas recontacter |
+| trash198001@gmail.com | 05/07 | pending | email jetable |
+
+---
+
+## C. TECHNIQUE
+
+### Site live — RAS
+
+| Contrôle | Résultat |
+|---|---|
+| Home | 200 |
+| `/collections/traitements-glp1/guide-complet-zepbound/` | 301 → `guide-complet-mounjaro` ✅ |
+| `sitemap-0.xml` | 200 |
+| `/dossier-glp1/` | 200 |
+| `/outils/test-eligibilite/` | 200 |
+| `/outils/carte-prix-pharmacies/` | 200 |
+| `/retraites/` | 200 |
+| `robots.txt` | 200 |
+
+### Conformité Zepbound — RAS
+
+Aucune occurrence dans `src/` ni `public/` hors les règles de redirection de `.htaccess` (attendu). Les 10 occurrences en base sont des messages Coach de mai-juin 2026, antérieurs à l'interdiction, plus un message utilisateur. **Aucune mention servie au public aujourd'hui.**
+
+### Déploiement
+
+Dernier deploy : **#518, vert, 25/08**. Rien depuis (aucun commit). Le site en prod est cohérent avec `main`. Le cron `sync-analytics` tourne tous les jours à 6h UTC et réussit — il collecte simplement une fenêtre trop courte (A2).
+
+### Sécurité Supabase (`get_advisors`)
+
+Rien de critique pour ce projet. À noter, sans urgence : 5 vues en `SECURITY DEFINER` (`pharmacy_latest_prices`, `latest_fact_checks`, `ab_test_stats`, `products_display`, `city_professional_stats`), une douzaine de fonctions à `search_path` mutable, la protection contre les mots de passe compromis désactivée, et des patchs de sécurité Postgres disponibles.
+
+---
+
+## D. CE QUI EST À L'ARRÊT DEPUIS LE 25/08
+
+La routine quotidienne ne tourne plus depuis 14 jours. Conséquences cumulées :
+
+- **0 article publié** (quota C5 : 1/run). 12 sujets non cochés restent dans `content-plan.md`.
+- **0 fact-check** (quota C6 : 2/run) → ~28 fact-checks non faits.
+- **37 récaps de leads** non envoyés (A3).
+- **2 emails hebdo Robin** manqués (lundis 31/08 et 07/09).
+- **Newsletter « Actu GLP-1 »** jamais lancée (1re édition due le 31/08).
+- **Cannibalisation** figée à 5/42 requêtes traitées.
+- **Keep-list pharmacies** non rafraîchie (et de toute façon aveugle tant que A2 n'est pas corrigé).
+- **Panne du Coach non détectée** pendant 8 jours (A1).
+
+---
+
+## EN ATTENTE DE DÉCISION ROBIN
+
+1. **Coach IA** — choisir A (créditer Mistral, recommandé), B (Groq Dev Tier) ou C (autre fournisseur). Tant que rien n'est fait, chaque visiteur reçoit une réponse générique.
+2. **Sync GSC** — go pour passer `--days 3` → `--days 10` dans `sync-analytics.yml` (modif workflow CI/CD, hors autonomie). Sans ça, aucun rapport SEO n'est fiable. Robin peut aussi lancer un backfill immédiat : Actions → « Sync GA4 + GSC » → Run workflow → days = `20`.
+3. **37 leads en attente** — go pour envoyer les récaps en rattrapage ? Le retard va de 1 à 12 jours ; envoyer un « votre résultat » 12 jours après la promesse mérite un arbitrage plutôt qu'un envoi automatique.
+4. **Verdict noindex du 17/09** — donnée disponible ci-dessus : -103 sessions/jour, aucun report sur le reste du site. Décision maintenue jusqu'au 17/09 comme convenu.
+
+---
+
+*Rapport produit sans modification du site ni de la base : diagnostic à la demande.*

--- a/reports/daily-2026-09-08.md
+++ b/reports/daily-2026-09-08.md
@@ -57,9 +57,11 @@ Backfill manuel tenté ce jour via `workflow_dispatch` (l'input `days` existe d�
 
 **Conséquence** : tant que ce n'est pas corrigé, **aucun chiffre GSC postérieur au 20/08 n'est exploitable** (clics, impressions, positions, keep-list pharmacies). GA reste fiable.
 
-### A3. 37 leads sans réponse alors que le site promet un récap sous 24 h
+### A3. 10 leads sans réponse alors que le site promet un récap sous 24 h — ✅ TRAITÉ
 
 Aucun email envoyé depuis le **25/08** (dernier `eligibility_recap`).
+
+> **Correction** : le comptage initial de « 37 leads » portait sur des **lignes** de la table `contacts`, pas sur des personnes. Après dédoublonnage par email, il s'agit de **10 personnes distinctes** — plusieurs ont refait le test plusieurs fois (une personne l'a relancé 4 fois en faisant varier ses réponses). Le volume réel de la dette client est donc bien plus faible qu'annoncé.
 
 | Jour | Leads test d'éligibilité | Ont reçu un email |
 |---|---|---|
@@ -71,11 +73,19 @@ Aucun email envoyé depuis le **25/08** (dernier `eligibility_recap`).
 | 30/08 | 6 | 0 |
 | 28/08 | 2 | 0 |
 | 27/08 | 4 | 0 |
-| **Total** | **37** | **0** |
+| **Total** | **37 lignes → 10 personnes** | **0** |
 
 Sont également en retard : les 2 emails hebdo à Robin (lundis 31/08 et 07/09 manqués) et la **newsletter « Actu GLP-1 »**, dont la première édition était due le 31/08 — jamais lancée.
 
-Un lead a **répondu** à son récap le 25/08 (`xa65noycw@mozmail.com`, « Re: Votre test d'éligibilité GLP-1 ») et n'a jamais reçu de réponse — 14 jours.
+### A3 bis. Une demande STOP non honorée pendant 14 jours (bug de détection)
+
+`xa65noycw@mozmail.com` (Cyril) a répondu à son récap le **25/08**. Le corps du message est simplement « **Stop** » — c'était une désinscription, pas une question.
+
+Elle n'a jamais été enregistrée parce que **le corps de l'email était encodé en base64** dans `incoming_emails.body_text` : la détection STOP, qui fonctionne par `ILIKE '%stop%'` sur le texte brut, ne pouvait pas la voir.
+
+Audit complet ce jour : **28 emails entrants** ont un corps en base64. Un seul contenait une demande STOP (celle-ci) ; les 27 autres sont du spam de fournisseurs de peptides ou des réponses à la prospection partenaires. **Aucun autre désabonnement n'a été manqué**, et par chance aucun envoi n'a eu lieu vers cette adresse depuis le 25/08.
+
+Adresse ajoutée à `email_suppression` ce jour. **Le bug de détection reste ouvert** : tant que `sync-inbox` stocke certains corps en base64 sans les décoder, un futur STOP peut passer inaperçu. Correctif à prévoir (décoder à l'ingestion dans `sync-inbox`, ou décoder à la lecture).
 
 ### A4. Email de phishing reçu sur la boîte support
 
@@ -227,13 +237,60 @@ La routine quotidienne ne tourne plus depuis 14 jours. Conséquences cumulées :
 
 ---
 
-## EN ATTENTE DE DÉCISION ROBIN
+## E. ACTIONS EXÉCUTÉES (après arbitrage de Robin)
 
-1. **Coach IA** — choisir A (créditer Mistral, recommandé), B (Groq Dev Tier) ou C (autre fournisseur). Tant que rien n'est fait, chaque visiteur reçoit une réponse générique.
-2. **Sync GSC** — go pour passer `--days 3` → `--days 10` dans `sync-analytics.yml` (modif workflow CI/CD, hors autonomie). Sans ça, aucun rapport SEO n'est fiable. Robin peut aussi lancer un backfill immédiat : Actions → « Sync GA4 + GSC » → Run workflow → days = `20`.
-3. **37 leads en attente** — go pour envoyer les récaps en rattrapage ? Le retard va de 1 à 12 jours ; envoyer un « votre résultat » 12 jours après la promesse mérite un arbitrage plutôt qu'un envoi automatique.
-4. **Verdict noindex du 17/09** — donnée disponible ci-dessus : -103 sessions/jour, aucun report sur le reste du site. Décision maintenue jusqu'au 17/09 comme convenu.
+Robin a tranché : **(1) Mistral, (2) appliquer le fix GSC moi-même, (3) go sur les leads.**
+
+### E1. Sync GSC — fenêtre portée de 3 à 10 jours
+
+`.github/workflows/sync-analytics.yml` : `--days 3` → `--days 10`. La fenêtre couvre désormais largement la latence de finalisation GSC (2-3 jours), donc chaque jour est réécrit complet lors des runs suivants. L'upsert sur `(page_path, query, date)` fait le reste.
+
+**Portée du rattrapage automatique** : le prochain run programmé (6h UTC) réparera du 29/08 au 08/09. Les jours **21 → 28/08 restent partiels** — ils sortent de la fenêtre de 10 jours.
+
+**Reste à faire par Robin** (je n'ai pas les droits : `workflow_dispatch` refusé en 403, « Resource not accessible by integration ») :
+> GitHub → Actions → « Sync GA4 + GSC → Supabase » → Run workflow → days = `20` → Run.
+
+Un seul clic, ~30 secondes d'exécution, et l'historique du 21/08 au 08/09 est reconstruit.
+
+### E2. Coach IA — action côté compte Mistral
+
+Le correctif ne peut pas être fait depuis le code (voir A1 : le prompt système seul dépasse le plafond Groq). Marche à suivre pour Robin :
+> console.mistral.ai → Workspace → Billing → ajouter un moyen de paiement / créditer le compte.
+
+Le compte est en limite de quota (`code 1300`), pas en clé invalide — la clé API est bonne, il n'y a rien à changer dans les secrets Supabase. Dès que le quota repart, le Coach redevient fonctionnel **sans redéploiement**. Je vérifierai le taux de fallback au prochain run.
+
+### E3. Récapitulatifs leads — 10 envoyés
+
+10 emails personnalisés envoyés via `send-feedback-email` (catégorie `eligibility_recap`), tous en statut `sent:true, logged:true`, tracés dans `email_replies`.
+
+Contrôles préalables : croisement avec `email_suppression` (0 correspondance), recherche de STOP dans `incoming_emails` y compris les corps en base64 (0 correspondance parmi les 10), verdict retenu = celui de la **dernière** soumission de chaque personne.
+
+Contenu adapté au verdict, avec mention explicite du retard :
+
+| Destinataire | Verdict retenu | Angle |
+|---|---|---|
+| sevcara@yahoo.fr | éligible (IMC 40,2) | critères remplis + primo-prescription réservée aux CSO/CHU + Dossier |
+| labric.lima@hotmail.fr | éligible (IMC 38,3) | idem, formulé au conditionnel (4 tests successifs, données instables) |
+| didierlc@dlcfr.com | éligible après suivi (IMC 36,2) | seul le suivi nutritionnel de 6 mois manque + Dossier |
+| adiaminani22@gmail.com | IMC 37,1 sans comorbidité | dépister une comorbidité (apnée souvent non diagnostiquée), engager le suivi |
+| Laetitiagarnier680, nishaquemeneur, liboureaupascal59 | IMC 31,8-32,8 | en dessous du seuil de 35, option hors remboursement, guide gratuit |
+| anna.volobuieva, babourette57, viviana.occhionorelli | IMC 25,8-28,1 | traitement non indiqué, orientation médecin, sans argumentaire commercial |
+
+Aucun argumentaire Dossier vers les personnes non éligibles : leur vendre un dossier d'éligibilité qu'elles ne peuvent pas utiliser serait malhonnête. Pas de liste de CSO ni de checklist détaillée (exclusivité du Dossier payant). Mention « répondez STOP » en pied de page.
+
+### E4. Demande STOP en attente honorée
+
+`xa65noycw@mozmail.com` ajouté à `email_suppression` (raison `stop`, source tracée).
 
 ---
 
-*Rapport produit sans modification du site ni de la base : diagnostic à la demande.*
+## EN ATTENTE DE DÉCISION / ACTION ROBIN
+
+1. **Créditer Mistral** (E2) — le Coach sert des réponses génériques à chaque visiteur tant que ce n'est pas fait.
+2. **Lancer le backfill GSC** (E1) — un clic, Actions → Run workflow → days = `20`.
+3. **Bug STOP base64** (A3 bis) — correctif à faire dans `sync-inbox` ; je peux le prendre au prochain run si tu veux.
+4. **Verdict noindex du 17/09** — donnée disponible : -103 sessions/jour, aucun report sur le reste du site. Décision maintenue jusqu'au 17/09 comme convenu.
+
+---
+
+*Diagnostic à la demande. Modifications de ce run : 1 ligne de workflow, 10 emails leads, 1 ligne de suppression. Aucune modification du contenu du site.*


### PR DESCRIPTION
Diagnostic complet demandé par Robin après 14 jours sans run de routine (dernier run : 25/08), puis actions appliquées après son arbitrage.

## Diagnostic

**Coach IA en panne totale depuis ~8 jours.** 100 % des réponses de cette semaine sont des `fallback-v1`. Les 3 maillons de la chaîne LLM échouent en cascade : Mistral renvoie HTTP 429 (quota épuisé), puis les deux modèles Groq renvoient HTTP 413 (11 000 tokens demandés contre 8 000 autorisés en free tier). Le `SYSTEM_PROMPT` fait à lui seul ~9 400 tokens, donc élaguer le RAG et l'historique ne suffirait pas — il faudrait amputer les garde-fous médicaux. Correctif au niveau du compte Mistral, hors code.

**Données GSC inexploitables depuis le 21/08.** `sync-analytics.yml` utilisait `--days 3` alors que GSC finalise ses données avec 2-3 jours de latence : chaque jour était écrit partiel et jamais re-récupéré. Preuve : GA compte 146 sessions organiques/jour quand GSC n'en enregistre que 4 clics.

**Funnel Dossier affamé, pas cassé.** 0 création en 32 jours. Handler du formulaire, edge function `stripe-payment` et policies RLS vérifiés un par un : tout fonctionne. La landing est passée de 50 à 29 sessions/30j et le Coach n'a proposé le Dossier 0 fois en 14 jours.

**Le goulot du funnel s'est déplacé.** Le plan K1 a réussi (exposition ×3,8, capture email ×3,5 : 60 leads en 30 jours contre 5). Ces leads ne sont simplement pas traités.

**Verdict anticipé du noindex pharmacies** (décision de tenir jusqu'au 17/09 respectée, rien touché) : le cluster est passé de 120 à 17 sessions/jour, sans report sur le reste du site.

**Site sain par ailleurs** : home, sitemap, redirection Zepbound et pages funnel en 200/301, aucune occurrence Zepbound servie au public, dernier déploiement vert.

## Modifications de cette PR

**`--days 3` → `--days 10`** dans `sync-analytics.yml`. La fenêtre couvre désormais la latence de finalisation GSC, et l'upsert sur `(page_path, query, date)` réécrit les jours partiels. Les jours 21 → 28/08 sortent de la fenêtre et demandent un run manuel unique avec `days = 20` (le déclenchement par `workflow_dispatch` m'est refusé en 403).

**Rapport `reports/daily-2026-09-08.md`**, incluant deux corrections faites en cours de route :
- les « 37 leads » étaient des **lignes** de `contacts`, pas des personnes — il s'agit de **10 personnes** après dédoublonnage ;
- le lead qui avait « répondu sans réponse » le 25/08 demandait en fait **STOP**. Sa désinscription n'avait pas été enregistrée parce que le corps de l'email était encodé en base64, invisible à la détection par `ILIKE`. Les 28 corps base64 ont été audités : aucun autre désabonnement manqué.

## Actions hors dépôt

- 10 récapitulatifs leads envoyés (`send-feedback-email`, catégorie `eligibility_recap`), contenu adapté au verdict, sans argumentaire Dossier vers les personnes non éligibles.
- `xa65noycw@mozmail.com` ajouté à `email_suppression`.

## Reste à faire côté Robin

1. Créditer le compte Mistral (console.mistral.ai → Billing) — le Coach repart sans redéploiement.
2. Actions → « Sync GA4 + GSC » → Run workflow → days = `20`, pour reconstruire le 21 → 28/08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FGUcF5LdcfdZdKtBXjzG1