### PR TITLE
Sécurise la pagination GSC pour la fenêtre de sync élargie

### DIFF
--- a/scripts/sync-analytics.mjs
+++ b/scripts/sync-analytics.mjs
@@ -465,10 +465,16 @@ async function fetchGSC(token, days) {
   // Pagination (fix 24/08/2026) : l'ancien appel unique (rowLimit 25000, pas de
   // startRow) échantillonnait ~25k lignes sur des centaines de milliers → la longue
   // traîne (pages pharmacies notamment) était invisible, ce qui a rendu la keep-list
-  // noindex aveugle à ~100 sessions organiques/jour. On pagine jusqu'à 3 pages
-  // (75k lignes) pour borner l'IO.
+  // noindex aveugle à ~100 sessions organiques/jour.
+  //
+  // 08/09/2026 : le plafond de 3 pages (75k lignes) devient contraignant maintenant
+  // que la fenêtre passe de 3 à 10 jours — GSC trie par clics décroissants, donc une
+  // troncature coupe précisément la longue traîne qu'on cherche à voir. La boucle
+  // s'arrête dès qu'une page revient incomplète : monter le plafond ne coûte rien
+  // quand le volume est faible, et évite la troncature silencieuse quand il ne l'est
+  // pas. Si le log ci-dessous signale une troncature, il faut réduire --days.
   const PAGE_SIZE = 25000;
-  const MAX_PAGES = 3;
+  const MAX_PAGES = 12;
   const rawRows = [];
   for (let page = 0; page < MAX_PAGES; page++) {
     const r = await fetch(`https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(GSC_SITE_URL)}/searchAnalytics/query`, {
@@ -501,6 +507,12 @@ async function fetchGSC(token, days) {
     const batch = data.rows || [];
     rawRows.push(...batch);
     if (batch.length < PAGE_SIZE) break;
+    // Dernière page autorisée alors qu'elle est pleine = il reste des lignes côté
+    // GSC. Elles sont perdues, et comme l'API trie par clics décroissants, ce sont
+    // les moins vues qui sautent : le signal longue traîne redevient faux.
+    if (page === MAX_PAGES - 1) {
+      console.warn(`  ⚠️  TRONCATURE : ${MAX_PAGES} pages pleines (${rawRows.length} lignes) — la longue traîne est incomplète. Réduire --days ou monter MAX_PAGES.`);
+    }
   }
 
   const allRows = rawRows.map(row => {


### PR DESCRIPTION
Suite de la PR #148, qui a élargi la fenêtre de sync GSC de 3 à 10 jours.

## Le problème que #148 laissait ouvert

Le plafond de pagination (3 pages × 25 000 = 75 000 lignes) avait été dimensionné pour une fenêtre de 3 jours. Avec une fenêtre de 10 jours, le volume est multiplié par trois et le plafond peut devenir contraignant.

Ce qui rend la troncature sournoise : **l'API GSC renvoie les lignes par clics décroissants**. Ce qui saute quand on tronque, ce sont donc les pages les moins vues — précisément la longue traîne que le fix du 24/08 cherchait à récupérer, et dont l'absence avait rendu la keep-list noindex aveugle. On aurait élargi la fenêtre pour recréer le bug qu'on venait de corriger, sans aucun signal.

## Correctif

- Plafond porté de 3 à 12 pages. La boucle sort déjà dès qu'une page revient incomplète (`batch.length < PAGE_SIZE`), donc un plafond plus haut ne coûte rien tant que le volume est faible — il ne fait que retirer une limite arbitraire quand le volume est élevé.
- Ajout d'un avertissement explicite quand la dernière page autorisée revient pleine, c'est-à-dire quand des lignes sont réellement perdues. Sans ce log, la troncature est indétectable dans les données stockées.

Vérifié par `node --check`. Aucun autre comportement modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FGUcF5LdcfdZdKtBXjzG1

---
_Generated by [Claude Code](https://claude.ai/code/session_016FGUcF5LdcfdZdKtBXjzG1)_